### PR TITLE
[Review] Reduce file size of the Angular typescript client

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -86,6 +86,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether required types should be imported.</summary>
         public bool ImportRequiredTypes => _settings.ImportRequiredTypes;
 
+        /// <summary>Gets or sets a value indicating whether to use a simple Angular's result processing (without all these additional processXXX methods) (default: false)</summary>
+        public bool UseAngularResultProcessing => _settings.UseAngularResultProcessing;
+
         /// <summary>Gets a value indicating whether to call 'transformOptions' on the base class or extension class.</summary>
         public bool UseTransformOptionsMethod => _settings.UseTransformOptionsMethod;
 

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
@@ -62,7 +63,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
                 var response = GetSuccessResponse();
                 var isNullable = response?.IsNullable(_settings.CodeGeneratorSettings.SchemaType) == true;
 
-                var resultType = isNullable && SupportsStrictNullChecks && UnwrappedResultType != "void" && UnwrappedResultType != "null" ?
+                var resultType = isNullable && SupportsStrictNullChecks && !_settings.UseAngularResultProcessing && UnwrappedResultType != "void" && UnwrappedResultType != "null" ?
                     UnwrappedResultType + " | null" :
                     UnwrappedResultType;
 

--- a/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
@@ -71,6 +71,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets a value indicating whether to call 'transformResult' on the base class or extension class.</summary>
         public bool UseTransformResultMethod { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether to use a simple Angular's result processing (without all these additional processXXX methods) (default: false)</summary>
+        public bool UseAngularResultProcessing { get; set; }
+
         /// <summary>Gets or sets the token name for injecting the API base URL string (used in the Angular2 template, default: '').</summary>
         public string BaseUrlTokenName { get; set; }
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -46,25 +46,27 @@
         {% template Client.RequestBody %}
 
 {%     endif -%}
-        let options_ : any = {
-{%     if operation.HasBody -%}
+        let options_ : IRequestOptions = {
+{%     if UseAngularResultProcessing == false -%}
+{%          if operation.HasBody -%}
             body: content_,
-{%     endif -%}
-{%     if Framework.Angular.UseHttpClient -%}
+{%          endif -%}
+{%          if Framework.Angular.UseHttpClient -%}
             observe: "response",
             responseType: "blob",
-{%     else -%}
+{%          else -%}
             method: "{{ operation.HttpMethodLower }}",
+{%          endif -%}
 {%     endif -%}
 {%     if operation.IsFile and Framework.Angular.UseHttpClient == false -%}
             responseType: ResponseContentType.Blob,
 {%     endif -%}
             headers: new {% if Framework.Angular.UseHttpClient %}HttpHeaders{% else %}Headers{% endif %}({
 {%     for parameter in operation.HeaderParameters -%}
-                "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "", 
+                "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "",
 {%     endfor -%}
 {%     if operation.HasFormParameters == false -%}
-                "Content-Type": "{{ operation.Consumes }}", 
+                "Content-Type": "{{ operation.Consumes }}",
 {%     endif -%}
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 "Accept": "{{ operation.Produces }}"
@@ -72,44 +74,51 @@
             })
         };
 
-{%     if UseTransformOptionsMethod -%}
+{%     if UseAngularResultProcessing == false -%}
+{%        if UseTransformOptionsMethod -%}
         return {{ Framework.RxJs.ObservableFromMethod }}(this.transformOptions(options_)).{% if Framework.UseRxJs6 %}pipe({% endif %}{{ Framework.RxJs.ObservableMergeMapMethod }}(transformedOptions_ => {
             return this.http.request({% if Framework.Angular.UseHttpClient %}"{{ operation.HttpMethodLower }}", {% endif %}url_, transformedOptions_);
         }){% if Framework.UseRxJs6 %}){% endif %}.{% if Framework.UseRxJs6 %}pipe({% endif %}{{ Framework.RxJs.ObservableMergeMapMethod }}((response_: any) => {
-{%     else -%}
+{%        else -%}
         return this.http.request({% if Framework.Angular.UseHttpClient %}"{{ operation.HttpMethodLower }}", {% endif %}url_, options_).{% if Framework.UseRxJs6 %}pipe({% endif %}{{ Framework.RxJs.ObservableMergeMapMethod }}((response_ : any) => {
-{%     endif -%}
-{%     if UseTransformResultMethod -%}
+{%        endif -%}
+{%        if UseTransformResultMethod -%}
             return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(<any>r));
-{%     else -%}
+{%        else -%}
             return this.process{{ operation.ActualOperationNameUpper }}(response_);
-{%     endif -%}
+{%        endif -%}
         }){% if Framework.UseRxJs6 %}){% endif %}.{% if Framework.UseRxJs6 %}pipe({% endif %}{{ Framework.RxJs.ObservableCatchMethod }}((response_: any) => {
             if (response_ instanceof {% if Framework.Angular.UseHttpClient %}HttpResponseBase{% else %}Response{% endif %}) {
                 try {
-{%     if UseTransformResultMethod -%}
+{%        if UseTransformResultMethod -%}
                     return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(<any>r));
-{%     else -%}
+{%        else -%}
                     return this.process{{ operation.ActualOperationNameUpper }}(<any>response_);
-{%     endif -%}
+{%        endif -%}
                 } catch (e) {
                     return <Observable<{{ operation.ResultType }}>><any>{{ Framework.RxJs.ObservableThrowMethod }}(e);
                 }
             } else
                 return <Observable<{{ operation.ResultType }}>><any>{{ Framework.RxJs.ObservableThrowMethod }}(response_);
         }){% if Framework.UseRxJs6 %}){% endif %};
+{%     else -%}
+        return this.http.{{ operation.HttpMethodLower }}<{{ operation.ResultType }}>(url_, {% if operation.HasBody %}content_, {% endif %}options_);
+{%     endif -%}
     }
 
+{%  if UseAngularResultProcessing == false -%}
     protected process{{ operation.ActualOperationNameUpper }}(response: {% if Framework.Angular.UseHttpClient %}HttpResponseBase{% else %}Response{% endif %}): Observable<{{ operation.ResultType }}> {
         const status = response.status;
-{% if Framework.Angular.UseHttpClient -%}
-        const responseBlob = 
-            response instanceof HttpResponse ? response.body : 
+{%    if Framework.Angular.UseHttpClient -%}
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
             (<any>response).error instanceof Blob ? (<any>response).error : undefined;
-{% endif -%}
+{%    endif -%}
 
         {% template Client.ProcessResponse %}
     }
+{%  endif -%}
+
 {% endfor -%}
 }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -1,65 +1,67 @@
-﻿{% if Framework.IsAngular -%}
+﻿{% if UseAngularResultProcessing == false -%}
+{%  if Framework.IsAngular -%}
 function throwException(message: string, status: number, response: string, headers: { [key: string]: any; }, result?: any): Observable<any> {
-{%     if WrapDtoExceptions -%}
+{%      if WrapDtoExceptions -%}
     return {{ Framework.RxJs.ObservableThrowMethod }}(new SwaggerException(message, status, response, headers, result));
-{%     else -%}
+{%      else -%}
     if(result !== null && result !== undefined)
         return {{ Framework.RxJs.ObservableThrowMethod }}(result);
     else
         return {{ Framework.RxJs.ObservableThrowMethod }}(new SwaggerException(message, status, response, headers, null));
-{%     endif -%}
+{%      endif -%}
 }
 
-{% elseif Framework.IsAngularJS -%}
+{%  elseif Framework.IsAngularJS -%}
 function throwException(q: ng.IQService, message: string, status: number, response: string, headers: { [key: string]: any; }, result?: any): ng.IPromise<any> {
-{%     if WrapDtoExceptions -%}
+{%      if WrapDtoExceptions -%}
     return q.reject(new SwaggerException(message, status, response, headers, result));
-{%     else -%}
+{%      else -%}
     if(result !== null && result !== undefined)
         return q.reject(result);
     else
         return q.reject(new SwaggerException(message, status, response, headers, null));
-{%     endif -%}
+{%      endif -%}
 }
 
-{% else -%}
+{%  else -%}
 function throwException(message: string, status: number, response: string, headers: { [key: string]: any; }, result?: any): any {
-{%     if WrapDtoExceptions -%}
+{%      if WrapDtoExceptions -%}
     throw new SwaggerException(message, status, response, headers, result);
-{%     else -%}
+{%      else -%}
     if(result !== null && result !== undefined)
         throw result;
     else
         throw new SwaggerException(message, status, response, headers, null);
-{%     endif -%}
+{%      endif -%}
 }
 
+{%  endif -%}
 {% endif -%}
-{% if Framework.IsAngular -%}
+{% if Framework.IsAngular and UseAngularResultProcessing == false -%}
 function blobToText(blob: any): Observable<string> {
     return new Observable<string>((observer: any) => {
         if (!blob) {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader(); 
-            reader.onload = function() { 
+            let reader = new FileReader();
+            reader.onload = function() {
                 observer.next(this.result);
                 observer.complete();
             }
-            reader.readAsText(blob); 
+            reader.readAsText(blob);
         }
     });
 }
 
 {% elseif Framework.IsAngularJS -%}
 function blobToText(blob: Blob, q: ng.IQService): ng.IPromise<string> {
-    return new q((resolve) => { 
-        let reader = new FileReader(); 
-        reader.onload = function() { 
+    return new q((resolve) => {
+        let reader = new FileReader();
+        reader.onload = function() {
             resolve(this.result);
         }
-        reader.readAsText(blob); 
+        reader.readAsText(blob);
     });
 }
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -27,10 +27,24 @@ import { Observable, from as {{ Framework.RxJs.ObservableFromMethod }}, throwErr
 {%             endif -%}
 import { Injectable, Inject, Optional, {{ Framework.Angular.InjectionTokenType }} } from '@angular/core';
 {%             if Framework.Angular.UseHttpClient -%}
-import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase, HttpParams } from '@angular/common/http';
 {%             else -%}
 import { Http, Headers, ResponseContentType, Response{% if UseTransformOptionsMethod %}, RequestOptionsArgs{% endif %} } from '@angular/http';
 {%             endif -%}
+
+interface IRequestOptions {
+  headers?: HttpHeaders | {
+    [header: string]: string | string[];
+  };
+  observe?: 'body';
+  params?: HttpParams | {
+      [param: string]: string | string[];
+  };
+  reportProgress?: boolean;
+  responseType?: 'json';
+  withCredentials?: boolean;
+}
+
 {%         endif -%}
 {%         if Framework.IsAurelia -%}
 
@@ -81,8 +95,8 @@ namespace {{ Namespace }} {
     status: number;
     headers: { [key: string]: any; };
     result: TResult;
-        
-    constructor(status: number, headers: { [key: string]: any; }, result: TResult) 
+
+    constructor(status: number, headers: { [key: string]: any; }, result: TResult)
     {
         this.status = status;
         this.headers = headers;
@@ -111,10 +125,10 @@ namespace {{ Namespace }} {
 {% if RequiresSwaggerExceptionClass -%}
 {% if ExportTypes %}export {% endif %}class SwaggerException extends Error {
     message: string;
-    status: number; 
-    response: string; 
+    status: number;
+    response: string;
     headers: { [key: string]: any; };
-    result: any; 
+    result: any;
 
     constructor(message: string, status: number, response: string, headers: { [key: string]: any; }, result: any) {
         super();

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
@@ -159,6 +159,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.WrapResponses = value; }
         }
 
+        [Argument(Name = "UseAngularResultProcessing", IsRequired = false, Description = "Specifies whether to use a simple Angular's result processing (without all these additional processXXX methods)")]
+        public bool UseAngularResultProcessing
+        {
+            get { return Settings.UseAngularResultProcessing; }
+            set { Settings.UseAngularResultProcessing = value; }
+        }
+
         [Argument(Name = "WrapResponseMethods", IsRequired = false, Description = "List of methods where responses are wrapped ('ControllerName.MethodName', WrapResponses must be true).")]
         public string[] WrapResponseMethods
         {


### PR DESCRIPTION
File reduction is achieved by ignoring all the existing processing of the responses. Very simple construction can be used instead, which is just enough for us. 

Example with a diff:
```diff
-    return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
-        return this.processGetPermissions(response_);
-    })).pipe(_observableCatch((response_: any) => {
-        if (response_ instanceof HttpResponseBase) {
-            try {
-                return this.processGetPermissions(<any>response_);
-            } catch (e) {
-                return <Observable<string[]>><any>_observableThrow(e);
-            }
-        } else
-            return <Observable<string[]>><any>_observableThrow(response_);
-    }));
+    return this.http.get<string[]>(url_, options_);
-}
-
-protected processGetPermissions(response: HttpResponseBase): Observable<string[]> {
-    const status = response.status;
-    const responseBlob = 
-        response instanceof HttpResponse ? response.body : 
-        (<any>response).error instanceof Blob ? (<any>response).error : undefined;
-
-    let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }};
-    if (status === 200) {
-        return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
-        let result200: any = null;
-        result200 = _responseText === "" ? null : <string[]>JSON.parse(_responseText, this.jsonParseReviver);
-        return _observableOf(result200);
-        }));
-    } else if (status !== 200 && status !== 204) {
-        return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
-        return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-        }));
-    }
-    return _observableOf<string[]>(<any>null);
-}
```

So it's 1 line instead of existing 35.

I know that this may be a breaking change for someone, so this change is done in a way that it is possible to enable / disable the new shorter template using a new flag: `UseAngularResultProcessing`. By default (`false`) it's an existing behaviour.

Additional thing that happened in this PR is using the same flag to adjust behaviour of the Result Type generated in the Observable. In our codebase it was been generating always as a nullable Observable, which was not true (and more importantly it was just a PITA)

Please let me know your thoughts.

BTW - this PR is similar to the #1248 but in this, a different approach is used. 