### PR TITLE
Add AllowAllSuccessCodes-Option to TS client generator.

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -64,12 +64,37 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         {
             get
             {
-                var response = GetSuccessResponse();
-                var isNullable = response?.IsNullable(_settings.CodeGeneratorSettings.SchemaType) == true;
+                string resultType = "";
+                bool isNullable = false;
 
-                var resultType = isNullable && SupportsStrictNullChecks && UnwrappedResultType != "void" && UnwrappedResultType != "null" ?
-                    UnwrappedResultType + " | null" :
-                    UnwrappedResultType;
+                if (!_settings.AllowAllSuccessCodes)
+                {
+                    var response = GetSuccessResponse();
+                    isNullable = response?.IsNullable(_settings.CodeGeneratorSettings.SchemaType) == true;
+
+                    resultType = UnwrappedResultType;
+
+                } else
+                {
+                    foreach (string _responseStatus in _operation.ActualResponses.Keys)
+                    {
+                        SwaggerResponse _response = _operation.ActualResponses[_responseStatus];
+                        if (_responseStatus.StartsWith("2"))
+                        {
+                            var _isNullable = _response.IsNullable(_settings.CodeGeneratorSettings.SchemaType);
+                            if (_isNullable)
+                                isNullable = true;
+                            var _type = _generator.GetTypeName(_response.ActualResponseSchema, _isNullable, "Response");
+                            resultType += (resultType != "" ? " | " : "") + _type;
+                        }
+                        
+                        if (resultType == "")
+                            resultType = "void";
+                    }
+                }
+
+                if (isNullable && SupportsStrictNullChecks && UnwrappedResultType != "void" && UnwrappedResultType != "null")
+                    resultType += " | null";
 
                 if (WrapResponse)
                 {

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptResponseModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptResponseModel.cs
@@ -9,6 +9,7 @@
 using NJsonSchema;
 using NJsonSchema.CodeGeneration.TypeScript;
 using NSwag.CodeGeneration.Models;
+using System.Linq;
 
 namespace NSwag.CodeGeneration.TypeScript.Models
 {
@@ -37,5 +38,24 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets or sets a value indicating whether to use a DTO class.</summary>
         public bool UseDtoClass => _settings.TypeScriptGeneratorSettings.GetTypeStyle(Type) != TypeScriptTypeStyle.Interface;
+
+        /// <summary>Gets a value indicating whether this is success response. </summary>
+        new public bool IsSuccess
+        {
+            get
+            {
+                if (IsPrimarySuccessResponse)
+                    return true;
+
+                var primarySuccessResponse = _operationModel.Responses.FirstOrDefault(r => r.IsPrimarySuccessResponse);
+                if (_settings.AllowAllSuccessCodes)
+                    return HttpUtilities.IsSuccessStatusCode(StatusCode);
+
+                return HttpUtilities.IsSuccessStatusCode(StatusCode) && (
+                    primarySuccessResponse == null ||
+                    primarySuccessResponse.Type == Type
+                );
+            }
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
@@ -100,6 +100,11 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
 
+        /// <summary>
+        /// When set to true, all Success codes (200-299) will be parsed as Successfull codes.
+        /// This can be used in cases where an operation returns both 200 and 204 status codes for example.
+        /// </summary>
+        public bool AllowAllSuccessCodes { get; set; } = false;
 
         internal ITemplate CreateTemplate(object model)
         {

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -16,7 +16,7 @@ namespace NSwag.CodeGeneration.Models
     /// <summary>The response template model.</summary>
     public abstract class ResponseModelBase
     {
-        private readonly IOperationModel _operationModel;
+        protected readonly IOperationModel _operationModel;
         private readonly SwaggerResponse _response;
         private readonly JsonSchema4 _exceptionSchema;
         private readonly IClientGenerator _generator;

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
@@ -324,6 +324,14 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.QueryNullValue = value; }
         }
 
+        [Argument(Name = "AllowAllSuccessCodes", IsRequired = false,
+            Description = "When set to true, all Success codes (200-299) will be parsed as Successfull codes.")]
+        public bool AllowAllSuccessCodes
+        {
+            get { return Settings.AllowAllSuccessCodes; }
+            set { Settings.AllowAllSuccessCodes = value; }
+        }
+
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
             var code = await RunAsync();


### PR DESCRIPTION
This is a (TypeScript-only) fix for issue #1602

Enabling this option (`AllowAllSuccessCodes`, false by default) will cause **every** 2xx status code to be handled as a successful one.

An Example: An operation that returns either a DTO with status code 200 or nothing with status code 204.

Before:

```typescript
if (status === 200) {
	return response.text().then((_responseText) => {
		let result200: any = null;
		result200 = _responseText === "" ? null : <MyDto[]>JSON.parse(_responseText);
		return new SwaggerResponse(status, _headers, result200);
	});
}
if (status === 204) {
	return response.text().then((_responseText) => {
		return throwException("A server error occurred.", status, _responseText, _headers);
	});
}
```

After:

```typescript
// ...
if (status === 200) {
	return response.text().then((_responseText) => {
		let result200: any = null;
		result200 = _responseText === "" ? null : <MyDto[]>JSON.parse(_responseText);
		return new SwaggerResponse(status, _headers, result200);
	});
}
if (status === 204) {
	return response.text().then((_responseText) => {
		return new SwaggerResponse(status, _headers, <any>null);
	});
}
// ...
```