### PR TITLE
Operation generation mode from first tag and path segments

### DIFF
--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="MultipleClientsFromPathSegmentsOperationNameGenerator.cs" company="NSwag">
+// <copyright file="MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs" company="NSwag">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
 // <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
@@ -25,8 +25,7 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
         /// <returns>The client name.</returns>
         public virtual string GetClientName(SwaggerDocument document, string path, string httpMethod, SwaggerOperation operation)
         {
-            var tags = operation.Tags;
-            return tags.Count > 0 ? tags[0] : string.Empty;
+            return ConversionUtilities.ConvertToUpperCamelCase(operation.Tags.FirstOrDefault(), false);
         }
 
         /// <summary>Gets the operation name for a given operation.</summary>
@@ -49,7 +48,7 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
 
             if (hasNameConflict)
             {
-                operationName += CapitalizeFirst(httpMethod);
+                operationName += ConversionUtilities.ConvertToUpperCamelCase(httpMethod, false);
             }
 
             return operationName;
@@ -65,20 +64,6 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
                 .Where(p => !p.Contains("{") && !string.IsNullOrWhiteSpace(p))
                 .Reverse()
                 .FirstOrDefault() ?? "Index";
-        }
-
-        /// <summary>Capitalizes first letter.</summary>
-        /// <param name="name">The name to capitalize.</param>
-        /// <returns>Capitalized name.</returns>
-        internal static string CapitalizeFirst(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                return string.Empty;
-            }
-
-            var capitalized = name.ToLower();
-            return char.ToUpper(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
         }
     }
 }

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs
@@ -11,8 +11,8 @@ using System.Linq;
 
 namespace NSwag.CodeGeneration.OperationNameGenerators
 {
-    /// <summary>Generates the client and operation name based on the path segments (operation name = last segment, client name = second to last segment).</summary>
-    public class MultipleClientsFromFirstTagOperationNameGenerator : IOperationNameGenerator
+    /// <summary>Generates the client name based on the first tag and operation name based on the path segments (operation name = last segment, client name = first tag).</summary>
+    public class MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator : IOperationNameGenerator
     {
         /// <summary>Gets a value indicating whether the generator supports multiple client classes.</summary>
         public bool SupportsMultipleClients { get; } = true;

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagOperationNameGenerator.cs
@@ -1,0 +1,84 @@
+//-----------------------------------------------------------------------
+// <copyright file="MultipleClientsFromPathSegmentsOperationNameGenerator.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using NJsonSchema;
+using System.Linq;
+
+namespace NSwag.CodeGeneration.OperationNameGenerators
+{
+    /// <summary>Generates the client and operation name based on the path segments (operation name = last segment, client name = second to last segment).</summary>
+    public class MultipleClientsFromFirstTagOperationNameGenerator : IOperationNameGenerator
+    {
+        /// <summary>Gets a value indicating whether the generator supports multiple client classes.</summary>
+        public bool SupportsMultipleClients { get; } = true;
+
+        /// <summary>Gets the client name for a given operation (may be empty).</summary>
+        /// <param name="document">The Swagger document.</param>
+        /// <param name="path">The HTTP path.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="operation">The operation.</param>
+        /// <returns>The client name.</returns>
+        public virtual string GetClientName(SwaggerDocument document, string path, string httpMethod, SwaggerOperation operation)
+        {
+            var tags = operation.Tags;
+            return tags.Count > 0 ? tags[0] : string.Empty;
+        }
+
+        /// <summary>Gets the operation name for a given operation.</summary>
+        /// <param name="document">The Swagger document.</param>
+        /// <param name="path">The HTTP path.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="operation">The operation.</param>
+        /// <returns>The operation name.</returns>
+        public virtual string GetOperationName(SwaggerDocument document, string path, string httpMethod, SwaggerOperation operation)
+        {
+            var operationName = ConvertPathToName(path);
+
+            var hasNameConflict = document.Paths
+                .SelectMany(pair => pair.Value.Select(p => new { Path = pair.Key.Trim('/'), HttpMethod = p.Key, Operation = p.Value }))
+                .Where(op =>
+                    GetClientName(document, op.Path, op.HttpMethod, op.Operation) == GetClientName(document, path, httpMethod, operation) &&
+                    ConvertPathToName(op.Path) == operationName
+                ).ToList()
+                .Count > 1;
+
+            if (hasNameConflict)
+            {
+                operationName += CapitalizeFirst(httpMethod);
+            }
+
+            return operationName;
+        }
+
+        /// <summary>Converts the path to an operation name.</summary>
+        /// <param name="path">The HTTP path.</param>
+        /// <returns>The operation name.</returns>
+        internal static string ConvertPathToName(string path)
+        {
+            return path
+                .Split('/')
+                .Where(p => !p.Contains("{") && !string.IsNullOrWhiteSpace(p))
+                .Reverse()
+                .FirstOrDefault() ?? "Index";
+        }
+
+        /// <summary>Capitalizes first letter.</summary>
+        /// <param name="name">The name to capitalize.</param>
+        /// <returns>Capitalized name.</returns>
+        internal static string CapitalizeFirst(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return string.Empty;
+            }
+
+            var capitalized = name.ToLower();
+            return char.ToUpper(capitalized[0]) + (capitalized.Length > 1 ? capitalized.Substring(1) : "");
+        }
+    }
+}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
@@ -17,6 +17,9 @@ namespace NSwag.Commands.CodeGeneration
         /// <summary>From path segments (operation name = last segment, client name = second to last segment).</summary>
         MultipleClientsFromPathSegments,
 
+        /// <summary>From the first SwaggerDocument tag.</summary>
+        MultipleClientsFromFirstTag,
+
         /// <summary>From the Swagger operation ID.</summary>
         SingleClientFromOperationId,
 

--- a/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
@@ -17,8 +17,8 @@ namespace NSwag.Commands.CodeGeneration
         /// <summary>From path segments (operation name = last segment, client name = second to last segment).</summary>
         MultipleClientsFromPathSegments,
 
-        /// <summary>From the first SwaggerDocument tag.</summary>
-        MultipleClientsFromFirstTag,
+        /// <summary>From the first operation tag and path segments (operation name = last segment, client name = first operation tag).</summary>
+        MultipleClientsFromFirstTagAndPathSegments,
 
         /// <summary>From the Swagger operation ID.</summary>
         SingleClientFromOperationId,

--- a/src/NSwag.Commands/OperationGenerationModeConverter.cs
+++ b/src/NSwag.Commands/OperationGenerationModeConverter.cs
@@ -19,8 +19,8 @@ namespace NSwag.Commands
                 return OperationGenerationMode.MultipleClientsFromOperationId;
             if (operationNameGenerator is MultipleClientsFromPathSegmentsOperationNameGenerator)
                 return OperationGenerationMode.MultipleClientsFromPathSegments;
-            if (operationNameGenerator is MultipleClientsFromFirstTagOperationNameGenerator)
-                return OperationGenerationMode.MultipleClientsFromFirstTag;
+            if (operationNameGenerator is MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator)
+                return OperationGenerationMode.MultipleClientsFromFirstTagAndPathSegments;
             if (operationNameGenerator is SingleClientFromOperationIdOperationNameGenerator)
                 return OperationGenerationMode.SingleClientFromOperationId;
             if (operationNameGenerator is SingleClientFromPathSegmentsOperationNameGenerator)
@@ -34,8 +34,8 @@ namespace NSwag.Commands
                 return new MultipleClientsFromOperationIdOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromPathSegments)
                 return new MultipleClientsFromPathSegmentsOperationNameGenerator();
-            else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromFirstTag)
-                return new MultipleClientsFromFirstTagOperationNameGenerator();
+            else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromFirstTagAndPathSegments)
+                return new MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.SingleClientFromOperationId)
                 return new SingleClientFromOperationIdOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.SingleClientFromPathSegments)

--- a/src/NSwag.Commands/OperationGenerationModeConverter.cs
+++ b/src/NSwag.Commands/OperationGenerationModeConverter.cs
@@ -19,6 +19,8 @@ namespace NSwag.Commands
                 return OperationGenerationMode.MultipleClientsFromOperationId;
             if (operationNameGenerator is MultipleClientsFromPathSegmentsOperationNameGenerator)
                 return OperationGenerationMode.MultipleClientsFromPathSegments;
+            if (operationNameGenerator is MultipleClientsFromFirstTagOperationNameGenerator)
+                return OperationGenerationMode.MultipleClientsFromFirstTag;
             if (operationNameGenerator is SingleClientFromOperationIdOperationNameGenerator)
                 return OperationGenerationMode.SingleClientFromOperationId;
             if (operationNameGenerator is SingleClientFromPathSegmentsOperationNameGenerator)
@@ -32,6 +34,8 @@ namespace NSwag.Commands
                 return new MultipleClientsFromOperationIdOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromPathSegments)
                 return new MultipleClientsFromPathSegmentsOperationNameGenerator();
+            else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromFirstTag)
+                return new MultipleClientsFromFirstTagOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.SingleClientFromOperationId)
                 return new SingleClientFromOperationIdOperationNameGenerator();
             else if (operationGenerationMode == OperationGenerationMode.SingleClientFromPathSegments)

--- a/src/NSwag.SwaggerGeneration.WebApi.Tests/NSwag.SwaggerGeneration.WebApi.Tests.csproj
+++ b/src/NSwag.SwaggerGeneration.WebApi.Tests/NSwag.SwaggerGeneration.WebApi.Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Attributes\SwaggerIgnoreTests.cs" />
     <Compile Include="Attributes\TagsTests.cs" />
     <Compile Include="ControllerClassesTests.cs" />
+    <Compile Include="OperationNameGenerator\MultipleClientsFromFirstTagAndPathSegmentsOperationNameGeneratorTests.cs" />
     <Compile Include="OperationNameGenerator\MultipleClientsFromOperationIdOperationNameGeneratorTests.cs" />
     <Compile Include="OperationNameGenerator\MultipleClientsFromPathSegmentsOperationNameGeneratorTests.cs" />
     <Compile Include="OperationProcessors\ApiVersionProcessorWithWebApiTests.cs" />

--- a/src/NSwag.SwaggerGeneration.WebApi.Tests/OperationNameGenerator/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGeneratorTests.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi.Tests/OperationNameGenerator/MultipleClientsFromFirstTagAndPathSegmentsOperationNameGeneratorTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSwag.Annotations;
+using NSwag.CodeGeneration.OperationNameGenerators;
+using NSwag.CodeGeneration.TypeScript;
+using System.Windows;
+using System.Linq;
+
+namespace NSwag.SwaggerGeneration.WebApi.Tests.OperationNameGenerator
+{
+    /// <summary>
+    /// Test class for MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator
+    /// </summary>
+    /// <remarks>
+    /// When endpoints are given OperationIds in the format {ControllerClassName}_{id}, use
+    /// MultipleClientsFromOperationIdOperationNameGenerator to ensure each controller gets its own client.
+    /// However, when the OperationId is in a different format use tags with the
+    /// MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator to generate unique clients.
+    /// </remarks>
+    [TestClass]
+    public class MultipleClientsFromFirstTagAndPathSegmentsOperationNameGeneratorTests
+    {
+        [SwaggerTag("PointControllerA")]
+        public class PointControllerA
+        {
+            [SwaggerOperation("PointControllerAGetPoint")]
+            [HttpGet]
+            public Point Get(int id) 
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [SwaggerTag("PointControllerB")]
+        public class PointControllerB
+        {
+            [SwaggerOperation("PointControllerBGetPoint")]
+            [HttpGet]
+            public Point Get(int id)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [TestMethod]
+        public async Task When_operations_have_different_tags_they_are_grouped_into_different_clients()
+        {
+            //// Arrange
+            var generator = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await generator.GenerateForControllersAsync(new List<Type>() { typeof(PointControllerA), typeof(PointControllerB) });
+            var codeGenerator = new SwaggerToTypeScriptClientGenerator(document, new SwaggerToTypeScriptClientGeneratorSettings
+            {
+                OperationNameGenerator = new MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator()
+            });
+
+            //// Act
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.IsTrue(code.Contains("export class PointControllerAClient"));
+            Assert.IsTrue(code.Contains("export class PointControllerBClient"));
+        }
+
+        [TestMethod]
+        public async Task When_operations_have_no_tags_they_are_grouped_into_one_client()
+        {
+            //// Arrange
+            var generator = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await generator.GenerateForControllersAsync(new List<Type>() { typeof(PointControllerA), typeof(PointControllerB) });
+
+            // Remove tags
+            foreach (var path in document.Paths.Values)
+            {
+                foreach (var operation in path.Values)
+                {
+                    operation.Tags.Clear();
+                }
+            }
+            var codeGenerator = new SwaggerToTypeScriptClientGenerator(document, new SwaggerToTypeScriptClientGeneratorSettings
+            {
+                OperationNameGenerator = new MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator()
+            });
+
+            //// Act
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.IsTrue(code.Contains("export class Client"));
+            Assert.IsTrue(!code.Contains("export class PointControllerAClient"));
+            Assert.IsTrue(!code.Contains("export class PointControllerBClient"));
+        }
+    }
+}


### PR DESCRIPTION
Adds new IOperationNameGenerator class (MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator.cs) for generating {controller} using the first tag in each operation and generating the operation name based on the path

Related issues: #1823, #1805
