### PR TITLE
Fix generation date parameters using form data

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -57,6 +57,8 @@ else
 {%                 else -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.data, {{ parameter.VariableName }}.fileName ? {{ parameter.VariableName }}.fileName : "{{ parameter.Name }}");
 {%                 endif -%}
+{%             elseif parameter.IsDate -%}
+    content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toJSON());
 {%             else -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toString());
 {%             endif -%}


### PR DESCRIPTION
Hey there!

When we create a `multipart/form-data` request and pass date parameters, they transform into the `string` using `.toString()` function, but you used `.toJSON()` transformation for dates in every part of this repository.

Controllers cannot parse format like this: 
> Thu Mar 28 2019 10:39:19 GMT+0200 (Eastern European Standard Time)

Therefore we must transform dates to ISO format.