### PR TITLE
Allow detection of application/vnd.*+json as Json response

### DIFF
--- a/src/NSwag.Core.Tests/SwaggerResponseTests.cs
+++ b/src/NSwag.Core.Tests/SwaggerResponseTests.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+
+namespace NSwag.Core.Tests
+{
+    public class SwaggerResponseTests
+    {
+        [Theory]
+        [InlineData("application/octet-stream", true)]
+        [InlineData("undefined", true)]
+        [InlineData("text/plain", false)]
+        [InlineData("application/json", false)]
+        [InlineData("application/vnd.model+json", false)]
+        public void When_response_contains_produces_detect_if_binary_response(string contentType, bool expectsBinary)
+        {
+            // Arrange
+            var response = new SwaggerResponse();
+            var operation = new SwaggerOperation();
+            operation.Produces = new System.Collections.Generic.List<string> { contentType };
+            operation.Responses.Add("200", response);
+
+            // Act
+            var isBinary = response.IsBinary(operation);
+
+            // Assert
+            Assert.Equal(expectsBinary, isBinary);
+        }
+    }
+}

--- a/src/NSwag.Core/SwaggerResponse.cs
+++ b/src/NSwag.Core/SwaggerResponse.cs
@@ -121,7 +121,8 @@ namespace NSwag
                 {
                     var contentIsBinary =
                         !ActualResponse.Content.ContainsKey("application/json") &&
-                        !ActualResponse.Content.ContainsKey("text/plain");
+                        !ActualResponse.Content.ContainsKey("text/plain") &&
+                        !ActualResponse.Content.Keys.Any(p => p.StartsWith("application/") && p.EndsWith("+json"));
                     if (contentIsBinary)
                     {
                         return true;
@@ -133,7 +134,8 @@ namespace NSwag
                 {
                     var producesIsBinary =
                         actualProduces?.Contains("application/json") != true &&
-                        actualProduces?.Contains("text/plain") != true;
+                        actualProduces?.Contains("text/plain") != true &&
+                        actualProduces?.Any(p => p.StartsWith("application/") && p.EndsWith("+json")) != true;
 
                     if (producesIsBinary)
                     {


### PR DESCRIPTION
85c5c2bfe4ede6c216246702e40cd6dd3b6e26a1 updated the detection of binary responses. It only checks for `application/json`, but ignores other valid values, such as `application/vnd.model+json`. This caused the following regression for this controller action:

```csharp
[Produces("application/vnd.com.danglit.ProjectDto.v1+json")]
[ProducesResponseType(typeof(ProjectDto), 200)]
public async Task<IActionResult> ConvertToAvaAsync()
```

Produces the following, shortened Swagger document:

```json
"post": {
  "produces": [
    "application/vnd.com.danglit.ProjectDto.v1+json"
  ],
  "responses": {
    "200": {
      "x-nullable": true,
      "schema": {
        "$ref": "#/definitions/ProjectDto"
      }
    }
  }
}
```

This is now no longer detected as Json and results in the C# Client generating a `FileResponse`.
