### PR TITLE
Use controller name from ApiExplorer instead of custom logic for AspNetCoreToSwaggerGenerator

### DIFF
--- a/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGeneratorSettings.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGeneratorSettings.cs
@@ -19,7 +19,7 @@ namespace NSwag.SwaggerGeneration.AspNetCore
         {
             OperationProcessors.Insert(2, new OperationParameterProcessor(this));
             OperationProcessors.Insert(2, new OperationResponseProcessor(this));
-            OperationProcessors.Replace<OperationTagsProcessor>(new OperationTagsProcessorNetCore());
+            OperationProcessors.Replace<OperationTagsProcessor>(new AspNetCoreOperationTagsProcessor());
         }
 
         /// <summary>Gets or sets the ASP.NET Core API Explorer group names to include (default: empty/null = all, often used to select API version).</summary>

--- a/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGeneratorSettings.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGeneratorSettings.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using NSwag.SwaggerGeneration.Processors;
 using NSwag.SwaggerGeneration.AspNetCore.Processors;
 
 namespace NSwag.SwaggerGeneration.AspNetCore
@@ -18,6 +19,7 @@ namespace NSwag.SwaggerGeneration.AspNetCore
         {
             OperationProcessors.Insert(2, new OperationParameterProcessor(this));
             OperationProcessors.Insert(2, new OperationResponseProcessor(this));
+            OperationProcessors.Replace<OperationTagsProcessor>(new OperationTagsProcessorNetCore());
         }
 
         /// <summary>Gets or sets the ASP.NET Core API Explorer group names to include (default: empty/null = all, often used to select API version).</summary>

--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/AspNetCoreOperationTagsProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/AspNetCoreOperationTagsProcessor.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="OperationTagsProcessor.cs" company="NSwag">
+// <copyright file="AspNetCoreOperationTagsProcessor.cs" company="NSwag">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
 // <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
@@ -13,7 +13,7 @@ using NSwag.SwaggerGeneration.Processors.Contexts;
 namespace NSwag.SwaggerGeneration.AspNetCore.Processors
 {
     /// <summary>Processes the SwaggerTagsAttribute on the operation method.</summary>
-    public class OperationTagsProcessorNetCore : OperationTagsProcessor
+    public class AspNetCoreOperationTagsProcessor : OperationTagsProcessor
     {
         protected override void AddControllerNameTag(OperationProcessorContext context)
         {

--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationTagsProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationTagsProcessor.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OperationTagsProcessor.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using NSwag.SwaggerGeneration.Processors;
+using NSwag.SwaggerGeneration.Processors.Contexts;
+
+namespace NSwag.SwaggerGeneration.AspNetCore.Processors
+{
+    /// <summary>Processes the SwaggerTagsAttribute on the operation method.</summary>
+    public class OperationTagsProcessorNetCore : OperationTagsProcessor
+    {
+        protected override void AddControllerNameTag(OperationProcessorContext context)
+        {
+            var aspNetCoreContext = (AspNetCoreOperationProcessorContext)context;
+            if (aspNetCoreContext.ApiDescription.ActionDescriptor is ControllerActionDescriptor descriptor)
+            {
+                aspNetCoreContext.OperationDescription.Operation.Tags.Add(descriptor.ControllerName);
+                return;
+            }
+
+            base.AddControllerNameTag(context);
+        }
+    }
+}

--- a/src/NSwag.SwaggerGeneration/Processors/Collections/OperationProcessorCollection.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/Collections/OperationProcessorCollection.cs
@@ -21,5 +21,23 @@ namespace NSwag.SwaggerGeneration.Processors.Collections
         {
             return (T)this.FirstOrDefault(p => p is T);
         }
+
+        /// <summary>Replaces the first element of type <typeparamref name="T"/>
+        /// with <paramref name="newItem"/>.</summary>
+        /// <typeparam name="T">The operation processor type to replace.</typeparam>
+        /// <param name="newItem">The replacement item.</param>
+        /// <returns>true, if an item was replaced; otherwise false.</returns>
+        public bool Replace<T>(IOperationProcessor newItem) where T : IOperationProcessor
+        {
+            var item = this.OfType<T>().FirstOrDefault();
+
+            if (item != null)
+            {
+                this.SetItem(this.IndexOf(item), newItem);
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/NSwag.SwaggerGeneration/Processors/Collections/OperationProcessorCollection.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/Collections/OperationProcessorCollection.cs
@@ -33,7 +33,7 @@ namespace NSwag.SwaggerGeneration.Processors.Collections
 
             if (item != null)
             {
-                this.SetItem(this.IndexOf(item), newItem);
+                SetItem(IndexOf(item), newItem);
                 return true;
             }
 

--- a/src/NSwag.SwaggerGeneration/Processors/OperationTagsProcessor.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/OperationTagsProcessor.cs
@@ -32,7 +32,7 @@ namespace NSwag.SwaggerGeneration.Processors
             return Task.FromResult(true);
         }
 
-        private void AddControllerNameTag(OperationProcessorContext context)
+        protected virtual void AddControllerNameTag(OperationProcessorContext context)
         {
             var controllerName = context.ControllerType.Name;
             if (controllerName.EndsWith("Controller"))


### PR DESCRIPTION
With ApiExplorer, we can do better than this:

            if (controllerName.EndsWith("Controller"))
                controllerName = controllerName.Substring(0, controllerName.Length - 10);

