### PR TITLE
Fix overwriting global consumes and produces sections

### DIFF
--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Requests/MultipartConsumesController.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Requests/MultipartConsumesController.cs
@@ -4,18 +4,11 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Requests
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ConsumesController : Controller
+    public class MultipartConsumesController : Controller
     {
-        [Consumes("foo/bar", "text/html")] // requires CustomTextInputFormatter
+        [Consumes("multipart/form-data")]
         [HttpPost("ConsumesOnOperation")]
         public ActionResult ConsumesOnOperation([FromBody] string body)
-        {
-            return Ok();
-        }
-
-        [Consumes("text/html")]
-        [HttpPost("SecondOperation")]
-        public ActionResult SecondOperation([FromBody] string body)
         {
             return Ok();
         }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Requests/MultipartConsumesController.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Requests/MultipartConsumesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Requests
 {
@@ -6,9 +7,8 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Requests
     [Route("api/[controller]")]
     public class MultipartConsumesController : Controller
     {
-        [Consumes("multipart/form-data")]
         [HttpPost("ConsumesOnOperation")]
-        public ActionResult ConsumesOnOperation([FromBody] string body)
+        public ActionResult ConsumesOnOperation(IFormFile body)
         {
             return Ok();
         }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Responses/JsonProducesController.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Responses/JsonProducesController.cs
@@ -4,9 +4,9 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Responses
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ProducesController : Controller
+    public class JsonProducesController : Controller
     {
-        [Produces("text/html")]
+        [Produces("application/json")]
         [HttpPost("ProducesOnOperation")]
         public ActionResult<string> ProducesOnOperation([FromBody] string body)
         {

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Responses/TextProducesController.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Responses/TextProducesController.cs
@@ -4,7 +4,7 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Responses
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ProducesController : Controller
+    public class TextProducesController : Controller
     {
         [Produces("text/html")]
         [HttpPost("ProducesOnOperation")]

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Requests/ConsumesTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Requests/ConsumesTests.cs
@@ -51,23 +51,27 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Requests
             var settings = new AspNetCoreToSwaggerGeneratorSettings();
 
             // Act
-            var document = await GenerateDocumentAsync(settings, 
-                typeof(ConsumesController), typeof(MultipartConsumesController));
+            var document = await GenerateDocumentAsync(settings, typeof(ConsumesController), typeof(MultipartConsumesController));
             var json = document.ToJson();
 
             // Assert
             const string expectedTestContentType = "foo/bar";
             const string expectedMultipartContentType = "multipart/form-data";
             
-            var operation = document.Operations.First(o => o.Operation.OperationId == "Consumes_ConsumesOnOperation")
+            var operation = document.Operations
+                .First(o => o.Operation.OperationId == "Consumes_ConsumesOnOperation")
                 .Operation;
-            var multipartOperation = document.Operations.First(o => o.Operation.OperationId == "MultipartConsumes_ConsumesOnOperation")
+
+            var multipartOperation = document.Operations
+                .First(o => o.Operation.OperationId == "MultipartConsumes_ConsumesOnOperation")
                 .Operation;
             
             Assert.DoesNotContain(expectedTestContentType, document.Consumes);
             Assert.DoesNotContain(expectedMultipartContentType, document.Consumes);
+
             Assert.Contains(expectedTestContentType, operation.Consumes);
             Assert.Contains(expectedTestContentType, operation.ActualConsumes);
+
             Assert.Contains(expectedMultipartContentType, multipartOperation.Consumes);
             Assert.Contains(expectedMultipartContentType, multipartOperation.ActualConsumes);
         }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Requests/ConsumesTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Requests/ConsumesTests.cs
@@ -43,5 +43,33 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Requests
             Assert.Contains("foo/bar", operation.Consumes);
             Assert.Contains("foo/bar", operation.ActualConsumes);
         }
+
+        [Fact]
+        public async Task When_operation_consumes_is_different_in_several_controllers_then_they_are_added_to_the_operation()
+        {
+            // Arrange
+            var settings = new AspNetCoreToSwaggerGeneratorSettings();
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, 
+                typeof(ConsumesController), typeof(MultipartConsumesController));
+            var json = document.ToJson();
+
+            // Assert
+            const string expectedTestContentType = "foo/bar";
+            const string expectedMultipartContentType = "multipart/form-data";
+            
+            var operation = document.Operations.First(o => o.Operation.OperationId == "Consumes_ConsumesOnOperation")
+                .Operation;
+            var multipartOperation = document.Operations.First(o => o.Operation.OperationId == "MultipartConsumes_ConsumesOnOperation")
+                .Operation;
+            
+            Assert.DoesNotContain(expectedTestContentType, document.Consumes);
+            Assert.DoesNotContain(expectedMultipartContentType, document.Consumes);
+            Assert.Contains(expectedTestContentType, operation.Consumes);
+            Assert.Contains(expectedTestContentType, operation.ActualConsumes);
+            Assert.Contains(expectedMultipartContentType, multipartOperation.Consumes);
+            Assert.Contains(expectedMultipartContentType, multipartOperation.ActualConsumes);
+        }
     }
 }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ProducesTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ProducesTests.cs
@@ -1,9 +1,9 @@
-﻿using NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Requests;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
+using NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Responses;
 using Xunit;
 
-namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Requests
+namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Responses
 {
     public class ProducesTests : AspNetCoreTestsBase
     {
@@ -23,6 +23,30 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Requests
             Assert.Contains("text/html", document.Produces);
             Assert.Contains("text/html", operation.ActualProduces);
             Assert.Null(operation.Produces);
+        }
+        
+        [Fact]
+        public async Task When_operation_produces_is_different_in_several_controllers_then_they_are_added_to_the_operation()
+        {
+            // Arrange
+            var settings = new AspNetCoreToSwaggerGeneratorSettings();
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(ProducesController), typeof(JsonProducesController));
+            var json = document.ToJson();
+
+            // Assert
+            const string expectedTextContentType = "text/html";
+            const string expectedJsonJsonType = "application/json";
+            var textOperation = document.Operations.First(o => o.Operation.OperationId == "Produces_ProducesOnOperation").Operation;
+            var jsonOperation = document.Operations.First(o => o.Operation.OperationId == "JsonProduces_ProducesOnOperation").Operation;
+
+            Assert.DoesNotContain(expectedTextContentType, document.Produces);
+            Assert.DoesNotContain(expectedJsonJsonType, document.Produces);
+            Assert.Contains(expectedTextContentType, textOperation.Produces);
+            Assert.Contains(expectedTextContentType, textOperation.ActualProduces);
+            Assert.Contains(expectedJsonJsonType, jsonOperation.Produces);
+            Assert.Contains(expectedJsonJsonType, jsonOperation.ActualProduces);
         }
     }
 }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ProducesTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ProducesTests.cs
@@ -14,11 +14,11 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Responses
             var settings = new AspNetCoreToSwaggerGeneratorSettings();
 
             // Act
-            var document = await GenerateDocumentAsync(settings, typeof(ProducesController));
+            var document = await GenerateDocumentAsync(settings, typeof(TextProducesController));
             var json = document.ToJson();
 
             // Assert
-            var operation = document.Operations.First(o => o.Operation.OperationId == "Produces_ProducesOnOperation").Operation;
+            var operation = document.Operations.First(o => o.Operation.OperationId == "TextProduces_ProducesOnOperation").Operation;
 
             Assert.Contains("text/html", document.Produces);
             Assert.Contains("text/html", operation.ActualProduces);
@@ -32,19 +32,22 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Responses
             var settings = new AspNetCoreToSwaggerGeneratorSettings();
 
             // Act
-            var document = await GenerateDocumentAsync(settings, typeof(ProducesController), typeof(JsonProducesController));
+            var document = await GenerateDocumentAsync(settings, typeof(TextProducesController), typeof(JsonProducesController));
             var json = document.ToJson();
 
             // Assert
             const string expectedTextContentType = "text/html";
             const string expectedJsonJsonType = "application/json";
-            var textOperation = document.Operations.First(o => o.Operation.OperationId == "Produces_ProducesOnOperation").Operation;
+
+            var textOperation = document.Operations.First(o => o.Operation.OperationId == "TextProduces_ProducesOnOperation").Operation;
             var jsonOperation = document.Operations.First(o => o.Operation.OperationId == "JsonProduces_ProducesOnOperation").Operation;
 
             Assert.DoesNotContain(expectedTextContentType, document.Produces);
             Assert.DoesNotContain(expectedJsonJsonType, document.Produces);
+
             Assert.Contains(expectedTextContentType, textOperation.Produces);
             Assert.Contains(expectedTextContentType, textOperation.ActualProduces);
+
             Assert.Contains(expectedJsonJsonType, jsonOperation.Produces);
             Assert.Contains(expectedJsonJsonType, jsonOperation.ActualProduces);
         }

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ResponseAttributesTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Responses/ResponseAttributesTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers;
 using Xunit;
 
-namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Parameters
+namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Responses
 {
     public class ResponseAttributesTests : AspNetCoreTestsBase
     {

--- a/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs
@@ -72,14 +72,14 @@ namespace NSwag.SwaggerGeneration.AspNetCore
             document.Consumes = apiGroups
                 .SelectMany(s => s.SupportedRequestFormats)
                 .Select(s => s.MediaType)
-                .Where(m => apiGroups.All(a => !a.SupportedRequestFormats.Any() || a.SupportedRequestFormats.Contains(m)))
+                .Where(m => apiGroups.All(a => a.SupportedRequestFormats.Contains(m)))
                 .Distinct()
                 .ToList();
             
             document.Produces = apiGroups
                 .SelectMany(c => c.SupportedResponseTypes)
                 .SelectMany(s => s.ApiResponseFormats.Select(f => f.MediaType))
-                .Where(c => apiGroups.All(o => !o.SupportedResponseTypes.Any() || o.SupportedResponseTypes.Contains(c)))
+                .Where(c => apiGroups.All(o => o.SupportedResponseTypes.Contains(c)))
                 .Distinct()
                 .ToList();
             

--- a/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs
@@ -194,7 +194,14 @@ namespace NSwag.SwaggerGeneration.AspNetCore
 
             if (globalConsumes.Any())
             {
-                document.Consumes = globalConsumes.ToList();
+                if (document.Consumes == null)
+                {
+                    document.Consumes = globalConsumes.ToList();
+                }
+                else
+                {
+                    document.Consumes.AddRange(globalConsumes.Where(c => !document.Consumes.Contains(c)));
+                }
             }
 
             var globalProduces = operations
@@ -204,7 +211,14 @@ namespace NSwag.SwaggerGeneration.AspNetCore
 
             if (globalProduces.Any())
             {
-                document.Produces = globalProduces.ToList();
+                if (document.Produces == null)
+                {
+                    document.Produces = globalProduces.ToList();
+                }
+                else
+                {
+                    document.Produces.AddRange(globalProduces.Where(c => !document.Produces.Contains(c)));
+                }
             }
 
             var addedOperations = 0;


### PR DESCRIPTION
Hey, there!

I recently upgraded from v12.0.14 and now I'm getting an error where several requests return **415 HTTP-response**.

Sorry, but I think you have a problem [here](https://github.com/RicoSuter/NSwag/blob/19ecd169938a78fe33afabf43cb1fa2e7c959be1/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs#L197).

For every controller you received from the `IApiDescriptionGroupCollectionProvider` you overwrite **global consumes** and it can be a problem when **operation's consume** attribute equals to the **global consume** value. Look at [here](https://github.com/RicoSuter/NSwag/blob/19ecd169938a78fe33afabf43cb1fa2e7c959be1/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs#L219). If **operation's consume** attributes equals to **global**, you don't write a consume section to the operation at all.

There is an example of this problem:

```
public class Controller1
{
    [Consumes("application/json")]
    public ViewModel GetSomeData() { ... }
}

public class Controller2 
{
    [Consumes("multipart/form-data")]
    public ViewModel SaveSomeData() { ... }
}
```

Controllers consume `application/json` by default. After processing `Controller1`, document will have 3 values in **global consume** section and no one in the operation's section (`GetSomeData`):

- application/json-patch+;
- application/json;
- application/*+json.

But after processing `Controller2` the **document consume section** will be overwritten with `multipart/form-data`. So as we don't have any **consume section** for `GetSomeData` operation and **global consume section** will be equals to `multipart/form-data`, every request to `Controller1` will return 415 HTTP-code. So this logic works only for one document per controller, but we have only one document creation [.](https://github.com/RicoSuter/NSwag/blob/19ecd169938a78fe33afabf43cb1fa2e7c959be1/src/NSwag.SwaggerGeneration.AspNetCore/AspNetCoreToSwaggerGenerator.cs#L64)

These changes are related to the following [commit](https://github.com/RicoSuter/NSwag/commit/556d4b3d6c020305b656ece7662adc8534e9af13)

I hope I gave you enough details to explain this case. 

Thanks.