### PR TITLE
Fix content (mime) types in SwaggerResponse

### DIFF
--- a/src/NSwag.Core.Tests/Serialization/ExampleSerializationTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/ExampleSerializationTests.cs
@@ -69,9 +69,17 @@ namespace NSwag.Core.Tests.Serialization
                             {
                                 "200",
                                 new SwaggerResponse
-                                {
-                                    Examples = 1
-                                }
+                                    {
+                                        Content =
+                                            {
+                                                {
+                                                    "application/json", new OpenApiMediaType
+                                                    {
+                                                        Example = 1,
+                                                    }
+                                                }
+                                            },
+                                    }
                             }
                         }
                     }

--- a/src/NSwag.Core.Tests/Serialization/MediaTypesSerializationTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/MediaTypesSerializationTests.cs
@@ -159,19 +159,27 @@ namespace NSwag.Core.Tests.Serialization
                         new SwaggerPathItem
                         {
                             {
-                                SwaggerOperationMethod.Get, 
+                                SwaggerOperationMethod.Get,
                                 new SwaggerOperation
                                 {
                                     Responses =
                                     {
                                         {
-                                            "200", 
+                                            "200",
                                             new SwaggerResponse
                                             {
-                                                Examples = 123,
-                                                Schema = new JsonSchema4
+                                                Content =
                                                 {
-                                                    Type = type
+                                                    {
+                                                        "application/json", new OpenApiMediaType
+                                                        {
+                                                            Schema = new JsonSchema4
+                                                            {
+                                                                Type = type
+                                                            },
+                                                            Example = 123,
+                                                        }
+                                                    }
                                                 },
                                             }
                                         }

--- a/src/NSwag.Core/SwaggerResponse.cs
+++ b/src/NSwag.Core/SwaggerResponse.cs
@@ -59,7 +59,7 @@ namespace NSwag
         public JsonSchema4 Schema
         {
             get => Content.FirstOrDefault(c => c.Value.Schema != null).Value?.Schema;
-            set => UpdateContent(value, Examples);
+            ////set => UpdateContent(value, Examples);
         }
 
         /// <summary>Gets or sets the headers (Swagger only).</summary>
@@ -67,21 +67,29 @@ namespace NSwag
         public object Examples
         {
             get => Content.FirstOrDefault(c => c.Value.Example != null).Value?.Example;
-            set => UpdateContent(Schema, value);
+            ////set => UpdateContent(Schema, value);
         }
 
-        private void UpdateContent(JsonSchema4 schema, object example)
+        public void UpdateContent(JsonSchema4 schema, object example, IList<string> contentTypes)
         {
             Content.Clear();
 
             if (schema != null || example != null)
             {
-                var mimeType = schema?.IsBinary == true ? "application/octet-stream" : "application/json";
-                Content[mimeType] = new OpenApiMediaType
+                contentTypes = contentTypes
+                    .DefaultIfEmpty("application/json")
+                    .ToList();
+
+                if (schema?.IsBinary == true)
                 {
-                    Schema = schema,
-                    Example = example
-                };
+                    contentTypes.Clear();
+                    contentTypes.Add("application/octet-stream");
+                }
+
+                foreach (var contentType in contentTypes)
+                {
+                    Content[contentType] = new OpenApiMediaType { Schema = schema, Example = example };
+                }
             }
         }
 

--- a/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
@@ -133,9 +133,14 @@ namespace NSwag.SwaggerGeneration.Processors
 
                     response.IsNullableRaw = isNullable;
                     response.ExpectedSchemas = await GenerateExpectedSchemasAsync(statusCodeGroup, context);
-                    response.Schema = await context.SchemaGenerator
+
+                    var schema = await context.SchemaGenerator
                         .GenerateWithReferenceAndNullabilityAsync<JsonSchema4>(returnType, null, isNullable, context.SchemaResolver)
                         .ConfigureAwait(false);
+
+                    var contentTypes = context.OperationDescription.Operation.ActualProduces.ToList();
+
+                    response.UpdateContent(schema, null, contentTypes);
                 }
 
                 context.OperationDescription.Operation.Responses[httpStatusCode] = response;
@@ -213,12 +218,16 @@ namespace NSwag.SwaggerGeneration.Processors
                 var responseSchema = await context.SchemaGenerator.GenerateWithReferenceAndNullabilityAsync<JsonSchema4>(
                     returnType, returnParameterAttributes, typeDescription.IsNullable, context.SchemaResolver).ConfigureAwait(false);
 
-                operation.Responses["200"] = new SwaggerResponse
+                var response = new SwaggerResponse
                 {
                     Description = successXmlDescription,
                     IsNullableRaw = typeDescription.IsNullable,
-                    Schema = responseSchema
                 };
+
+                var contentTypes = context.OperationDescription.Operation.ActualProduces.ToList();
+                response.UpdateContent(responseSchema, null, contentTypes);
+
+                operation.Responses["200"] = response;
             }
         }
 


### PR DESCRIPTION
Previously, this was hardcoded to application/json or application/octet-stream. 
This resulted in missing mime types in OpenApi documents. 

E.g. it was impossible to have xml responses in OpenApi 3 documents.