### PR TITLE
Add AspNetCoreOperationSecurityScopeProcessor

### DIFF
--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/AspNetCoreOperationSecurityScopeProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/AspNetCoreOperationSecurityScopeProcessor.cs
@@ -1,0 +1,86 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AspNetCoreOperationSecurityScopeProcessor.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using NSwag.SwaggerGeneration.Processors;
+using NSwag.SwaggerGeneration.Processors.Contexts;
+
+namespace NSwag.SwaggerGeneration.Processors.Security
+{
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc.Controllers;
+
+    using NSwag.SwaggerGeneration.AspNetCore;
+
+    /// <summary>Generates the OAuth2 security scopes for an operation by reflecting the AuthorizeAttribute attributes.</summary>
+    public class AspNetCoreOperationSecurityScopeProcessor : IOperationProcessor
+    {
+        private readonly string _name;
+
+        /// <summary>Initializes a new instance of the <see cref="OperationSecurityScopeProcessor"/> class with 'Bearer' name.</summary>
+        public AspNetCoreOperationSecurityScopeProcessor() : this("Bearer")
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="OperationSecurityScopeProcessor"/> class.</summary>
+        /// <param name="name">The security definition name.</param>
+        public AspNetCoreOperationSecurityScopeProcessor(string name)
+        {
+            _name = name;
+        }
+
+        /// <summary>Processes the specified method information.</summary>
+        /// <param name="context"></param>
+        /// <returns>true if the operation should be added to the Swagger specification.</returns>
+        public Task<bool> ProcessAsync(OperationProcessorContext context)
+        {
+            var aspNetCoreContext = (AspNetCoreOperationProcessorContext)context;
+
+            var endpointMetadata = aspNetCoreContext.ApiDescription.ActionDescriptor.EndpointMetadata;
+
+            var allowAnonymous = endpointMetadata.OfType<AllowAnonymousAttribute>().Any();
+            if (allowAnonymous)
+            {
+                return Task.FromResult(true);
+            }
+
+            var authorizeAttributes = endpointMetadata.OfType<AuthorizeAttribute>().ToList();
+            if (!authorizeAttributes.Any())
+            {
+                return Task.FromResult(true);
+            }
+
+            if (context.OperationDescription.Operation.Security == null)
+            {
+                context.OperationDescription.Operation.Security = new List<SwaggerSecurityRequirement>();
+            }
+
+            var scopes = this.GetScopes(authorizeAttributes);
+            context.OperationDescription.Operation.Security.Add(new SwaggerSecurityRequirement
+            {
+                { _name, scopes }
+            });
+
+            return Task.FromResult(true);
+        }
+
+        /// <summary>Gets the security scopes for an operation.</summary>
+        /// <param name="authorizeAttributes">The authorize attributes.</param>
+        /// <returns>The scopes.</returns>
+        protected virtual IEnumerable<string> GetScopes(IEnumerable<AuthorizeAttribute> authorizeAttributes)
+        {
+            return authorizeAttributes
+                .Where(a => a.Roles != null)
+                .SelectMany(a => a.Roles.Split(','))
+                .Distinct();
+        }
+    }
+}


### PR DESCRIPTION
This doesn't compile by default!
It requires aspnetcore2.2

I still thought it might be worth sharing this as it solves the following problems:

- fixes bug with existing OperationSecurityScopeProcessor which marks all methods as requiring authorization
- Uses EndpointMetadata from ActionDescriptor instead of custom code for detecting attributes. This makes sure that we're getting the exact same results as the aspnetcore runtime
- Checks for presence of the AllowAnonymous attribute
- The current code in OperationSecurityScopeProcessor is incorrectly concatenating AuthorizeAttributes of the method with AuthorizeAttributes of the declaring type and then doing 'SelectMany'. This is incorrect. Attributes of the declaring type should only be used when there's no such attribute on the method. That problem doesn't exist with the code in this PR
