### PR TITLE
Fix 'UseSwagger()' generating swagger failed when using 'swaggerToCSh…

### DIFF
--- a/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
@@ -77,7 +77,7 @@ namespace NSwag.SwaggerGeneration.Processors
             var returnParameter = operationProcessorContext.MethodInfo.ReturnParameter;
             var operationXmlDocs = await operationProcessorContext.MethodInfo.GetXmlDocumentationAsync();
             var operationXmlDocsNodes = operationXmlDocs?.Nodes()?.OfType<XElement>();
-            var returnParameterXmlDocs = await returnParameter.GetDescriptionAsync(returnParameter.GetCustomAttributes())
+            var returnParameterXmlDocs = await returnParameter.GetDescriptionAsync(returnParameter.GetCustomAttributes(false).Cast<Attribute>())
                 .ConfigureAwait(false) ?? string.Empty;
 
             if (!string.IsNullOrEmpty(returnParameterXmlDocs) || operationXmlDocsNodes?.Any() == true)


### PR DESCRIPTION
…arpController' with controller style: Abstract

### Use Case:
- Framework: net462
- using swaggerToCSharpController generator to generate abstract class ***ControllerBase
- using swagger middleware `UseSwagger().UseSwaggerUi3()`
then NSwag throws an Unhandled Exception when generating http://localhost:****/swagger/v1/swagger.json 

Here is a bug from Microsoft:
https://github.com/dotnet/coreclr/issues/6600
https://stackoverflow.com/questions/38700721/reflection-with-generic-syntax-fails-on-a-return-parameter-of-an-overridden-meth
which throws an Unhandled Exception: System.IndexOutOfRangeException

This is a workaround for this bug.