### PR TITLE
Roll forward on console tools

### DIFF
--- a/src/NSwag.ConsoleCore/runtimeconfig.template.json
+++ b/src/NSwag.ConsoleCore/runtimeconfig.template.json
@@ -1,3 +1,4 @@
 {
-  "applyPatches": true
+  "applyPatches": true,
+  "rollForwardOnNoCandidateFx": 2
 }


### PR DESCRIPTION
This allows the nswag tool to roll forward on to higher major versions, making it usable out of the box for 3.0 preview builds.