### PR TITLE
TS injection and baseUrl fixes

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -22,7 +22,7 @@
 {%     endif -%}
         this.http = http ? http : <any>window;
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl = baseUrl  && baseUrl !== "" ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = this.getBaseUrl("{{ BaseUrl }}", baseUrl);
 {%     else -%}
         this.baseUrl = baseUrl ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -8,7 +8,7 @@
 {% endif -%}
 
 {% if UseAureliaHttpInjection -%}
-@inject(String, HttpClient)
+@inject({% if HasConfigurationClass %}{{ ConfigurationClass }}, {% endif %}String, HttpClient)
 {% endif -%}
 {% if ExportTypes %}export {% endif %}class {{ Class }} {% if HasBaseClass %}extends {{ BaseClass }} {% endif %}{% if GenerateClientInterfaces %}implements I{{ Class }} {% endif %}{
     private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
@@ -22,7 +22,7 @@
 {%     endif -%}
         this.http = http ? http : <any>window;
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl = baseUrl ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl  && baseUrl != "" ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
         this.baseUrl = baseUrl ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
@@ -49,10 +49,10 @@
             method: "{{ operation.HttpMethodUpper | upcase }}",
             headers: {
 {%     for parameter in operation.HeaderParameters -%}
-                "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "", 
+                "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "",
 {%     endfor -%}
 {%     if operation.HasContent or operation.ConsumesFormUrlEncoded -%}
-                "Content-Type": "{{ operation.Consumes }}", 
+                "Content-Type": "{{ operation.Consumes }}",
 {%     endif -%}
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 "Accept": "{{ operation.Produces }}"

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -22,7 +22,7 @@
 {%     endif -%}
         this.http = http ? http : <any>window;
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl = baseUrl  && baseUrl != "" ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl  && baseUrl !== "" ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
         this.baseUrl = baseUrl ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}


### PR DESCRIPTION
* Allows ConfigurationClass to be injected.

    If a configuration class is specified, it has to be added to the `inject` list. Otherwise, Aurelia's DI will pass an empty string for the configuration class instance. For that matter, I'm really not sure how/why you'd want to inject a string with DI. 
* Handles empty baseUrl

   The string that is injected into the client is always empty... so the check I added here allows the base class to configure the base URL. 