### PR TITLE
Change default of DefaultResponseReferenceTypeNullHandling to NotNull

### DIFF
--- a/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_project.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_project.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_project_swagger.json
+++ b/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_project_swagger.json
@@ -19,7 +19,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -82,7 +82,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "string"

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly_swagger.json
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly_swagger.json
@@ -19,7 +19,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -82,7 +82,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "string"

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_project.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_project.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_project_swagger.json
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_project_swagger.json
@@ -19,7 +19,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -82,7 +82,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "string"

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_reflection.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_reflection.nswag
@@ -11,7 +11,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Responses/NullableResponseController.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Responses/NullableResponseController.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NSwag.Generation.AspNetCore.Tests.Web.Controllers.Responses
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class NullableResponseController : Controller
+    {
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <response code="200" nullable="true">Order created.</response>
+        /// <response code="404">Order not found.</response>
+        [HttpPost("OperationWithNullableResponse")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(SerializableError), StatusCodes.Status400BadRequest)]
+        public ActionResult<string> OperationWithNullableResponse()
+        {
+            return Ok();
+        }
+
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <response code="200" nullable="false">Order created.</response>
+        /// <response code="404">Order not found.</response>
+        [HttpPost("OperationWithNonNullableResponse")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(SerializableError), StatusCodes.Status400BadRequest)]
+        public ActionResult<string> OperationWithNonNullableResponse()
+        {
+            return Ok();
+        }
+
+        [HttpPost("OperationWithNoXmlDocs")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(SerializableError), StatusCodes.Status400BadRequest)]
+        public ActionResult<string> OperationWithNoXmlDocs()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/NSwag.Generation.AspNetCore.Tests/Responses/NullableResponseTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Responses/NullableResponseTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using NSwag.Generation.AspNetCore.Tests.Web.Controllers;
+using NSwag.Generation.AspNetCore.Tests.Web.Controllers.Responses;
 using Xunit;
 
 namespace NSwag.Generation.AspNetCore.Tests.Responses
@@ -43,6 +44,82 @@ namespace NSwag.Generation.AspNetCore.Tests.Responses
 
             // Assert
             var operation = document.Operations.First().Operation;
+
+            Assert.True(operation.ActualResponses.First().Value.Schema.IsNullable(SchemaType.OpenApi3));
+        }
+
+        [Fact]
+        public async Task When_nullable_xml_docs_is_set_to_true_then_response_is_nullable()
+        {
+            // Arrange
+            var settings = new AspNetCoreOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3,
+                DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.NotNull
+            };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(NullableResponseController));
+
+            // Assert
+            var operation = document.Operations.First(o => o.Path.Contains(nameof(NullableResponseController.OperationWithNullableResponse))).Operation;
+
+            Assert.True(operation.ActualResponses.First().Value.Schema.IsNullable(SchemaType.OpenApi3));
+        }
+
+        [Fact]
+        public async Task When_nullable_xml_docs_is_set_to_false_then_response_is_not_nullable()
+        {
+            // Arrange
+            var settings = new AspNetCoreOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3,
+                DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.Null
+            };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(NullableResponseController));
+
+            // Assert
+            var operation = document.Operations.First(o => o.Path.Contains(nameof(NullableResponseController.OperationWithNonNullableResponse))).Operation;
+
+            Assert.False(operation.ActualResponses.First().Value.Schema.IsNullable(SchemaType.OpenApi3));
+        }
+
+        [Fact]
+        public async Task When_nullable_xml_docs_is_not_set_then_default_setting_NotNull_is_used()
+        {
+            // Arrange
+            var settings = new AspNetCoreOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3,
+                DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.NotNull
+            };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(NullableResponseController));
+
+            // Assert
+            var operation = document.Operations.First(o => o.Path.Contains(nameof(NullableResponseController.OperationWithNoXmlDocs))).Operation;
+
+            Assert.False(operation.ActualResponses.First().Value.Schema.IsNullable(SchemaType.OpenApi3));
+        }
+
+        [Fact]
+        public async Task When_nullable_xml_docs_is_not_set_then_default_setting_Null_is_used()
+        {
+            // Arrange
+            var settings = new AspNetCoreOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3,
+                DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.Null
+            };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(NullableResponseController));
+
+            // Assert
+            var operation = document.Operations.First(o => o.Path.Contains(nameof(NullableResponseController.OperationWithNoXmlDocs))).Operation;
 
             Assert.True(operation.ActualResponses.First().Value.Schema.IsNullable(SchemaType.OpenApi3));
         }

--- a/src/NSwag.Generation.WebApi.Tests/Nullability/ResponseNullabilityTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/Nullability/ResponseNullabilityTests.cs
@@ -5,6 +5,7 @@ using System.Web.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema;
 using NJsonSchema.Annotations;
+using NJsonSchema.Generation;
 using NSwag.Annotations;
 
 namespace NSwag.Generation.WebApi.Tests.Nullability
@@ -41,7 +42,10 @@ namespace NSwag.Generation.WebApi.Tests.Nullability
         public async Task When_response_is_not_nullable_then_nullable_is_false_in_spec()
         {
             /// Arrange
-            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.Null
+            });
 
             /// Act
             var document = await generator.GenerateForControllerAsync<NotNullResponseTestController>();

--- a/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
@@ -25,7 +25,7 @@ namespace NSwag.Generation
         public OpenApiDocumentGeneratorSettings()
         {
             SchemaGenerator = new OpenApiSchemaGenerator(this);
-            DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.Null;
+            DefaultResponseReferenceTypeNullHandling = ReferenceTypeNullHandling.NotNull;
             SchemaType = SchemaType.Swagger2;
         }
 

--- a/src/NSwag.Integration.ClientPCL/swagger.json
+++ b/src/NSwag.Integration.ClientPCL/swagger.json
@@ -243,7 +243,7 @@
             "description": ""
           },
           "450": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "A custom error occured.",
             "schema": {
               "$ref": "#/definitions/Exception"
@@ -445,7 +445,7 @@
         ],
         "responses": {
           "500": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/PersonNotFoundException"
@@ -528,14 +528,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Person"
             }
           },
           "500": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/PersonNotFoundException"
@@ -564,14 +564,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "The person's name.",
             "schema": {
               "type": "string"
             }
           },
           "500": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/PersonNotFoundException"

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngular.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngular.ts
@@ -493,7 +493,7 @@ export class GeoClient extends MyBaseClass {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : jsonParse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450, _mappings) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450, _mappings) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
             }));
         } else if (status !== 200 && status !== 204) {
@@ -889,7 +889,7 @@ export class PersonsClient extends MyBaseClass {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : jsonParse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             }));
         } else if (status === 200) {
@@ -1011,7 +1011,7 @@ export class PersonsClient extends MyBaseClass {
         return _observableOf<Person | null>(<any>null);
     }
 
-    throw(id: string): Observable<Person | null> {
+    throw(id: string): Observable<Person> {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -1036,14 +1036,14 @@ export class PersonsClient extends MyBaseClass {
                 try {
                     return this.transformResult(url_, response_, (r) => this.processThrow(<any>r));
                 } catch (e) {
-                    return <Observable<Person | null>><any>_observableThrow(e);
+                    return <Observable<Person>><any>_observableThrow(e);
                 }
             } else
-                return <Observable<Person | null>><any>_observableThrow(response_);
+                return <Observable<Person>><any>_observableThrow(response_);
         }));
     }
 
-    protected processThrow(response: HttpResponseBase): Observable<Person | null> {
+    protected processThrow(response: HttpResponseBase): Observable<Person> {
         const status = response.status;
         const responseBlob = 
             response instanceof HttpResponse ? response.body : 
@@ -1055,14 +1055,14 @@ export class PersonsClient extends MyBaseClass {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : jsonParse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200, _mappings) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200, _mappings) : new Person();
             return _observableOf(result200);
             }));
         } else if (status === 500) {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : jsonParse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             }));
         } else if (status !== 200 && status !== 204) {
@@ -1070,7 +1070,7 @@ export class PersonsClient extends MyBaseClass {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             }));
         }
-        return _observableOf<Person | null>(<any>null);
+        return _observableOf<Person>(<any>null);
     }
 
     /**
@@ -1078,7 +1078,7 @@ export class PersonsClient extends MyBaseClass {
      * @param id The person ID.
      * @return The person's name.
      */
-    getName(id: string): Observable<string | null> {
+    getName(id: string): Observable<string> {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -1102,14 +1102,14 @@ export class PersonsClient extends MyBaseClass {
                 try {
                     return this.transformResult(url_, response_, (r) => this.processGetName(<any>r));
                 } catch (e) {
-                    return <Observable<string | null>><any>_observableThrow(e);
+                    return <Observable<string>><any>_observableThrow(e);
                 }
             } else
-                return <Observable<string | null>><any>_observableThrow(response_);
+                return <Observable<string>><any>_observableThrow(response_);
         }));
     }
 
-    protected processGetName(response: HttpResponseBase): Observable<string | null> {
+    protected processGetName(response: HttpResponseBase): Observable<string> {
         const status = response.status;
         const responseBlob = 
             response instanceof HttpResponse ? response.body : 
@@ -1128,7 +1128,7 @@ export class PersonsClient extends MyBaseClass {
             return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : jsonParse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500, _mappings) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             }));
         } else if (status !== 200 && status !== 204) {
@@ -1136,7 +1136,7 @@ export class PersonsClient extends MyBaseClass {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             }));
         }
-        return _observableOf<string | null>(<any>null);
+        return _observableOf<string>(<any>null);
     }
 
     addXml(person: string | null): Observable<string | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngularJS.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngularJS.ts
@@ -379,7 +379,7 @@ export class GeoClient {
             const _responseText = response.data;
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException(this.q, "A server error occurred.", status, _responseText, _headers, result450);
         } else if (status !== 200 && status !== 204) {
             const _responseText = response.data;
@@ -697,7 +697,7 @@ export class PersonsClient {
             const _responseText = response.data;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException(this.q, "A server error occurred.", status, _responseText, _headers, result500);
         } else if (status === 200) {
             const _responseText = response.data;
@@ -793,7 +793,7 @@ export class PersonsClient {
         return this.q.resolve<Person | null>(<any>null);
     }
 
-    throw(id: string): ng.IPromise<Person | null> {
+    throw(id: string): ng.IPromise<Person> {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -819,7 +819,7 @@ export class PersonsClient {
         });
     }
 
-    protected processThrow(response: any): ng.IPromise<Person | null> {
+    protected processThrow(response: any): ng.IPromise<Person> {
         const status = response.status; 
 
         let _headers: any = {};
@@ -827,19 +827,19 @@ export class PersonsClient {
             const _responseText = response.data;
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return this.q.resolve(result200);
         } else if (status === 500) {
             const _responseText = response.data;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException(this.q, "A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = response.data;
             return throwException(this.q, "An unexpected server error occurred.", status, _responseText, _headers);
         }
-        return this.q.resolve<Person | null>(<any>null);
+        return this.q.resolve<Person>(<any>null);
     }
 
     /**
@@ -847,7 +847,7 @@ export class PersonsClient {
      * @param id The person ID.
      * @return The person's name.
      */
-    getName(id: string): ng.IPromise<string | null> {
+    getName(id: string): ng.IPromise<string> {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -872,7 +872,7 @@ export class PersonsClient {
         });
     }
 
-    protected processGetName(response: any): ng.IPromise<string | null> {
+    protected processGetName(response: any): ng.IPromise<string> {
         const status = response.status; 
 
         let _headers: any = {};
@@ -886,13 +886,13 @@ export class PersonsClient {
             const _responseText = response.data;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException(this.q, "A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = response.data;
             return throwException(this.q, "An unexpected server error occurred.", status, _responseText, _headers);
         }
-        return this.q.resolve<string | null>(<any>null);
+        return this.q.resolve<string>(<any>null);
     }
 
     addXml(person: string | null): ng.IPromise<string | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAurelia.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAurelia.ts
@@ -333,7 +333,7 @@ export class GeoClient {
             return response.text().then((_responseText) => {
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
             });
         } else if (status !== 200 && status !== 204) {
@@ -612,7 +612,7 @@ export class PersonsClient {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status === 200) {
@@ -701,7 +701,7 @@ export class PersonsClient {
         return Promise.resolve<Person | null>(<any>null);
     }
 
-    throw(id: string): Promise<Person | null> {
+    throw(id: string): Promise<Person> {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -721,21 +721,21 @@ export class PersonsClient {
         });
     }
 
-    protected processThrow(response: Response): Promise<Person | null> {
+    protected processThrow(response: Response): Promise<Person> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return result200;
             });
         } else if (status === 500) {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status !== 200 && status !== 204) {
@@ -743,7 +743,7 @@ export class PersonsClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<Person | null>(<any>null);
+        return Promise.resolve<Person>(<any>null);
     }
 
     /**
@@ -751,7 +751,7 @@ export class PersonsClient {
      * @param id The person ID.
      * @return The person's name.
      */
-    getName(id: string): Promise<string | null> {
+    getName(id: string): Promise<string> {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -770,7 +770,7 @@ export class PersonsClient {
         });
     }
 
-    protected processGetName(response: Response): Promise<string | null> {
+    protected processGetName(response: Response): Promise<string> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
@@ -784,7 +784,7 @@ export class PersonsClient {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status !== 200 && status !== 204) {
@@ -792,7 +792,7 @@ export class PersonsClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<string | null>(<any>null);
+        return Promise.resolve<string>(<any>null);
     }
 
     addXml(person: string | null): Promise<string | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsFetch.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsFetch.ts
@@ -329,7 +329,7 @@ export class GeoClient {
             return response.text().then((_responseText) => {
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
             });
         } else if (status !== 200 && status !== 204) {
@@ -607,7 +607,7 @@ export class PersonsClient {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status === 200) {
@@ -696,7 +696,7 @@ export class PersonsClient {
         return Promise.resolve<Person | null>(<any>null);
     }
 
-    throw(id: string): Promise<Person | null> {
+    throw(id: string): Promise<Person> {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -716,21 +716,21 @@ export class PersonsClient {
         });
     }
 
-    protected processThrow(response: Response): Promise<Person | null> {
+    protected processThrow(response: Response): Promise<Person> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return result200;
             });
         } else if (status === 500) {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status !== 200 && status !== 204) {
@@ -738,7 +738,7 @@ export class PersonsClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<Person | null>(<any>null);
+        return Promise.resolve<Person>(<any>null);
     }
 
     /**
@@ -746,7 +746,7 @@ export class PersonsClient {
      * @param id The person ID.
      * @return The person's name.
      */
-    getName(id: string): Promise<string | null> {
+    getName(id: string): Promise<string> {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -765,7 +765,7 @@ export class PersonsClient {
         });
     }
 
-    protected processGetName(response: Response): Promise<string | null> {
+    protected processGetName(response: Response): Promise<string> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
@@ -779,7 +779,7 @@ export class PersonsClient {
             return response.text().then((_responseText) => {
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
             });
         } else if (status !== 200 && status !== 204) {
@@ -787,7 +787,7 @@ export class PersonsClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<string | null>(<any>null);
+        return Promise.resolve<string>(<any>null);
     }
 
     addXml(person: string | null): Promise<string | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryCallbacks.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryCallbacks.ts
@@ -486,7 +486,7 @@ export class GeoClient {
             const _responseText = xhr.responseText;
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -884,7 +884,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status === 200) {
             const _responseText = xhr.responseText;
@@ -1004,7 +1004,7 @@ export class PersonsClient {
         return null;
     }
 
-    throw(id: string, onSuccess?: (result: Person | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void): JQueryXHR {
+    throw(id: string, onSuccess?: (result: Person) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void): JQueryXHR {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -1042,7 +1042,7 @@ export class PersonsClient {
         }
     }
 
-    protected processThrow(xhr: any): Person | null | null {
+    protected processThrow(xhr: any): Person | null {
         const status = xhr.status;
 
         let _headers: any = {};
@@ -1050,13 +1050,13 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return result200;
         } else if (status === 500) {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -1070,7 +1070,7 @@ export class PersonsClient {
      * @param id The person ID.
      * @return The person's name.
      */
-    getName(id: string, onSuccess?: (result: string | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void): JQueryXHR {
+    getName(id: string, onSuccess?: (result: string) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void): JQueryXHR {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -1107,7 +1107,7 @@ export class PersonsClient {
         }
     }
 
-    protected processGetName(xhr: any): string | null | null {
+    protected processGetName(xhr: any): string | null {
         const status = xhr.status;
 
         let _headers: any = {};
@@ -1121,7 +1121,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromises.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromises.ts
@@ -504,7 +504,7 @@ export class GeoClient {
             const _responseText = xhr.responseText;
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -916,7 +916,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status === 200) {
             const _responseText = xhr.responseText;
@@ -1041,12 +1041,12 @@ export class PersonsClient {
     }
 
     throw(id: string) {
-        return new Promise<Person | null>((resolve, reject) => {
+        return new Promise<Person>((resolve, reject) => {
             this.throwWithCallbacks(id, (result) => resolve(result), (exception, _reason) => reject(exception));
         });
     }
     
-    private throwWithCallbacks(id: string, onSuccess?: (result: Person | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
+    private throwWithCallbacks(id: string, onSuccess?: (result: Person) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -1080,7 +1080,7 @@ export class PersonsClient {
         }
     }
 
-    protected processThrow(xhr: any): Person | null | null {
+    protected processThrow(xhr: any): Person | null {
         const status = xhr.status; 
 
         let _headers: any = {};
@@ -1088,13 +1088,13 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return result200;
         } else if (status === 500) {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -1109,12 +1109,12 @@ export class PersonsClient {
      * @return The person's name.
      */
     getName(id: string) {
-        return new Promise<string | null>((resolve, reject) => {
+        return new Promise<string>((resolve, reject) => {
             this.getNameWithCallbacks(id, (result) => resolve(result), (exception, _reason) => reject(exception));
         });
     }
     
-    private getNameWithCallbacks(id: string, onSuccess?: (result: string | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
+    private getNameWithCallbacks(id: string, onSuccess?: (result: string) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -1147,7 +1147,7 @@ export class PersonsClient {
         }
     }
 
-    protected processGetName(xhr: any): string | null | null {
+    protected processGetName(xhr: any): string | null {
         const status = xhr.status; 
 
         let _headers: any = {};
@@ -1161,7 +1161,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromisesKO.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromisesKO.ts
@@ -506,7 +506,7 @@ export class GeoClient {
             const _responseText = xhr.responseText;
             let result450: any = null;
             let resultData450 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result450 = resultData450 ? Exception.fromJS(resultData450) : <any>null;
+            result450 = resultData450 ? Exception.fromJS(resultData450) : new Exception();
             return throwException("A server error occurred.", status, _responseText, _headers, result450);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -918,7 +918,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status === 200) {
             const _responseText = xhr.responseText;
@@ -1043,12 +1043,12 @@ export class PersonsClient {
     }
 
     throw(id: string) {
-        return new Promise<Person | null>((resolve, reject) => {
+        return new Promise<Person>((resolve, reject) => {
             this.throwWithCallbacks(id, (result) => resolve(result), (exception, _reason) => reject(exception));
         });
     }
     
-    private throwWithCallbacks(id: string, onSuccess?: (result: Person | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
+    private throwWithCallbacks(id: string, onSuccess?: (result: Person) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
         let url_ = this.baseUrl + "/api/Persons/Throw?";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined and cannot be null.");
@@ -1082,7 +1082,7 @@ export class PersonsClient {
         }
     }
 
-    protected processThrow(xhr: any): Person | null | null {
+    protected processThrow(xhr: any): Person | null {
         const status = xhr.status; 
 
         let _headers: any = {};
@@ -1090,13 +1090,13 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = resultData200 ? Person.fromJS(resultData200) : <any>null;
+            result200 = resultData200 ? Person.fromJS(resultData200) : new Person();
             return result200;
         } else if (status === 500) {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;
@@ -1111,12 +1111,12 @@ export class PersonsClient {
      * @return The person's name.
      */
     getName(id: string) {
-        return new Promise<string | null>((resolve, reject) => {
+        return new Promise<string>((resolve, reject) => {
             this.getNameWithCallbacks(id, (result) => resolve(result), (exception, _reason) => reject(exception));
         });
     }
     
-    private getNameWithCallbacks(id: string, onSuccess?: (result: string | null) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
+    private getNameWithCallbacks(id: string, onSuccess?: (result: string) => void, onFail?: (exception: PersonNotFoundException | string, reason: string) => void) {
         let url_ = this.baseUrl + "/api/Persons/{id}/Name";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -1149,7 +1149,7 @@ export class PersonsClient {
         }
     }
 
-    protected processGetName(xhr: any): string | null | null {
+    protected processGetName(xhr: any): string | null {
         const status = xhr.status; 
 
         let _headers: any = {};
@@ -1163,7 +1163,7 @@ export class PersonsClient {
             const _responseText = xhr.responseText;
             let result500: any = null;
             let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : <any>null;
+            result500 = resultData500 ? PersonNotFoundException.fromJS(resultData500) : new PersonNotFoundException();
             return throwException("A server error occurred.", status, _responseText, _headers, result500);
         } else if (status !== 200 && status !== 204) {
             const _responseText = xhr.responseText;

--- a/src/NSwag.Integration.WebAPI/Swagger_Angular.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_Angular.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_AngularJS.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_AngularJS.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_Aurelia.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_Aurelia.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_ClientConsole.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_ClientConsole.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_ClientPCL.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_ClientPCL.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_Fetch.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_Fetch.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_JQueryCallbacks.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_JQueryCallbacks.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_JQueryPromises.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_JQueryPromises.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Integration.WebAPI/Swagger_JQueryPromises_KO.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_JQueryPromises_KO.nswag
@@ -14,7 +14,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore11/nswag.json
+++ b/src/NSwag.Sample.NETCore11/nswag.json
@@ -11,7 +11,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "CamelCase",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore11/swagger.json
+++ b/src/NSwag.Sample.NETCore11/swagger.json
@@ -34,7 +34,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -63,7 +63,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -92,7 +92,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -102,7 +102,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -147,7 +147,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -157,7 +157,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -183,7 +183,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -193,7 +193,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -220,14 +220,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -267,7 +267,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -295,7 +295,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -335,14 +335,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"

--- a/src/NSwag.Sample.NETCore20/nswag.json
+++ b/src/NSwag.Sample.NETCore20/nswag.json
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore20/swagger.json
+++ b/src/NSwag.Sample.NETCore20/swagger.json
@@ -31,7 +31,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -68,7 +68,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -105,7 +105,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -115,7 +115,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -168,7 +168,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -178,7 +178,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -211,7 +211,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -221,7 +221,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -256,14 +256,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -368,7 +368,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -404,7 +404,7 @@
         ],
         "responses": {
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -451,14 +451,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -564,7 +564,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "string"

--- a/src/NSwag.Sample.NETCore21/nswag_assembly.nswag
+++ b/src/NSwag.Sample.NETCore21/nswag_assembly.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore21/nswag_project.nswag
+++ b/src/NSwag.Sample.NETCore21/nswag_project.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore21/swagger_assembly_cli.json
+++ b/src/NSwag.Sample.NETCore21/swagger_assembly_cli.json
@@ -28,7 +28,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "Order invalid",
             "schema": {
               "type": "object",
@@ -68,7 +68,7 @@
             "description": "My success response description."
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -103,7 +103,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -136,7 +136,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -168,7 +168,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -178,7 +178,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -208,14 +208,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -327,7 +327,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -361,7 +361,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -404,14 +404,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"

--- a/src/NSwag.Sample.NETCore21/swagger_project_cli.json
+++ b/src/NSwag.Sample.NETCore21/swagger_project_cli.json
@@ -28,7 +28,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "Order invalid",
             "schema": {
               "type": "object",
@@ -68,7 +68,7 @@
             "description": "My success response description."
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -103,7 +103,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -136,7 +136,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -168,7 +168,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -178,7 +178,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -208,14 +208,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -327,7 +327,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -361,7 +361,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -404,14 +404,14 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"

--- a/src/NSwag.Sample.NETCore22/nswag_assembly.nswag
+++ b/src/NSwag.Sample.NETCore22/nswag_assembly.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore22/nswag_oas_project.nswag
+++ b/src/NSwag.Sample.NETCore22/nswag_oas_project.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore22/nswag_project.nswag
+++ b/src/NSwag.Sample.NETCore22/nswag_project.nswag
@@ -15,7 +15,7 @@
       "apiGroupNames": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,

--- a/src/NSwag.Sample.NETCore22/openapi_project_cli.json
+++ b/src/NSwag.Sample.NETCore22/openapi_project_cli.json
@@ -33,12 +33,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -71,12 +66,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -112,7 +102,6 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "nullable": true,
                   "items": {
                     "$ref": "#/components/schemas/Pet"
                   }
@@ -149,7 +138,6 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "nullable": true,
                   "items": {
                     "$ref": "#/components/schemas/Pet"
                   }
@@ -162,12 +150,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -199,12 +182,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/Pet"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/Pet"
                 }
               }
             }
@@ -214,12 +192,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -229,12 +202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -361,12 +329,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -376,12 +339,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -414,12 +372,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -429,12 +382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -477,12 +425,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ApiResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ApiResponse"
                 }
               }
             }
@@ -492,12 +435,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SerializableError"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SerializableError"
                 }
               }
             }
@@ -507,12 +445,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "nullable": true,
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/ProblemDetails"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }

--- a/src/NSwag.Sample.NETCore22/swagger_assembly_cli.json
+++ b/src/NSwag.Sample.NETCore22/swagger_assembly_cli.json
@@ -36,7 +36,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -70,7 +70,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -107,7 +107,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -137,7 +137,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -147,7 +147,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -174,21 +174,21 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -296,14 +296,14 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -331,14 +331,14 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -375,21 +375,21 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"

--- a/src/NSwag.Sample.NETCore22/swagger_project_cli.json
+++ b/src/NSwag.Sample.NETCore22/swagger_project_cli.json
@@ -36,7 +36,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -70,7 +70,7 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -107,7 +107,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -137,7 +137,7 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "type": "array",
@@ -147,7 +147,7 @@
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
@@ -174,21 +174,21 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -296,14 +296,14 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -331,14 +331,14 @@
             "description": ""
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"
@@ -375,21 +375,21 @@
         ],
         "responses": {
           "200": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ApiResponse"
             }
           },
           "400": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
             }
           },
           "404": {
-            "x-nullable": true,
+            "x-nullable": false,
             "description": "",
             "schema": {
               "$ref": "#/definitions/ProblemDetails"

--- a/src/NSwag.Sample.NetGlobalAsax/nswag.json
+++ b/src/NSwag.Sample.NetGlobalAsax/nswag.json
@@ -13,7 +13,7 @@
       "includedVersions": null,
       "defaultPropertyNameHandling": "Default",
       "defaultReferenceTypeNullHandling": "Null",
-      "defaultResponseReferenceTypeNullHandling": "Null",
+      "defaultResponseReferenceTypeNullHandling": "NotNull",
       "defaultEnumHandling": "Integer",
       "flattenInheritanceHierarchy": false,
       "generateKnownTypes": true,


### PR DESCRIPTION
This PR:

- Changes the default of `DefaultResponseReferenceTypeNullHandling` from `Null` to `NotNull`.
- Adds support for the "nullable" xml docs attribute

Details: 

- Currently there is no way to specify nullability of the response with `ProducesResponseTypeAttribute`. This could be solved with a new "nullable" attribute in the XML docs (which always wins if specified):

```xml
/// <summary>
/// Gets an order.
/// </summary>
/// <response code="200" nullable="true">Order created.</response>
...
```

- Most of the time (I assume?) people want a not nullable response and use 404 in the not found case and do not return null
- I think Swagger UI 3 still cannot handle nullable responses (spec in the first example)
- In the Swagger 2 the difference is only in the `x-nullable` property and thus the impact is lower.

Sample operation: 

```csharp
[HttpGet("{petId}", Name = "FindPetById")]
[Produces("application/json")]
[ProducesResponseType(typeof(Pet), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(SerializableError), StatusCodes.Status400BadRequest)]
[ProducesResponseType(StatusCodes.Status404NotFound)]
public async Task<ActionResult<Pet>> FindById(int petId)
```

With `DefaultResponseReferenceTypeNullHandling = Null` (current default, OpenAPI 3)

```
    "/pet/{petId}": {
      "get": {
        "operationId": "Pet_FindById",
        "parameters": [
          {
          }
        ],
        "responses": {
          "200": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "nullable": true,
                  "oneOf": [
                    {
                      "$ref": "#/components/schemas/Pet"
                    }
                  ]
                }
              }
            }
          },
```

With `DefaultResponseReferenceTypeNullHandling = NotNull` (new default, OpenAPI 3)

```json
    "/pet/{petId}": {
      "get": {
        "operationId": "Pet_FindById",
        "parameters": [
          {
          }
        ],
        "responses": {
          "200": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Pet"
                }
              }
            }
          },
```

Open questions:

- **Should we change the default?**
    - Pro: Most devs probably already design their APIs so that they don't return null and thus expect the default to be NotNull
    - Con: NotNull does not really reflect what the actual API is allowed to return (i.e. it is a missmatch between the spec and the runtime)

/cc @pranavkm @dougbu What's your take on this?