### PR TITLE
More Flexible Type Name Generation

### DIFF
--- a/src/NSwag.Core/OpenApiDocument.Serialization.cs
+++ b/src/NSwag.Core/OpenApiDocument.Serialization.cs
@@ -199,6 +199,10 @@ namespace NSwag
         [JsonProperty(PropertyName = "definitions", Order = 13, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IDictionary<string, JsonSchema> Definitions => Components.Schemas;
 
+        /// <summary>Gets or sets a list of type mappings to be used for post processing.</summary>
+        [JsonIgnore]
+        public List<TypeDefinitionTracker> DefinitionsMap { get; set; } = new List<TypeDefinitionTracker>();
+
         /// <summary>Gets or sets the parameters which can be used for all operations (Swagger only).</summary>
         [JsonProperty(PropertyName = "parameters", Order = 14, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IDictionary<string, OpenApiParameter> Parameters => Components.Parameters;

--- a/src/NSwag.Core/OpenApiSchemaResolver.cs
+++ b/src/NSwag.Core/OpenApiSchemaResolver.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using NJsonSchema;
 using NJsonSchema.Generation;
 
@@ -37,11 +38,18 @@ namespace NSwag
         /// <summary>Appends the schema to the root object.</summary>
         /// <param name="schema">The schema to append.</param>
         /// <param name="typeNameHint">The type name hint.</param>
-        public override void AppendSchema(JsonSchema schema, string typeNameHint)
+        public override void AppendSchema(JsonSchema schema, string typeNameHint, Type type)
         {
             if (!Document.Definitions.Values.Contains(schema))
             {
                 var typeName = _typeNameGenerator.Generate(schema, typeNameHint, Document.Definitions.Keys);
+                var attemptedTypeName = _typeNameGenerator.Generate(schema, typeNameHint, new List<string>() { });
+                Document.DefinitionsMap.Add(new TypeDefinitionTracker()
+                {
+                    GeneratedTypeName = typeName,
+                    AttemptedTypeName = attemptedTypeName,
+                    Type = type
+                });
                 Document.Definitions[typeName] = schema;
             }
         }

--- a/src/NSwag.Core/TypeDefinitionTracker.cs
+++ b/src/NSwag.Core/TypeDefinitionTracker.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NSwag
+{
+    public class TypeDefinitionTracker
+    {
+        public string GeneratedTypeName { get; set; }
+        public string AttemptedTypeName { get; set; }
+        public Type Type { get; set; }
+    }
+}

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -11,6 +11,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Namotion.Reflection;
 using NJsonSchema;
@@ -100,7 +101,93 @@ namespace NSwag.Generation.WebApi
                     usedControllerTypes, schemaResolver, Settings.SchemaGenerator, Settings));
             }
 
+            AddNamespaceToDuplicateTypeNames(document);
+
             return document;
+        }
+
+        private void AddNamespaceToDuplicateTypeNames(OpenApiDocument document)
+        {
+            var duplicateDefinitionGroups = document.DefinitionsMap.GroupBy(m => m.AttemptedTypeName).Where(g => g.Count() > 1).ToList();
+
+            foreach (var duplicateDefinitionGroup in duplicateDefinitionGroups)
+            {
+                var typeNameWrappers = duplicateDefinitionGroup.Select(i => new TypeNameWrapper()
+                {
+                    fullName = i.Type.FullName,
+                    parts = i.Type.FullName.Split('.').Reverse().ToList(),
+                    differentDepth = 0
+                })
+                .ToList();
+
+
+                FindUncommonPart(typeNameWrappers, 1);
+
+                foreach (var definition in duplicateDefinitionGroup)
+                {
+                    StringBuilder typeNameSB = new StringBuilder();
+
+                    var correspondingTypeNameWrappers = typeNameWrappers.Where(p => p.fullName == definition.Type.FullName).Single();
+
+                    for (int i = correspondingTypeNameWrappers.differentDepth; i >= 0; i--)
+                    {
+                        if (correspondingTypeNameWrappers.depthsToIgnore.Contains(i))
+                        {
+                            continue;
+                        }
+
+                        typeNameSB.Append(correspondingTypeNameWrappers.parts[i]);
+                        if (i != 0)
+                        {
+                            typeNameSB.Append("_");
+                        }
+                    }
+
+                    var schema = document.Definitions[definition.GeneratedTypeName];
+                    document.Definitions.Remove(definition.GeneratedTypeName);
+                    document.Definitions.Add(typeNameSB.ToString(), schema);
+                }
+            }
+        }
+
+        private void FindUncommonPart(List<TypeNameWrapper> typeNameWrappers, int depth)
+        {
+            var sameDepthParts = typeNameWrappers.Select(w => w.parts[depth]).ToList();
+
+            //If all parts at that depth are the same, ignore them
+            if (sameDepthParts.Distinct().Count() == 1)
+            {
+                foreach (var typeNameWrapper in typeNameWrappers)
+                {
+                    typeNameWrapper.depthsToIgnore.Add(depth);
+                }
+
+            }
+
+            //If a part does not exist in other paths, this is the desired depth for that path
+            foreach (var typeNameWrapper in typeNameWrappers)
+            {
+                if (sameDepthParts.Where(part => part == typeNameWrapper.parts[depth]).Count() == 1)
+                {
+                    typeNameWrapper.differentDepth = depth;
+                }
+            }
+
+            //Only continue with paths that are not assigned a desired depth
+            var eligiblePaths = typeNameWrappers.Where(p => p.differentDepth == 0).ToList();
+
+            if (eligiblePaths.Any())
+            {
+                FindUncommonPart(eligiblePaths, depth + 1);
+            }
+        }
+
+        private class TypeNameWrapper
+        {
+            public string fullName;
+            public List<string> parts;
+            public int differentDepth;
+            public List<int> depthsToIgnore = new List<int>();
         }
 
         private async Task<OpenApiDocument> CreateDocumentAsync()
@@ -240,7 +327,7 @@ namespace NSwag.Generation.WebApi
             // 1. Run from settings
             foreach (var operationProcessor in Settings.OperationProcessors)
             {
-                if (operationProcessor.Process(context)== false)
+                if (operationProcessor.Process(context) == false)
                 {
                     return false;
                 }


### PR DESCRIPTION
When there are multiple data models with the same name, the default behavior is that a counter assigns each duplicate model an incrementing suffix.

I tried to assign more meaningful names to duplicate types by using their namespaces. Non-duplicate ones should remain to have simple names without namespaces. And duplicate ones should incorporate only the parts of the namespace just enough to differentiate them, not the complete namespace.

But as far as I have examined, there seems to be no pluggable way to do this without changing the source code. 

So, I have forked the project and created this PR.

In order for this to work, I also had to make changes to the NJsonSchema project so that AppendSchema method would receive the type information: https://github.com/RicoSuter/NJsonSchema/pull/1001

The only problem is that in its current state, this becomes the default behavior. I tried to factor out the namespace related code so that it would be a generic solution where anyone could inject this behavior at will. But due to various serializations and deserializations of the OpenApiDocument, it loses the DefinitionsMap variable which I used to contain the type related information along with the generated and duplicate type names. So the following code which I used to generate the document does not have access to this type information:

```
var command = new WebApiToOpenApiCommand();

command.AssemblyPaths = new string[] { @"....dll" };
command.OutputFilePath = "swagger.json";

var doc = (OpenApiDocument)command.RunAsync(null, new ConsoleHost()).Result;
var docJson = doc.ToJson();
```

It would be great if someone could pitch in to extract this logic away from `WebApiOpenApiDocumentGenerator.cs `to the consumer code above. If the above code has access to the DefinitionsMap, then it would be possible to abstract away this postprocessing into a pluggable structure.
