### PR TITLE
"PreservePropertyNameCasing" parameter

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
@@ -66,5 +66,25 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the dictionary type of operation parameters.</summary>
         public string ParameterDictionaryType { get; set; }
+
+        private bool _preservePropertyNameCasing = false;
+
+        /// <summary>Gets or sets a value indicating whether to preserve the casing for the first letter of properties. Default is false, resulting in UpperCamelCase.</summary>
+        public override bool PreservePropertyNameCasing
+        {
+            get { return _preservePropertyNameCasing; }
+            set
+            {
+                _preservePropertyNameCasing = value;
+                if (value)
+                {
+                    CodeGeneratorSettings.PropertyNameGenerator = new CasePreservingPropertyNameGenerator();
+                }
+                else
+                {
+                    CodeGeneratorSettings.PropertyNameGenerator = new CSharpPropertyNameGenerator();
+                }
+            }
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/CasePreservingPropertyNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CasePreservingPropertyNameGenerator.cs
@@ -1,0 +1,31 @@
+﻿using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>Generates the property name for a given CSharp <see cref="JsonSchemaProperty"/>, preserving the case of the first letter.</summary>
+    class CasePreservingPropertyNameGenerator : IPropertyNameGenerator
+    {
+        /// <summary>Generates the property name.</summary>
+        /// <param name="property">The property.</param>
+        /// <returns>The new name.</returns>
+        public virtual string Generate(JsonSchemaProperty property)
+        {
+            return property.Name
+                    .Replace("\"", string.Empty)
+                    .Replace("@", string.Empty)
+                    .Replace("$", string.Empty)
+                    .Replace("[", string.Empty)
+                    .Replace("]", string.Empty)
+                    .Replace(".", "-")
+                    .Replace("=", "-")
+                    .Replace("+", "plus")
+                    .Replace("*", "Star")
+                    .Replace(":", "_")
+                    .Replace("-", "_");
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/CasePreservingPropertyNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/CasePreservingPropertyNameGenerator.cs
@@ -1,0 +1,39 @@
+﻿using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NSwag.CodeGeneration.TypeScript
+{
+    /// <summary>Generates the property name for a given TypeScript <see cref="JsonSchemaProperty"/>, preserving the case of the first letter.</summary>
+    class CasePreservingPropertyNameGenerator : IPropertyNameGenerator
+    {
+        /// <summary>Gets or sets the reserved names.</summary>
+        public IEnumerable<string> ReservedPropertyNames { get; set; } = new List<string> { "constructor" };
+
+        /// <summary>Generates the property name.</summary>
+        /// <param name="property">The property.</param>
+        /// <returns>The new name.</returns>
+        public virtual string Generate(JsonSchemaProperty property)
+        {
+            var name = property.Name
+                    .Replace("\"", string.Empty)
+                    .Replace("@", string.Empty)
+                    .Replace(".", "-")
+                    .Replace("=", "-")
+                    .Replace("+", "plus")
+                    .Replace("*", "Star")
+                    .Replace(":", "_")
+                    .Replace("-", "_");
+
+            if (ReservedPropertyNames.Contains(name))
+            {
+                return name + "_";
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -105,6 +105,25 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
 
+        private bool _preservePropertyNameCasing = false;
+        /// <summary>Gets or sets a value indicating whether to preserve the casing for the first letter of properties. Default is false, resulting in camelCase.</summary>
+        public override bool PreservePropertyNameCasing
+        {
+            get { return _preservePropertyNameCasing; }
+            set
+            {
+                _preservePropertyNameCasing = value;
+                if (value)
+                {
+                    CodeGeneratorSettings.PropertyNameGenerator = new CasePreservingPropertyNameGenerator();
+                }
+                else
+                {
+                    CodeGeneratorSettings.PropertyNameGenerator = new TypeScriptPropertyNameGenerator();
+                }
+            }
+        }
+
         internal ITemplate CreateTemplate(object model)
         {
             if (Template == TypeScriptTemplate.Aurelia)

--- a/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
@@ -77,5 +77,8 @@ namespace NSwag.CodeGeneration
 
         /// <summary>Gets or sets the name of the response class (supports the '{controller}' placeholder).</summary>
         public string ResponseClass { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether to preserve the casing for the first letter of properties.</summary>
+        public abstract bool PreservePropertyNameCasing { get; set; }
     }
 }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -331,5 +331,12 @@ namespace NSwag.Commands.CodeGeneration
             get { return Settings.GenerateDtoTypes; }
             set { Settings.GenerateDtoTypes = value; }
         }
+
+        [Argument(Name = "PreservePropertyNameCasing", IsRequired = false, Description = "Specifies whether to preserve the casing for the first letter of properties. Default is to UpperCamelCase.")]
+        public bool PreservePropertyNameCasing
+        {
+            get { return Settings.PreservePropertyNameCasing; }
+            set { Settings.PreservePropertyNameCasing = value; }
+        }
     }
 }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -359,6 +359,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.TypeScriptGeneratorSettings.InlineNamedAny = value; }
         }
 
+        [Argument(Name = "PreservePropertyNameCasing", IsRequired = false, Description = "Specifies whether to preserve the casing for the first letter of properties. Default is to camelCase.")]
+        public bool PreservePropertyNameCasing
+        {
+            get { return Settings.PreservePropertyNameCasing; }
+            set { Settings.PreservePropertyNameCasing = value; }
+        }
+
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
             var code = await RunAsync();


### PR DESCRIPTION
"PreservePropertyNameCasing" parameter added for giving the option to not automatically UpperCamelCasing for C# and camelCasing for TypeScript models in code generation.