### PR TITLE
Added `IncludeOpenAPIAnalyzers` flag to the produced NuGet package

### DIFF
--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -23,7 +23,7 @@
     <EmbeddedResource Include="SwaggerUi3\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="build\NSwag.AspNetCore.props" />
+    <Content Include="build\netcoreapp3.0\NSwag.AspNetCore.props" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.3" />

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -23,6 +23,9 @@
     <EmbeddedResource Include="SwaggerUi3\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="build\NSwag.AspNetCore.props" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project>
+  <ItemGroup>
+    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+  </ItemGroup>
+</Project>

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project>
-  <ItemGroup>
-    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
-  </ItemGroup>
-</Project>

--- a/src/NSwag.AspNetCore/build/netcoreapp3.0/NSwag.AspNetCore.props
+++ b/src/NSwag.AspNetCore/build/netcoreapp3.0/NSwag.AspNetCore.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
 Hi Rico.

In ASP.NET Core we've added a feature to the WebSDK to enable OpenAPI analyzers when the `IncludeOpenAPIAnalyzers` flag is present. This change adds that flag to the NSwag.AspNetCore project, so that as soon as that NuGet package is referenced from an ASP.NET Core project, the API Analyzer is enabled.

/cc @pranavkm 

Addresses https://github.com/aspnet/AspNetCore/issues/8418