### PR TITLE
Ensure axios returns request headers, use responseType: blob for files

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -44,7 +44,7 @@
             data: content_,
 {%     endif -%}
 {%     if operation.IsFile -%}
-            responseType: "arraybuffer",
+            responseType: "blob",
 {%     endif -%}
             method: "{{ operation.HttpMethodUpper | upcase }}",
             url: url_,

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -24,7 +24,7 @@ return {{ Framework.RxJs.ObservableOfMethod }}({ fileName: fileName, data: {% if
 {%         elseif Framework.IsAngularJS -%}
 return this.q.resolve({ fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers });
 {%         elseif Framework.IsAxios -%}
-return Promise.resolve({ fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers });
+return Promise.resolve({ fileName: fileName, status: status, data: response.data as Blob, headers: _headers });
 {%         else -%}
 return response.blob().then(blob => { return { fileName: fileName, data: blob, status: status, headers: _headers }; });
 {%         endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.ReadHeaders.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.ReadHeaders.liquid
@@ -7,10 +7,14 @@ let _headers: any = response.headers ? response.headers.toJSON() : {};
 {% elseif Framework.IsFetchOrAurelia -%}
 let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
 {% elseif Framework.IsAxios -%}
-let _headers: any = {}; 
-if (response.headers && response.headers.forEach) { 
-    response.headers.forEach((v: any, k: any) => _headers[k] = v);
-};
+let _headers: any = {};
+if (response.headers && typeof response.headers === "object") {
+    for (let k in response.headers) {
+        if (response.headers.hasOwnProperty(k)) {
+            _headers[k] = response.headers[k];
+        }
+    }
+}
 {% else -%}
 let _headers: any = {};
 {% endif -%}


### PR DESCRIPTION
Axios request headers have been fixed. Currently, an empty request header object is returned because the object type is different to fetch.

Also, file requests have been fixed. The 'blob' requestType is used instead of 'arraybuffer' to ensure the content-type is preserved (previously a blob was constructed from an arraybuffer which can lose the content-type and display a file as garbage text)

These modifications should make the the client responses more consistent with the fetch template