### PR TITLE
Fix default implementation of TransformToExternalPath

### DIFF
--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -35,7 +35,7 @@ namespace NSwag.AspNetCore
         public SwaggerUiSettingsBase()
         {
             TransformToExternalPath = (internalUiRoute, request) =>
-                request.GetBasePath().TrimEnd('/') + '/' + internalUiRoute.TrimStart('/');
+                request.GetBasePath()?.TrimEnd('/') + '/' + internalUiRoute?.TrimStart('/');
         }
 
         /// <summary>Gets or sets the internal swagger UI route (must start with '/').</summary>

--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -35,7 +35,7 @@ namespace NSwag.AspNetCore
         public SwaggerUiSettingsBase()
         {
             TransformToExternalPath = (internalUiRoute, request) =>
-                request.GetBasePath()?.TrimEnd('/') + '/' + internalUiRoute?.TrimStart('/');
+                '/' + (request.GetBasePath()?.TrimEnd('/') + '/' + internalUiRoute?.TrimStart('/')).Trim('/');
         }
 
         /// <summary>Gets or sets the internal swagger UI route (must start with '/').</summary>

--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -35,9 +35,7 @@ namespace NSwag.AspNetCore
         public SwaggerUiSettingsBase()
         {
             TransformToExternalPath = (internalUiRoute, request) =>
-            {
-                return request.GetBasePath() + internalUiRoute;
-            };
+                request.GetBasePath().TrimEnd('/') + '/' + internalUiRoute.TrimStart('/');
         }
 
         /// <summary>Gets or sets the internal swagger UI route (must start with '/').</summary>


### PR DESCRIPTION
Addresses #2294 
* Ensures only a single separator is added between the base path and the internal ui path.