### PR TITLE
Fixed processing of Summary and Description fields of OpenApiOperation

### DIFF
--- a/src/NSwag.Annotations/OpenApiOperationAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiOperationAttribute.cs
@@ -38,6 +38,12 @@ namespace NSwag.Annotations
             Summary = summary;
             Description = description;
         }
+
+        /// <summary>Gets or sets the operation summary.</summary>
+        public string Summary { get; private set; }
+
+        /// <summary>Gets or sets the operation description.</summary>
+        public string Description { get; private set; }
     }
 
     /// <summary>Specifies the operation id.</summary>
@@ -54,11 +60,5 @@ namespace NSwag.Annotations
 
         /// <summary>Gets or sets the operation ID.</summary>
         public string OperationId { get; private set; }
-
-        /// <summary>Gets or sets the operation summary.</summary>
-        public string Summary { get; protected set; }
-
-        /// <summary>Gets or sets the operation description.</summary>
-        public string Description { get; protected set; }
     }
 }

--- a/src/NSwag.Annotations/OpenApiOperationAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiOperationAttribute.cs
@@ -10,14 +10,33 @@ using System;
 
 namespace NSwag.Annotations
 {
-    /// <summary>Specifies the operation id.</summary>
+    /// <summary>Specifies the operation id, summary and description</summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class OpenApiOperationAttribute : SwaggerOperationAttribute
     {
-        /// <summary>Initializes a new instance of the <see cref="SwaggerOperationAttribute"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="OpenApiOperationAttribute"/> class.</summary>
         /// <param name="operationId">The operation ID.</param>
         public OpenApiOperationAttribute(string operationId) : base(operationId)
         {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="OpenApiOperationAttribute"/> class.</summary>
+        /// <param name="summary">The operation summary.</param>
+        /// /// <param name="description">The operation description.</param>
+        public OpenApiOperationAttribute(string summary, string description) : base(null)
+        {
+            Summary = summary;
+            Description = description;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="OpenApiOperationAttribute"/> class.</summary>
+        /// /// <param name="operationId">The operation ID.</param>
+        /// <param name="summary">The operation summary.</param>
+        /// /// <param name="description">The operation description.</param>
+        public OpenApiOperationAttribute(string operationId, string summary, string description) : base(operationId)
+        {
+            Summary = summary;
+            Description = description;
         }
     }
 
@@ -35,5 +54,11 @@ namespace NSwag.Annotations
 
         /// <summary>Gets or sets the operation ID.</summary>
         public string OperationId { get; private set; }
+
+        /// <summary>Gets or sets the operation summary.</summary>
+        public string Summary { get; protected set; }
+
+        /// <summary>Gets or sets the operation description.</summary>
+        public string Description { get; protected set; }
     }
 }


### PR DESCRIPTION
Currently content of a DescriptionAttribute on a controller method (operation) is being parsed into a OpenAPI summary field instead of a description field (see this issue: https://github.com/RicoSuter/NSwag/issues/1930).

Unfortunately, this behavior can't be changed by simply parsing DescriptionAttribute into description field since it breaks backward compatibility. Also we need some source for summary field - and it looks like there is no appropriate attribute in System.ComponentModel namespace.

Proposed solution is to extend OpenApiOperationAttribute class with Summary and Description properties and use them in OperationSummaryAndDescriptionProcessor. 

If controller method has OpenApiOperationAttribute, then we'll get summary and description from it. If there is no such attribute, then usual logic will be applied - get summary from DescriptionAttribute (or xml docs summary) and get description from xml docs remarks.