### PR TITLE
Move to Preview 7 version of Microsoft.Extensions.ApiDescription.* packages

### DIFF
--- a/build/01_Build.bat
+++ b/build/01_Build.bat
@@ -10,14 +10,7 @@ xcopy "%~dp0/../src/NSwag.Console/bin/Release/net461" "%~dp0/../src/NSwag.Npm/bi
 xcopy "%~dp0\..\src\NSwag.Console.x86\bin\Release\net461\NSwag.x86.exe" "%~dp0\..\src\NSwag.Npm\bin\binaries\Win"
 xcopy "%~dp0\..\src\NSwag.Console.x86\bin\Release\net461\NSwag.x86.exe.config" "%~dp0\..\src\NSwag.Npm\bin\binaries\Win"
 
-REM Build and copy .NET Core command line
-dotnet restore "%~dp0/../src/NSwag.ConsoleCore" --no-cache
-dotnet publish "%~dp0/../src/NSwag.ConsoleCore" -c release -f "netcoreapp1.0" -o "bin/release/netcoreapp1.0/Publish" /property:Platform=AnyCPU || goto :error
-dotnet publish "%~dp0/../src/NSwag.ConsoleCore" -c release -f "netcoreapp1.1" -o "bin/release/netcoreapp1.1/Publish" /property:Platform=AnyCPU || goto :error
-dotnet publish "%~dp0/../src/NSwag.ConsoleCore" -c release -f "netcoreapp2.0" -o "bin/release/netcoreapp2.0/Publish" /property:Platform=AnyCPU || goto :error
-dotnet publish "%~dp0/../src/NSwag.ConsoleCore" -c release -f "netcoreapp2.1" -o "bin/release/netcoreapp2.1/Publish" /property:Platform=AnyCPU || goto :error
-dotnet publish "%~dp0/../src/NSwag.ConsoleCore" -c release -f "netcoreapp2.2" -o "bin/release/netcoreapp2.2/Publish" /property:Platform=AnyCPU || goto :error
-
+REM Build and publish .NET Core command line done in prebuild event for NSwagStudio.Installer.wixproj
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp1.0/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore10" /E /I /y
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp1.1/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore11" /E /I /y
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp2.0/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore20" /E /I /y

--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
@@ -15,12 +15,13 @@
     <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="0.3.0-preview6.19307.2" />
+      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="0.3.0-preview7.19365.7" />
       <dependency id="NSwag.MSBuild" version="13.0.5" />
     </dependencies>
     <references />
   </metadata>
   <files>
+    <file src="NSwag.ApiDescription.Client.props" target="build" />
     <file src="NSwag.ApiDescription.Client.targets" target="build" />
   </files>
 </package>

--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.props
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project>
+  <!-- Reset well-known metadata of the code generator item groups to make NSwag C# generator the default. -->
+  <ItemDefinitionGroup>
+    <OpenApiReference>
+      <CodeGenerator>NSwagCSharp</CodeGenerator>
+    </OpenApiReference>
+    <OpenApiProjectReference>
+      <CodeGenerator>NSwagCSharp</CodeGenerator>
+    </OpenApiProjectReference>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -24,7 +24,8 @@
 
     <Message Importance="high" Text="%0AGenerateNSwagCSharp:" />
     <Message Importance="high" Text="  %(CurrentOpenApiReference.Command)" />
-    <Exec Command="%(CurrentOpenApiReference.Command)" IgnoreExitCode="$([System.IO.File]::Exists('%(OutputPath)'))" />
+
+    <Exec Command="%(CurrentOpenApiReference.Command)" LogStandardErrorAsError="true" />
   </Target>
 
   <!-- OpenApiReference support for TypeScript -->
@@ -42,6 +43,6 @@
 
     <Message Importance="high" Text="%0AGenerateNSwagTypeScript:" />
     <Message Importance="high" Text="  %(CurrentOpenApiReference.Command)" />
-    <Exec Command="%(CurrentOpenApiReference.Command)" IgnoreExitCode="$([System.IO.File]::Exists('%(OutputPath)'))" />
+    <Exec Command="%(CurrentOpenApiReference.Command)" LogStandardErrorAsError="true" />
   </Target>
 </Project>

--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -15,10 +15,10 @@
         <Command>$(_NSwagCommand) openapi2csclient /className:%(ClassName) /namespace:%(Namespace)</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
-        <Command>%(Command) /input:%(FullPath) /output:%(OutputPath) %(Options)</Command>
+        <Command Condition="! %(FirstForGenerator)">%(Command) /GenerateExceptionClasses:false</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
-        <Command Condition="! %(FirstForGenerator)">%(Command) /GenerateExceptionClasses:false</Command>
+        <Command>%(Command) /input:%(FullPath) /output:%(OutputPath) %(Options)</Command>
       </CurrentOpenApiReference>
     </ItemGroup>
 

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -21,7 +21,7 @@
     <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.3</MicrosoftAspNetCoreMvcCorePackageVersion>
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.3</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.2</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftExtensionsApiDescriptionServerPackageVersion>0.3.0-preview6.19307.2</MicrosoftExtensionsApiDescriptionServerPackageVersion>
+    <MicrosoftExtensionsApiDescriptionServerPackageVersion>0.3.0-preview7.19365.7</MicrosoftExtensionsApiDescriptionServerPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
@@ -2,12 +2,15 @@
 <Project>
   <PropertyGroup>
     <!--
-      Disable document generation by default. This currently overrides Microsoft.Extensions.ApiDescription.Server.props.
+      Disable document generation by default in NSwag.AspNetCore.targets. These settings help distinguish user settings
+      from changes made in Microsoft.Extensions.ApiDescription.Server.targets.
     -->
-    <OpenApiGenerateDocuments/>
+    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">default-false</OpenApiGenerateDocuments>
+    <OpenApiGenerateDocumentsOnBuild
+        Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' ">default-false</OpenApiGenerateDocumentsOnBuild>
 
     <!-- Enable analyzers from the Microsoft.AspNetCore.Mvc.Api.Analyzers package. -->
     <IncludeOpenAPIAnalyzers
-        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0' ">true</IncludeOpenAPIAnalyzers>
+        Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetFrameworkVersion.TrimStart(&quot;vV&quot;))' >= '3.0' ">true</IncludeOpenAPIAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.targets
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.targets
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(OpenApiGenerateDocuments)' == 'default-false' ">
     <!--
-      If user has changed $(OpenApiDocumentsDirectory) but not $(OpenApiGenerateDocuments), enable document generation.
+      If user changed $(OpenApiDocumentsDirectory) but not $(OpenApiGenerateDocuments), enable document generation.
+      Otherwise, disable document generation.
     -->
+    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <OpenApiGenerateDocuments
-        Condition=" '$(OpenApiDocumentsDirectory)' != '$(BaseIntermediateOutputPath)' AND '$(OpenApiGenerateDocuments)' == '' ">true</OpenApiGenerateDocuments>
+        Condition=" '$(OpenApiDocumentsDirectory)' != '$(BaseIntermediateOutputPath)' ">true</OpenApiGenerateDocuments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'default-false' ">
+    <OpenApiGenerateDocumentsOnBuild>$(OpenApiGenerateDocuments)</OpenApiGenerateDocumentsOnBuild>
   </PropertyGroup>
 </Project>

--- a/src/NSwag.Npm/package-lock.json
+++ b/src/NSwag.Npm/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "nswag",
-  "version": "13.0.3",
+  "version": "13.0.5",
   "lockfileVersion": 1
 }

--- a/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
+++ b/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
@@ -52,28 +52,28 @@
     <HeatDirectory DirectoryRefId="RootDirectory" VerboseOutput="true" AutogenerateGuids="true" GenerateGuidsNow="true" SuppressRootDirectory="true" OutputFile="Generated.wxs" RunAsSeparateProcess="true" PreprocessorVariable="var.SourcePath" Directory="..\NSwagStudio\bin\$(Configuration)" ComponentGroupName="SourceComponentGroup" ToolPath="$(WixToolPath)" />
   </Target>
   <PropertyGroup>
-    <PreBuildEvent>rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/Win" /Q /S nonemptydir
-rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore10" /Q /S nonemptydir
-rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore11" /Q /S nonemptydir
-rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore20" /Q /S nonemptydir
-rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore21" /Q /S nonemptydir
-rmdir "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore22" /Q /S nonemptydir
+    <PreBuildEvent>rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /Q /S nonemptydir
+rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore10" /Q /S nonemptydir
+rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore11" /Q /S nonemptydir
+rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore20" /Q /S nonemptydir
+rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore21" /Q /S nonemptydir
+rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore22" /Q /S nonemptydir
 
-dotnet restore "../../../../src/NSwag.ConsoleCore" --no-cache
+dotnet restore "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" --no-cache
 
-dotnet publish "../../../../src/NSwag.ConsoleCore" -c $(ConfigurationName) -f "netcoreapp1.0" -o "bin/$(ConfigurationName)/netcoreapp1.0/Publish" /property:Platform=AnyCPU
-dotnet publish "../../../../src/NSwag.ConsoleCore" -c $(ConfigurationName) -f "netcoreapp1.1" -o "bin/$(ConfigurationName)/netcoreapp1.1/Publish" /property:Platform=AnyCPU
-dotnet publish "../../../../src/NSwag.ConsoleCore" -c $(ConfigurationName) -f "netcoreapp2.0" -o "bin/$(ConfigurationName)/netcoreapp2.0/Publish" /property:Platform=AnyCPU
-dotnet publish "../../../../src/NSwag.ConsoleCore" -c $(ConfigurationName) -f "netcoreapp2.1" -o "bin/$(ConfigurationName)/netcoreapp2.1/Publish" /property:Platform=AnyCPU
-dotnet publish "../../../../src/NSwag.ConsoleCore" -c $(ConfigurationName) -f "netcoreapp2.2" -o "bin/$(ConfigurationName)/netcoreapp2.2/Publish" /property:Platform=AnyCPU
+dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp1.0" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.0/Publish" /property:Platform=AnyCPU
+dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp1.1" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.1/Publish" /property:Platform=AnyCPU
+dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp2.0" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.0/Publish" /property:Platform=AnyCPU
+dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp2.1" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.1/Publish" /property:Platform=AnyCPU
+dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp2.2" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.2/Publish" /property:Platform=AnyCPU
 
-xcopy "../../../../src/NSwag.Console.x86/bin/$(ConfigurationName)/net461" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
-xcopy "../../../../src/NSwag.Console/bin/$(ConfigurationName)/net461" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.Console.x86/bin/$(ConfigurationName)/net461" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.Console/bin/$(ConfigurationName)/net461" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
 
-xcopy "../../../../src/NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.0/publish" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore10" /E /I /y
-xcopy "../../../../src/NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.1/publish" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore11" /E /I /y
-xcopy "../../../../src/NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.0/publish" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore20" /E /I /y
-xcopy "../../../../src/NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.1/publish" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore21" /E /I /y
-xcopy "../../../../src/NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.2/publish" "../../../../src/NSwagStudio/bin/$(ConfigurationName)/NetCore22" /E /I /y</PreBuildEvent>
+xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.0/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore10" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp1.1/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore11" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.0/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore20" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.1/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore21" /E /I /y
+xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.2/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore22" /E /I /y</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Move to Preview 7 version of Microsoft.Extensions.ApiDescription.* packages
- ensure NSwag code generator is the default
- adjust to later `$(OpenApiGenerateDocuments)` / `$(OpenApiGenerateDocumentsOnBuild)` default settings

nit: stop using a "private" MSBuild property in NSwag.AspNetCore.props
note: see aspnet/AspNetCore#13159 for why this doesn't use Preview 8 packages

### Never ignore non-zero exit codes from code generation tool
- remove `IgnoreExitCode` attribute
- add `LogStandardErrorAsError` since anything the tool writes to `stderr` indicates a problem

### Move `%(FirstForGenerator)` handling earlier
- ensure `%(Options)` can override `/GenerateExceptionClasses:false`

### Get build working again: Correct publish paths in prebuild event
- publish is relative to current directory, not project location
- nit: use `$(MSBuildProjectDirectory)` to make all paths in this event absolute
- remove redundant commands from build/01_Build.bat

nit: update NSwag.Npm/package-lock.json