### PR TITLE
Added global alias for System in C# generation

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/FileTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/FileTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NSwag.Generation.WebApi;
+using Xunit;
+
+namespace NSwag.CodeGeneration.CSharp.Tests
+{
+    public class FileTests
+    {
+        public class FileDownloadController : Controller
+        {
+            [Route("DownloadFile")]
+            public HttpResponseMessage DownloadFile()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public async Task When_file_is_generated_system_alias_is_there()
+        {
+            //// Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<FileDownloadController>();
+
+            //// Act
+            var codeGen = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientInterfaces = true
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("System = global::System", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -16,6 +16,8 @@ using {{ usage }};
 
 namespace {{ Namespace }}
 {
+    using System = global::System;
+    
     {{ Clients | tab }}
 
 {% if GenerateContracts -%}


### PR DESCRIPTION
I run into namespace conflict if using NSwag code generation for C#

## Context
We have namespace `Microsoft.Omex.System` (unfortunate name, and we work on renaming this https://github.com/microsoft/Omex/issues/101). I made a new namespace `Microsoft.Omex.Metrics.ApiClient` and used this namespace for ApiClient generated using nswag

Result is shown on this picture
![image](https://user-images.githubusercontent.com/5101272/63170963-711af280-c032-11e9-8169-ae29bd7bfac1.png)


## Current Behavior
Compilation failed because `System` resolved to `Microsoft.Omex.System`

## Expected Behavior
Compilation is fine.


## Possible Solution
Add global alias `System = global::System` in generated file
![image](https://user-images.githubusercontent.com/5101272/63172631-0f5c8780-c036-11e9-8bae-665bca6e0983.png)
or
prefix all usages of `System` with `global::` alias.

Given that first fix is way smaller, I decided to go for it. Let me know if second option is preferred. 

PS: I did not make a test - I failed to build code on my local machine, so was not even sure how to run tests.

