### PR TITLE
"Combined client" generation

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -106,6 +106,18 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets a value indicating whether to generate the response class (only applied when WrapResponses == true, default: true).</summary>
         public bool GenerateResponseClasses => _settings.GenerateResponseClasses;
 
+        /// <summary>Gets or sets a value indicating whether to generate a class that includes all generated client types as lazy fields (default: false). If <see cref="GenerateClientInterfaces"/> is <c>true</c> then an interface for it will also be created.</summary>
+        public bool GenerateCombinedClientClass => _settings.GenerateCombinedClientClass;
+
+        /// <summary>Gets or sets a value indicating whether to generate interfaces for the client classes (default: false).</summary>
+        public bool GenerateClientInterfaces => _settings.GenerateClientInterfaces;
+
+        /// <summary>Gets or sets the generated combined client's class name (default: &quot;CombinedClient&quot;).</summary>
+        public string CombinedClientClassName => _settings.CombinedClientClassName;
+
+        /// <summary>Gets or sets a value indicating the generated combined client's (<see cref="GenerateCombinedClientClass"/>) constructor access modifier. Use a private constructor when you'll need custom construction logic in a partial class definition. (default: &quot;public&quot;).</summary>
+        public string CombinedClientConstructorAccess => _settings.CombinedClassConstructorAccess;
+
         /// <summary>Gets the response class names.</summary>
         public IEnumerable<string> ResponseClassNames
         {

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -16,7 +16,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
     /// <summary>The CSharp file template model.</summary>
     public class CSharpFileTemplateModel
     {
-        private readonly string _clientCode;
+        private readonly IEnumerable<CodeArtifact> _clientTypes;
         private readonly OpenApiDocument _document;
         private readonly CSharpGeneratorBaseSettings _settings;
         private readonly CSharpTypeResolver _resolver;
@@ -40,12 +40,12 @@ namespace NSwag.CodeGeneration.CSharp.Models
             CSharpGeneratorBase generator,
             CSharpTypeResolver resolver)
         {
+            _clientTypes = clientTypes;
             _outputType = outputType;
             _document = document;
             _generator = generator;
             _settings = settings;
             _resolver = resolver;
-            _clientCode = clientTypes.Concatenate();
 
             Classes = dtoTypes.Concatenate();
         }
@@ -72,7 +72,10 @@ namespace NSwag.CodeGeneration.CSharp.Models
         public bool GenerateClientClasses => _settings.GenerateClientClasses;
 
         /// <summary>Gets the clients code.</summary>
-        public string Clients => _settings.GenerateClientClasses ? _clientCode : string.Empty;
+        public string Clients => _settings.GenerateClientClasses ? _clientTypes.Concatenate() : string.Empty;
+
+        /// <summary>Gets the clients code.</summary>
+        public string[] ClientNames => _clientTypes.Where( cc => cc.Category == CodeArtifactCategory.Client ).Select( cc => cc.TypeName ).ToArray();
 
         /// <summary>Gets the classes code.</summary>
         public string Classes { get; }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -18,6 +18,47 @@ namespace {{ Namespace }}
 {
     using System = global::System;
     
+{% if GenerateCombinedClientClass -%}
+{%     if GenerateClientInterfaces -%}
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
+    partial interface I{{ CombinedClientClassName }}
+    {
+{%         for clientClassName in ClientNames -%}
+        I{{ clientClassName }} {{ clientClassName }} { get; }
+{%         endfor -%}
+    }
+    {% endif -%}
+
+{% if GenerateClientInterfaces -%}
+    partial class {{ CombinedClientClassName }} : I{{ CombinedClientClassName }}
+    {
+        #region I{{ CombinedClientClassName }}
+{%     for clientClassName in ClientNames -%}
+        I{{ clientClassName }} I{{ CombinedClientClassName }}.{{ clientClassName }} => this.{{ clientClassName }};
+{%     endfor -%}
+        #endregion
+{% else -%}
+    partial class {{ CombinedClientClassName }}
+    {
+{% endif -%}
+        
+        {{ CombinedClientConstructorAccess }} {{ CombinedClientClassName }}(System.Net.Http.HttpClient httpClient)
+        {
+            if( httpClient == null ) throw new ArgumentNullException(nameof(httpClient));
+
+{%     for clientClassName in ClientNames -%}
+            _{{ clientClassName }} = new Lazy<{{ clientClassName }}>( () => new {{ clientClassName }}( httpClient ) );
+{%     endfor -%}
+        }
+
+{%     for clientClassName in ClientNames -%}
+        private readonly Lazy<{{ clientClassName }}> _{{ clientClassName }};
+        public {{ clientClassName }} {{ clientClassName }} => _{{ clientClassName }}.Value;
+
+{%     endfor -%}
+    }
+{% endif %}
+
     {{ Clients | tab }}
 
 {% if GenerateContracts -%}

--- a/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
@@ -26,6 +26,8 @@ namespace NSwag.CodeGeneration
 
             GenerateResponseClasses = true;
             ResponseClass = "SwaggerResponse";
+            CombinedClientClassName = "CombinedClient";
+            CombinedClassConstructorAccess = "public";
 
             WrapResponseMethods = new string[0];
             ExcludedParameterNames = new string[0];
@@ -45,6 +47,15 @@ namespace NSwag.CodeGeneration
 
         /// <summary>Gets or sets a value indicating whether to generate client types (default: true).</summary>
         public bool GenerateClientClasses { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether to generate a class that includes all generated client types as lazy fields (default: false). If <see cref="GenerateClientInterfaces"/> is <c>true</c> then an interface for it will also be created.</summary>
+        public bool GenerateCombinedClientClass { get; set; }
+
+        /// <summary>The name of the combined client class. (default: &quot;CombinedClient&quot;).</summary>
+        public string CombinedClientClassName { get; set; }
+
+        /// <summary>Gets or sets a value indicating the generated combined client's (<see cref="GenerateCombinedClientClass"/>) constructor access modifier. Use a private constructor when you'll need custom construction logic in a partial class definition and don't want to expose the constructor to dependency-injection. (default: &quot;public&quot;).</summary>
+        public string CombinedClassConstructorAccess { get; set; }
 
         /// <summary>Gets or sets the operation name generator.</summary>
         public IOperationNameGenerator OperationNameGenerator { get; set; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -52,6 +52,27 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.GenerateClientClasses = value; }
         }
 
+        [Argument(Name = "GenerateCombinedClientClass", IsRequired = false, Description = "Whether to generate a class that includes all generated client types as lazy fields ")]
+        public bool GenerateCombinedClientClass
+        {
+            get { return Settings.GenerateCombinedClientClass; }
+            set { Settings.GenerateCombinedClientClass = value; }
+        }
+
+        [Argument(Name = "CombinedClientClassName", IsRequired = false, Description = "The name of the combined client class.")]
+        public string CombinedClientClassName
+        {
+            get { return Settings.CombinedClientClassName; }
+            set { Settings.CombinedClientClassName = value; }
+        }
+
+        [Argument(Name = "CombinedClientClassConstructorAccess", IsRequired = false, Description = "The generated combined client's constructor access modifier. Use a private constructor when you'll need custom construction logic in a partial class definition and don't want to expose the constructor to dependency-injection.")]
+        public string CombinedClientClassConstructorAccess
+        {
+            get { return Settings.CombinedClassConstructorAccess; }
+            set { Settings.CombinedClassConstructorAccess = value; }
+        }
+
         [Argument(Name = "GenerateClientInterfaces", IsRequired = false, Description = "Specifies whether generate interfaces for the client classes.")]
         public bool GenerateClientInterfaces
         {

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -1,4 +1,4 @@
-﻿<codeGenerators:CodeGeneratorViewBase x:Class="NSwagStudio.Views.CodeGenerators.SwaggerToCSharpClientGeneratorView"
+<codeGenerators:CodeGeneratorViewBase x:Class="NSwagStudio.Views.CodeGenerators.SwaggerToCSharpClientGeneratorView"
                                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -86,6 +86,24 @@
                                       Content="Generate Client Classes" Margin="0,0,0,12" />
 
                             <StackPanel Visibility="{Binding Command.GenerateClientClasses, Converter={StaticResource VisibilityConverter}}">
+
+                                <GroupBox>
+                                    <GroupBox.Header>
+                                        <CheckBox IsChecked="{Binding Command.GenerateCombinedClientClass, Mode=TwoWay}" 
+                                          Content="Generate combined client class" 
+                                          ToolTip="GenerateCombinedClientClass" />
+                                    </GroupBox.Header>
+                                    <StackPanel Margin="6" IsEnabled="{Binding Command.GenerateCombinedClientClass}">
+
+                                        <TextBlock Text="Combined client class name" FontWeight="Bold" Margin="0,0,0,6" />
+                                        <TextBox Text="{Binding Command.CombinedClientClassName, Mode=TwoWay}" ToolTip="CombinedClientClassName" Margin="0,0,0,12" />
+
+                                        <TextBlock Text="Combined client constructor access" FontWeight="Bold" Margin="0,0,0,6" />
+                                        <TextBox Text="{Binding Command.CombinedClientClassConstructorAccess, Mode=TwoWay}" ToolTip="CombinedClientClassConstructorAccess" Margin="0,0,0,6" />
+
+                                    </StackPanel>
+                                </GroupBox>
+
                                 <TextBlock Margin="0,0,0,6" TextWrapping="Wrap">
                                     <Run Text="Operation Generation Mode" FontWeight="Bold" />
                                     <LineBreak />


### PR DESCRIPTION
These changes optionally allow NSwag to generate a client class that exposes all generated client types as lazily-initialized instance members with a DI-injected `HttpClient` instance.

This PR isn't intended to be merged immediately: there are some further changes that need to be made that I need feedback for before continuing.

* Combined class constructor generation should match the constructor generation settings of the actual classes.
    * So if they aren't using injected `HttpClient` instances then the combined-client class won't use them either.
* Move the combined-class to its own `.liquid` template file.
* Also add option to render the combined-client class to its own separate output file?
    * Along with adding support for rendering each client class to separate files, which is a common request too.
* Should the `Lazy<T>` fields use the thread-safe mode or is it okay to use the default? Or disable thread-safety entirely?