### PR TITLE
Fixed inverted logic in nswag new

### DIFF
--- a/src/NSwag.Commands/Commands/Document/CreateDocumentCommand.cs
+++ b/src/NSwag.Commands/Commands/Document/CreateDocumentCommand.cs
@@ -20,7 +20,7 @@ namespace NSwag.Commands.Document
     {
         public async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-            if (DynamicApis.FileExists("nswag.json"))
+            if (!DynamicApis.FileExists("nswag.json"))
             {
                 await CreateDocumentAsync("nswag.json");
                 host.WriteMessage("nswag.json file created.");


### PR DESCRIPTION
`nswag new` says that `nswag.json already exists.` while it doesn't, and successfully generates the file after a `touch nswag.json`.

Disclaimer: I didn't test this change, I edited it through github.