### PR TITLE
Use 3.0 GA packages from Microsoft

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
@@ -15,7 +15,7 @@
     <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="0.3.0-preview7.19365.7" />
+      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="3.0.0" />
       <dependency id="NSwag.MSBuild" version="13.1.3" />
     </dependencies>
     <references />

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -21,7 +21,7 @@
     <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.3</MicrosoftAspNetCoreMvcCorePackageVersion>
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.3</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.2</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftExtensionsApiDescriptionServerPackageVersion>0.3.0-preview7.19365.7</MicrosoftExtensionsApiDescriptionServerPackageVersion>
+    <MicrosoftExtensionsApiDescriptionServerPackageVersion>3.0.0</MicrosoftExtensionsApiDescriptionServerPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.props
@@ -2,10 +2,9 @@
 <Project>
   <PropertyGroup>
     <!--
-      Disable document generation by default in NSwag.AspNetCore.targets. These settings help distinguish user settings
-      from changes made in Microsoft.Extensions.ApiDescription.Server.targets.
+      Disable document generation on build if property maintains this value into NSwag.AspNetCore.targets. This setting
+      helps distinguish user settings from changes made in Microsoft.Extensions.ApiDescription.Server.targets.
     -->
-    <OpenApiGenerateDocuments Condition=" '$(OpenApiGenerateDocuments)' == '' ">default-false</OpenApiGenerateDocuments>
     <OpenApiGenerateDocumentsOnBuild
         Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == '' ">default-false</OpenApiGenerateDocumentsOnBuild>
 

--- a/src/NSwag.AspNetCore/build/NSwag.AspNetCore.targets
+++ b/src/NSwag.AspNetCore/build/NSwag.AspNetCore.targets
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <PropertyGroup Condition=" '$(OpenApiGenerateDocuments)' == 'default-false' ">
-    <!--
-      If user changed $(OpenApiDocumentsDirectory) but not $(OpenApiGenerateDocuments), enable document generation.
-      Otherwise, disable document generation.
-    -->
-    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
-    <OpenApiGenerateDocuments
-        Condition=" '$(OpenApiDocumentsDirectory)' != '$(BaseIntermediateOutputPath)' ">true</OpenApiGenerateDocuments>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(OpenApiGenerateDocumentsOnBuild)' == 'default-false' ">
-    <OpenApiGenerateDocumentsOnBuild>$(OpenApiGenerateDocuments)</OpenApiGenerateDocumentsOnBuild>
+    <!--
+      Disable document generation on build by default. If user changed $(OpenApiDocumentsDirectory) but not
+      $(OpenApiGenerateDocumentsOnBuild) and feature is supported, enable document generation on build.
+
+      Changing $(OpenApiDocumentsDirectory) does nothing when $(OpenApiGenerateDocuments) is false.
+    -->
+    <OpenApiGenerateDocumentsOnBuild>false</OpenApiGenerateDocumentsOnBuild>
+    <OpenApiGenerateDocumentsOnBuild
+        Condition=" '$(OpenApiDocumentsDirectory)' != '$(BaseIntermediateOutputPath)' ">$(OpenApiGenerateDocuments)</OpenApiGenerateDocuments>
   </PropertyGroup>
 </Project>

--- a/src/NSwag.Npm/package-lock.json
+++ b/src/NSwag.Npm/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "nswag",
-  "version": "13.0.5",
+  "version": "13.1.3",
   "lockfileVersion": 1
 }


### PR DESCRIPTION
- adjust opting into document generation slightly (might need a release note?)
- bump npm version in lock file