### PR TITLE
Added support for custom name generators

### DIFF
--- a/src/NSwag.Commands/Commands/CodeGeneration/CodeGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/CodeGeneratorCommandBase.cs
@@ -41,7 +41,6 @@ namespace NSwag.Commands.CodeGeneration
         [Argument(Name = "EnumNameGeneratorType", IsRequired = false, Description = "The custom IEnumNameGenerator implementation type in the form 'assemblyName:fullTypeName' or 'fullTypeName').")]
         public string EnumNameGeneratorType { get; set; }
 
-        // TODO: Use InitializeCustomTypes method
         public void InitializeCustomTypes(AssemblyLoader.AssemblyLoader assemblyLoader)
         {
             if (!string.IsNullOrEmpty(TypeNameGeneratorType))

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -227,6 +227,8 @@ namespace NSwag.Commands.CodeGeneration
         {
             return await Task.Run(async () =>
             {
+                InitializeCustomTypes(new AssemblyLoader.AssemblyLoader());
+
                 var document = await GetInputSwaggerDocument().ConfigureAwait(false);
                 var clientGenerator = new CSharpClientGenerator(document, Settings);
 


### PR DESCRIPTION
Calling the InitializeCustomTypes method to load custom type/property/enum name generators. 