### PR TITLE
Use http method names to distinguish duplicate operations

### DIFF
--- a/src/NSwag.Core.Tests/OperationIdTests.cs
+++ b/src/NSwag.Core.Tests/OperationIdTests.cs
@@ -28,5 +28,40 @@ namespace NSwag.Core.Tests
             //// Assert
             Assert.True(document.Operations.GroupBy(o => o.Operation.OperationId).All(g => g.Count() == 1));
         }
+
+        [Fact]
+        public void When_operation_ids_are_not_unique_then_method_names_are_used()
+        {
+            //// Arrange
+            var document = new OpenApiDocument();
+            document.Paths["path1"] = new OpenApiPathItem
+            {
+                {
+                    OpenApiOperationMethod.Get,
+                    new OpenApiOperation { OperationId = "foo" }
+                },
+                {
+                    OpenApiOperationMethod.Post,
+                    new OpenApiOperation { OperationId = "foo" }
+                }
+            };
+
+            document.Paths["path2"] = new OpenApiPathItem
+            {
+                {
+                    OpenApiOperationMethod.Post,
+                    new OpenApiOperation { OperationId = "foo" }
+                }
+            };
+
+            //// Act
+            document.GenerateOperationIds();
+
+            var actual = document.Operations.ToList();
+            //// Assert
+            Assert.Equal("get-foo", actual[0].Operation.OperationId);
+            Assert.Equal("post-foo", actual[1].Operation.OperationId);
+            Assert.Equal("post-foo2", actual[2].Operation.OperationId);
+        }
     }
 }

--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -270,11 +270,23 @@ namespace NSwag
                         }
                     }
 
-                    // Add numbers
-                    var i = 2;
-                    foreach (var operation in operations.Skip(1))
+                    bool distinctByMethodName = operations.GroupBy(o => o.Method).Count() > 1;
+
+                    if (distinctByMethodName)
                     {
-                        operation.Operation.OperationId += i++;
+                        foreach (var operation in operations)
+                        {
+                            operation.Operation.OperationId = $"{operation.Method}-{operation.Operation.OperationId}";
+                        }
+                    }
+                    else
+                    {
+                        // Add numbers
+                        var i = 2;
+                        foreach (var operation in operations.Skip(1))
+                        {
+                            operation.Operation.OperationId += i++;
+                        }
                     }
 
                     GenerateOperationIds();


### PR DESCRIPTION
When generating C# client from yml document for a typical REST api that contains paths:
```
GET person
POST person
DELETE person
```
the generated client contains methods 
```
Person1Async()
Person2Async()
Person3Async()
```
I think this is pretty common case and the http mehod name could be used to distinguish the duplicates