### PR TITLE
Fix #2453

### DIFF
--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
@@ -306,10 +306,9 @@ namespace NSwag.Commands.Generation.AspNetCore
 
         protected override async Task<string> RunIsolatedAsync(AssemblyLoader.AssemblyLoader assemblyLoader)
         {
-            var currentWorkingDirectory = ChangeWorkingDirectoryAndSetAspNetCoreEnvironment();
             using (var webHost = await CreateWebHostAsync(assemblyLoader))
             {
-                var document = await GenerateDocumentAsync(assemblyLoader, webHost.TryGetPropertyValue<IServiceProvider>("Services"), currentWorkingDirectory);
+                var document = await GenerateDocumentAsync(assemblyLoader, webHost.TryGetPropertyValue<IServiceProvider>("Services"), Directory.GetCurrentDirectory());
                 return UseDocumentProvider ? document.ToJson() : document.ToJson(OutputType);
             }
         }


### PR DESCRIPTION
#2453

Tried to fix the problem myself. Looks like the problem originated from `AspNetCoreToOpenApiCommand` where different base directories were used to load the assemblies (during web host creation) and generate the documents.

My own basic tests were successful, but since I'm far from fully understanding the code base, I'm not sure about the implications of my changes. Couldn't find any unit tests for `AspNetCoreToOpenApiCommand` or related classes either. So any feedback would be nice.