### PR TITLE
Update NSwag.ApiDescription.Client.targets

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -18,7 +18,7 @@
         <Command Condition="! %(FirstForGenerator)">%(Command) /GenerateExceptionClasses:false</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
-        <Command>%(Command) /input:%(FullPath) /output:%(OutputPath) %(Options)</Command>
+        <Command>%(Command) /input:"%(FullPath)" /output:"%(OutputPath)" %(Options)</Command>
       </CurrentOpenApiReference>
     </ItemGroup>
 
@@ -37,7 +37,7 @@
         <Command>$(_NSwagCommand) swagger2tsclient /className:%(ClassName) /namespace:%(Namespace)</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
-        <Command>%(Command) /input:%(FullPath) /output:%(OutputPath) %(Options)</Command>
+        <Command>%(Command) /input:"%(FullPath)" /output:"%(OutputPath)" %(Options)</Command>
       </CurrentOpenApiReference>
     </ItemGroup>
 


### PR DESCRIPTION
Fixed command to handle paths containing spaces.
Without this fix, automatic code generation from within VS fails with error code -1 when your swagger definition file resides in a path containing blanks.