### PR TITLE
Use string.Empty rather than null as the default response text when throwing exceptions

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -49,6 +49,6 @@ return;
 {%         endif -%}
 {%     endif -%}
 {% else -%}{% comment %} implied: `if !response.HasType` so just read it as text {% endcomment %}
-string responseText_ = ( response_.Content == null ) ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
 throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, responseText_, headers_, null);
 {% endif -%}


### PR DESCRIPTION
refs #2335 - I was seeing a NullReferenceException due to responseText_ being set to null when the response had no content, and the construtor for ApiException trying to call Substring on the null value.

Defaulting responseText_ to string.Empty instead of null seems to avoid that ok (same idea as the change made for #2268)