### PR TITLE
ParameterDateFormat support

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -24,6 +24,7 @@ namespace NSwag.CodeGeneration.CSharp
             WrapDtoExceptions = true;
             DisposeHttpClient = true;
             ParameterDateTimeFormat = "s";
+            ParameterDateFormat = "yyyy-MM-dd";
             GenerateUpdateJsonSerializerSettingsMethod = true;
             QueryNullValue = "";
             GenerateBaseUrlProperty = true;
@@ -82,6 +83,9 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the format for DateTime type method parameters (default: "s").</summary>
         public string ParameterDateTimeFormat { get; set; }
+
+        /// <summary>Gets or sets the format for Date type method parameters (default: "yyyy-MM-dd").</summary>
+        public string ParameterDateFormat { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise, default: true).</summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -122,6 +122,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the format for DateTime type method parameters.</summary>
         public string ParameterDateTimeFormat => _settings.ParameterDateTimeFormat;
 
+        /// <summary>Gets or sets the format for Date type method parameters.</summary>
+        public string ParemeterDateFormat => _settings.ParameterDateFormat;
+
         /// <summary>Gets or sets a value indicating whether to expose the JsonSerializerSettings property.</summary>
         public bool ExposeJsonSerializerSettings => _settings.ExposeJsonSerializerSettings;
 

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -123,7 +123,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
         public string ParameterDateTimeFormat => _settings.ParameterDateTimeFormat;
 
         /// <summary>Gets or sets the format for Date type method parameters.</summary>
-        public string ParemeterDateFormat => _settings.ParameterDateFormat;
+        public string ParameterDateFormat => _settings.ParameterDateFormat;
 
         /// <summary>Gets or sets a value indicating whether to expose the JsonSerializerSettings property.</summary>
         public bool ExposeJsonSerializerSettings => _settings.ExposeJsonSerializerSettings;

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
@@ -1,7 +1,11 @@
-{% if parameter.IsDateArray -%}
+{% if parameter.IsDateTimeArray -%}
 urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
-{% elseif parameter.IsDate -%}
+{% elseif parameter.IsDateArray -%}
+urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
+{% elseif parameter.IsDateTime -%}
 urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
+{% elseif parameter.IsDate -%}
+urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 {% elseif parameter.IsArray -%}
 urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => ConvertToString(s_, System.Globalization.CultureInfo.InvariantCulture)))));
 {% else -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -1,7 +1,11 @@
-{% if parameter.IsDateArray -%}
+{% if parameter.IsDateTimeArray -%}
 foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
-{% elseif parameter.IsDate -%}
+{% elseif parameter.IsDateArray -%}
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+{% elseif parameter.IsDateTime -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
+{% elseif parameter.IsDate -%}
+urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% elseif parameter.IsArray -%}
 foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% elseif parameter.IsDeepObject -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -37,7 +37,7 @@ let result{{ response.StatusCode }}: any = null;
 let resultData{{ response.StatusCode }}  = _responseText;
 {{ response.DataConversionCode }}
 {%         else -%}
-{%              if response.UseDtoClass or response.IsDate -%}
+{%              if response.UseDtoClass or response.IsDateOrDateTime -%}
 let resultData{{ response.StatusCode }} = _responseText === "" ? null : {% if operation.HandleReferences %}jsonParse{% else %}JSON.parse{% endif %}(_responseText, this.jsonParseReviver);
 {{ response.DataConversionCode }}
 {%              else -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -21,7 +21,7 @@ if ({{ parameter.VariableName }} === null)
 else if ({{ parameter.VariableName }} !== undefined)
 {%                 endif -%}
 {%             endif -%}
-{%             if parameter.IsDateArray -%}
+{%             if parameter.IsDateOrDateTimeArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item_ => { content_ += encodeURIComponent("{{ parameter.Name }}") + "=" + encodeURIComponent(item_ ? "" + item_.toJSON() : "null") + "&"; });
 {%             elseif parameter.IsObjectArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach((item_, index_) => { 
@@ -31,7 +31,7 @@ else if ({{ parameter.VariableName }} !== undefined)
            }
         }
     });
-{%             elseif parameter.IsDate -%}
+{%             elseif parameter.IsDateOrDateTime -%}
     content_ += encodeURIComponent("{{ parameter.Name }}") + "=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.toJSON() : "{{ QueryNullValue }}") + "&"; 
 {%             elseif parameter.IsArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item => { content_ += encodeURIComponent("{{ parameter.Name }}") + "=" + encodeURIComponent("" + item) + "&"; });
@@ -57,7 +57,7 @@ else
 {%                 else -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.data, {{ parameter.VariableName }}.fileName ? {{ parameter.VariableName }}.fileName : "{{ parameter.Name }}");
 {%                 endif -%}
-{%             elseif parameter.IsDate -%}
+{%             elseif parameter.IsDateOrDateTime -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toJSON());
 {%             else -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toString());

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -6,9 +6,9 @@ if ({{ parameter.VariableName }} === undefined || {{ parameter.VariableName }} =
 {%     else -%}
 if ({{ parameter.VariableName }} !== null && {{ parameter.VariableName }} !== undefined)
 {%     endif -%}
-{%     if parameter.IsDateArray -%}
+{%     if parameter.IsDateOrDateTimeArray -%}
 url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }}.map(s_ => s_ ? s_.toJSON() : "null").join())); 
-{%     elseif parameter.IsDate -%}
+{%     elseif parameter.IsDateOrDateTime -%}
 url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.toJSON() : "null")); 
 {%     elseif parameter.IsArray -%}
 url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }}.join())); 
@@ -40,7 +40,7 @@ if ({{ parameter.VariableName }} === null)
 else if ({{ parameter.VariableName }} !== undefined)
 {%         endif -%}
 {%     endif -%}
-{%     if parameter.IsDateArray -%}
+{%     if parameter.IsDateOrDateTimeArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item_ => { url_ += "{{ parameter.Name }}=" + encodeURIComponent(item_ ? "" + item_.toJSON() : "null") + "&"; });
 {%     elseif parameter.IsObjectArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach((item, index) => { 
@@ -49,7 +49,7 @@ else if ({{ parameter.VariableName }} !== undefined)
 				url_ += "{{ parameter.Name }}[" + index + "]." + attr + "=" + encodeURIComponent("" + (<any>item)[attr]) + "&";
 			}
     });
-{%     elseif parameter.IsDate -%}
+{%     elseif parameter.IsDateOrDateTime -%}
     url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.toJSON() : "{{ QueryNullValue }}") + "&"; 
 {%     elseif parameter.IsArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "&"; });

--- a/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
@@ -145,9 +145,15 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets a value indicating whether the parameter is of type date.</summary>
         public bool IsDate =>
-            (Schema.Format == JsonFormatStrings.DateTime ||
-            Schema.Format == JsonFormatStrings.Date) &&
+            Schema.Format == JsonFormatStrings.Date &&
             _generator.GetTypeName(Schema, IsNullable, null) != "string";
+
+        /// <summary>Gets a value indicating whether the parameter is of type date-time</summary>
+        public bool IsDateTime =>
+            Schema.Format == JsonFormatStrings.DateTime && _generator.GetTypeName(Schema, IsNullable, null) != "string";
+
+        /// <summary>Gets a value indicating whether the parameter is of type date-time or date</summary>
+        public bool IsDateOrDateTime => IsDate || IsDateTime;
 
         /// <summary>Gets a value indicating whether the parameter is of type array.</summary>
         public bool IsArray => Schema.Type.HasFlag(JsonObjectType.Array) || _parameter.CollectionFormat == OpenApiParameterCollectionFormat.Multi;
@@ -164,11 +170,19 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether the parameter is of type dictionary.</summary>
         public bool IsDictionary => Schema.IsDictionary;
 
+        /// <summary>Gets a value indicating whether the parameter is of type date-time array.</summary>
+        public bool IsDateTimeArray =>
+            IsArray &&
+            Schema.Item?.ActualSchema.Format == JsonFormatStrings.DateTime &&
+            _generator.GetTypeName(Schema.Item.ActualSchema, IsNullable, null) != "string";
+
+        /// <summary>Gets a value indicating whether the parameter is of type date-time or date array.</summary>
+        public bool IsDateOrDateTimeArray => IsDateArray || IsDateTimeArray;
+
         /// <summary>Gets a value indicating whether the parameter is of type date array.</summary>
         public bool IsDateArray =>
             IsArray &&
-            (Schema.Item?.ActualSchema.Format == JsonFormatStrings.DateTime ||
-            Schema.Item?.ActualSchema.Format == JsonFormatStrings.Date) &&
+            Schema.Item?.ActualSchema.Format == JsonFormatStrings.Date &&
             _generator.GetTypeName(Schema.Item.ActualSchema, IsNullable, null) != "string";
 
         /// <summary>Gets a value indicating whether the parameter is of type object array.</summary>

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -188,6 +188,14 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.ParameterDateTimeFormat = value; }
         }
 
+        [Argument(Name = "ParameterDateFormat", IsRequired = false,
+          Description = "Specifies the format for Date type method parameters (default: yyyy-MM-dd).")]
+        public string ParameterDateFormat
+        {
+            get { return Settings.ParameterDateFormat; }
+            set { Settings.ParameterDateFormat = value; }
+        }
+
         [Argument(Name = "GenerateUpdateJsonSerializerSettingsMethod", IsRequired = false,
             Description = "Generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise, default: true).")]
         public bool GenerateUpdateJsonSerializerSettingsMethod

--- a/src/NSwag.Integration.WebAPI/Swagger_ClientConsole.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_ClientConsole.nswag
@@ -81,6 +81,7 @@
       "contractsNamespace": "NSwag.Integration.Console.Contracts",
       "contractsOutputFilePath": "../NSwag.Integration.Console/ServiceClientsContracts.cs",
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwag.Integration.WebAPI/Swagger_ClientPCL.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_ClientPCL.nswag
@@ -81,6 +81,7 @@
       "contractsNamespace": "NSwag.Integration.ClientPCL.Contracts",
       "contractsOutputFilePath": "../NSwag.Integration.ClientPCL/ServiceClientsContracts.cs",
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": false,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwag.Integration.WebAPI/Swagger_PetStore_Fetch.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_PetStore_Fetch.nswag
@@ -89,6 +89,7 @@
       "contractsNamespace": null,
       "contractsOutputFilePath": null,
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwag.Integration.WebAPI/Swagger_Uber_Fetch.nswag
+++ b/src/NSwag.Integration.WebAPI/Swagger_Uber_Fetch.nswag
@@ -87,6 +87,7 @@
       "contractsNamespace": null,
       "contractsOutputFilePath": null,
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwag.Sample.NetCoreAngular/nswag.json
+++ b/src/NSwag.Sample.NetCoreAngular/nswag.json
@@ -84,6 +84,7 @@
       "contractsNamespace": "NSwag.Sample.NetCoreAngular.Clients.Contracts",
       "contractsOutputFilePath": "../NSwag.Sample.NetCoreAngular.Clients/Contracts.cs",
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwag.Sample.NetCoreAurelia/nswag.json
+++ b/src/NSwag.Sample.NetCoreAurelia/nswag.json
@@ -84,6 +84,7 @@
       "contractsNamespace": "NSwag.Sample.NetCoreAngular.Clients.Contracts",
       "contractsOutputFilePath": "../NSwag.Sample.NetCoreAngular.Clients/Contracts.cs",
       "parameterDateTimeFormat": "s",
+      "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "serializeTypeInformation": false,
       "queryNullValue": "",

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -155,6 +155,9 @@
                                 <TextBlock Text="DateTime format for method parameters" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox Text="{Binding Command.ParameterDateTimeFormat, Mode=TwoWay}" ToolTip="ParameterDateTimeFormat" Margin="0,0,0,12" />
 
+                                <TextBlock Text="Date format for method parameters" FontWeight="Bold" Margin="0,0,0,6" />
+                                <TextBox Text="{Binding Command.ParameterDateFormat, Mode=TwoWay}" ToolTip="ParameterDateFormat" Margin="0,0,0,12" />
+
                                 <TextBlock Text="Null value used for query parameters which are null" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox Text="{Binding Command.QueryNullValue, Mode=TwoWay}" 
                                          ToolTip="QueryNullValue" Margin="0,0,0,12" />


### PR DESCRIPTION
Currently, Serialization of C# DateTime objects when used as Parameters can be configured by the Parameter ParameterDateTimeFormat. However, sometimes the DateTime object should be treated as Date and not DateTime. 

Therefore, I added the parameter ParameterDateFormat that defines the Format when only the date is required. 

Example: 
```
"paths": {
    "/v1.0/somePath}/{fromDate}/{to}": {
      "get": {
        "tags": [ "example"  ],
        "parameters": [
          {
            "name": "fromDate",
            "in": "path",
            "schema": {
              "type": "string",
              "format": "date"
            },
          {
            "name": "to",
            "in": "path",
            "schema": {
              "type": "string",
              "format": "date-time"
            },
          }
```

Remark: 
Since, I'm not too familiar with NSWAG code structur, so it could be that this changes does not fit in codewise.  So could very well be if this change is not ok. 




Related issues: 
#1211  (also see: #2084)