### PR TITLE
allow angular http request to send withCredentials

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFrameworkAngularModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFrameworkAngularModel.cs
@@ -31,6 +31,11 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         public bool UseHttpClient => _settings.Template == TypeScriptTemplate.Angular &&
                                      _settings.HttpClass == TypeScript.HttpClass.HttpClient;
 
+        /// <summary>Gets a value indicating whether to send withCredentials: true with the http request options.</summary>
+        public bool WithCredentials => _settings.Template == TypeScriptTemplate.Angular &&
+                                       _settings.HttpClass == TypeScript.HttpClass.HttpClient &&
+                                       _settings.WithCredentials;
+
         /// <summary>Gets a value indicating whether to use the Angular 6 Singleton Provider (Angular template only, default: false).</summary>
         public bool UseSingletonProvider => _settings.Template == TypeScriptTemplate.Angular &&
                                             _settings.UseSingletonProvider;

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -52,7 +52,10 @@
 {%     endif -%}
 {%     if Framework.Angular.UseHttpClient -%}
             observe: "response",
-            responseType: "blob",
+            responseType: "blob",			
+{%		if Framework.Angular.WithCredentials -%}
+            withCredentials: true,		
+{%      endif -%}
 {%     else -%}
             method: "{{ operation.HttpMethodLower }}",
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -53,9 +53,9 @@
 {%     if Framework.Angular.UseHttpClient -%}
             observe: "response",
             responseType: "blob",			
-{%		if Framework.Angular.WithCredentials -%}
+{%	       if Framework.Angular.WithCredentials -%}
             withCredentials: true,		
-{%      endif -%}
+{%         endif -%}
 {%     else -%}
             method: "{{ operation.HttpMethodLower }}",
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -96,7 +96,7 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the HTTP service class (applies only for the Angular template, default: HttpClient).</summary>
         public HttpClass HttpClass { get; set; } = HttpClass.HttpClient;
 
-        /// <summary>Gets or sets the WithCredentials flag</summary>
+        /// <summary>Gets or sets a value indicating whether to set the withCredentials flag.</summary>
         public bool WithCredentials { get; set; } = false;
 
         /// <summary>Gets the RxJs version (Angular template only, default: 6.0).</summary>

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -96,6 +96,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the HTTP service class (applies only for the Angular template, default: HttpClient).</summary>
         public HttpClass HttpClass { get; set; } = HttpClass.HttpClient;
 
+        /// <summary>Gets or sets the WithCredentials flag</summary>
+        public bool WithCredentials { get; set; } = false;
+
         /// <summary>Gets the RxJs version (Angular template only, default: 6.0).</summary>
         public decimal RxJsVersion { get; set; } = 6.0m;
 

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -81,7 +81,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.HttpClass = value; }
         }
 
-        [Argument(Name = "WithCredentials", IsRequired = false, Description = "The Angular HttpClient will send withCredentials: true in http requests.")]
+        [Argument(Name = "WithCredentials", IsRequired = false, Description = "The Angular HttpClient will send withCredentials: true in http requests (default: false).")]
         public bool WithCredentials
         {
             get { return Settings.WithCredentials; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -81,6 +81,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.HttpClass = value; }
         }
 
+        [Argument(Name = "WithCredentials", IsRequired = false, Description = "The Angular HttpClient will send withCredentials: true in http requests.")]
+        public bool WithCredentials
+        {
+            get { return Settings.WithCredentials; }
+            set { Settings.WithCredentials = value; }
+        }
+
         [Argument(Name = "UseSingletonProvider", IsRequired = false, Description = "Specifies whether to use the Angular 6 Singleton Provider (Angular template only, default: false).")]
         public bool UseSingletonProvider
         {

--- a/src/NSwagStudio/Converters/IsValueToVisibilityConverter.cs
+++ b/src/NSwagStudio/Converters/IsValueToVisibilityConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace NSwagStudio.Converters
+{
+    public class IsValueToVisibilityConverter : MarkupExtension, IValueConverter
+    {
+        public object Target { get; set; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null && Target == null)
+                return Visibility.Visible;
+
+            if (value == null || Target == null)
+                return Visibility.Collapsed;
+
+            if (value.Equals(Target))
+                return Visibility.Visible;
+
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NSwagStudio/NSwagStudio.csproj
+++ b/src/NSwagStudio/NSwagStudio.csproj
@@ -167,6 +167,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Controls\TabContent.cs" />
+    <Compile Include="Converters\IsValueToVisibilityConverter.cs" />
     <Compile Include="Converters\NumberAdditionConverter.cs" />
     <Compile Include="Converters\StringArrayConverter.cs" />
     <Compile Include="ISwaggerGeneratorView.cs" />

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
@@ -11,7 +11,8 @@
                                       xmlns:controls="clr-namespace:NSwagStudio.Controls"
                                       xmlns:dialogs="clr-namespace:MyToolkit.Dialogs;assembly=MyToolkit.Extended"
                                       xmlns:codeGenerators="clr-namespace:NSwagStudio.Views.CodeGenerators"
-                                      mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300">
+                                      xmlns:typeScriptEnums="clr-namespace:NSwag.CodeGeneration.TypeScript;assembly=NSwag.CodeGeneration.TypeScript"
+                                      mc:Ignorable="d" d:DesignHeight="800" d:DesignWidth="800">
 
     <UserControl.Resources>
         <viewModels:SwaggerToTypeScriptClientGeneratorViewModel x:Key="ViewModel" />
@@ -85,9 +86,21 @@
 
                                         <TextBlock Text="HTTP service class" FontWeight="Bold" Margin="0,0,0,6" />
                                         <TextBlock Text="HttpClient recommended for new projects (Angular 4.3+)" Margin="0,0,0,6" />
-                                        <ComboBox SelectedItem="{Binding Command.HttpClass, Mode=TwoWay}" 
-                                                  ToolTip="HttpClass" 
-                                                  ItemsSource="{Binding HttpClasses}" Margin="0,0,0,12" />
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <ComboBox Grid.Column="0" 
+                                                      SelectedItem="{Binding Command.HttpClass, Mode=TwoWay}" 
+                                                      ToolTip="HttpClass" 
+                                                      ItemsSource="{Binding HttpClasses}" Margin="0,0,0,12" />
+                                            <CheckBox Grid.Column="1" 
+                                                      Content="With Credentials"
+                                                      ToolTip="Send withCredentials parameter in http requests"
+                                                      Visibility="{Binding Command.HttpClass, Converter={localConverters:IsValueToVisibilityConverter Target={x:Static typeScriptEnums:HttpClass.HttpClient}}}"
+                                                      IsChecked="{Binding Command.WithCredentials, Mode=TwoWay}" Margin="4,4,0,12" />
+                                        </Grid>
 
                                         <TextBlock Text="Injection token type" FontWeight="Bold" Margin="0,0,0,6" />
                                         <TextBlock Text="InjectionToken recommended for new projects (Angular 4+)" Margin="0,0,0,6" />


### PR DESCRIPTION
When generating a typescript client you may want to be able to add withCredentails: true to the options, i.e.

```cs
let options_ : any = {
    observe: "response",
    responseType: "blob",
    withCredentials: true,
    headers: new HttpHeaders({
        "Accept": "application/json"
    })
};
```

this change allows the user to select whether or not to send this option