### PR TITLE
Fix Swagger UI empty Path #2510 (#2517)

### DIFF
--- a/src/NSwag.AspNetCore/Middlewares/RedirectToIndexMiddleware.cs
+++ b/src/NSwag.AspNetCore/Middlewares/RedirectToIndexMiddleware.cs
@@ -36,7 +36,7 @@ namespace NSwag.AspNetCore.Middlewares
             if (context.Request.Path.HasValue &&
                 string.Equals(context.Request.Path.Value.Trim('/'), _swaggerUiRoute.Trim('/'), StringComparison.OrdinalIgnoreCase))
             {
-                context.Response.StatusCode = 302;
+                context.Response.StatusCode = StatusCodes.Status302Found;
 
                 var suffix = !string.IsNullOrWhiteSpace(_swaggerRoute) ? "?url=" + _transformToExternal(_swaggerRoute, context.Request) : "";
                 var path = _transformToExternal(_swaggerUiRoute, context.Request);


### PR DESCRIPTION
* the previous commit allows to set the Path property in SwaggerUi3Settings to string.Empty, in order to redirect the Host Root to the Swagger UI index.html page.
* Moreover, if set the Path in the UseReDoc configuration to be string.Empty, the Host root page will redirect to ReDoc UI. Very Cool.
* If both UseSwaggerUi3 and UseReDoc configure Path to string.Empty, then the first Middleware takes effect.