### PR TITLE
Add partial methods to allow changes prior to deserialization

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -26,7 +26,7 @@ namespace NSwag.CodeGeneration.CSharp
             ParameterDateTimeFormat = "s";
             ParameterDateFormat = "yyyy-MM-dd";
             GenerateUpdateJsonSerializerSettingsMethod = true;
-            GeneratePreSerializationMethods = false;
+            UseRequestAndResponseSerializationSettings = false;
             QueryNullValue = "";
             GenerateBaseUrlProperty = true;
             ExposeJsonSerializerSettings = false;
@@ -91,8 +91,8 @@ namespace NSwag.CodeGeneration.CSharp
         /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise, default: true).</summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).</summary>
-        public bool GeneratePreSerializationMethods { get; set; }
+        /// <summary>Gets or sets a value indicating whether to generate different request and response serialization settings (default: false).</summary>
+        public bool UseRequestAndResponseSerializationSettings { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto).</summary>
         public bool SerializeTypeInformation { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -26,6 +26,7 @@ namespace NSwag.CodeGeneration.CSharp
             ParameterDateTimeFormat = "s";
             ParameterDateFormat = "yyyy-MM-dd";
             GenerateUpdateJsonSerializerSettingsMethod = true;
+            GeneratePreSerializationMethods = false;
             QueryNullValue = "";
             GenerateBaseUrlProperty = true;
             ExposeJsonSerializerSettings = false;
@@ -89,6 +90,9 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise, default: true).</summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether to generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).</summary>
+        public bool GeneratePreSerializationMethods { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto).</summary>
         public bool SerializeTypeInformation { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -131,8 +131,8 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method.</summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod => _settings.GenerateUpdateJsonSerializerSettingsMethod;
 
-        /// <summary>Gets or sets a value indicating whether to generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).</summary>
-        public bool GeneratePreSerializationMethods => _settings.GeneratePreSerializationMethods;
+        /// <summary>Gets or sets a value indicating whether to generate different request and response serialization settings (default: false).</summary>
+        public bool UseRequestAndResponseSerializationSettings => _settings.UseRequestAndResponseSerializationSettings;
 
         /// <summary>Gets or sets a value indicating whether to serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto).</summary>
         public bool SerializeTypeInformation => _settings.SerializeTypeInformation;

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -131,6 +131,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method.</summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod => _settings.GenerateUpdateJsonSerializerSettingsMethod;
 
+        /// <summary>Gets or sets a value indicating whether to generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).</summary>
+        public bool GeneratePreSerializationMethods => _settings.GeneratePreSerializationMethods;
+
         /// <summary>Gets or sets a value indicating whether to serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto).</summary>
         public bool SerializeTypeInformation => _settings.SerializeTypeInformation;
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -10,6 +10,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
     if (ReadResponseAsString)
     {
         var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        BeforeResponseDeserialization(ref responseText);
         try
         {
             var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -10,12 +10,9 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
     if (ReadResponseAsString)
     {
         var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-{% if GeneratePreSerializationMethods -%}
-        BeforeResponseDeserialization(ref responseText);
-{% endif -%}
         try
         {
-            var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);
+            var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
             return new ObjectResponseResult<T>(typedBody, responseText);
         }
         catch (Newtonsoft.Json.JsonException exception)
@@ -32,7 +29,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
             using (var streamReader = new System.IO.StreamReader(responseStream))
             using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
             {
-                var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
+                var serializer = Newtonsoft.Json.JsonSerializer.Create({% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
                 var typedBody = serializer.Deserialize<T>(jsonTextReader);
                 return new ObjectResponseResult<T>(typedBody, string.Empty);
             }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -10,7 +10,9 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
     if (ReadResponseAsString)
     {
         var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+{% if GeneratePreSerializationMethods -%}
         BeforeResponseDeserialization(ref responseText);
+{% endif -%}
         try
         {
             var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -58,6 +58,8 @@
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, string url);
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
     partial void ProcessResponse({{ HttpClientType }} client, System.Net.Http.HttpResponseMessage response);
+    partial void BeforeRequestSerialization<T>(ref T value);
+    partial void BeforeResponseDeserialization(ref string json);
 
 {% for operation in Operations -%}
 {%     if GenerateOptionalParameters == false -%}
@@ -151,6 +153,7 @@
 {%         elseif operation.HasXmlBodyParameter -%}
                 var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
 {%         else -%}
+                BeforeRequestSerialization(ref {{ operation.ContentParameter.VariableName }});
                 var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}_settings.Value));
 {%         endif -%}
                 content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -58,8 +58,10 @@
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, string url);
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
     partial void ProcessResponse({{ HttpClientType }} client, System.Net.Http.HttpResponseMessage response);
+{% if GeneratePreSerializationMethods -%}
     partial void BeforeRequestSerialization<T>(ref T value);
     partial void BeforeResponseDeserialization(ref string json);
+{% endif -%}
 
 {% for operation in Operations -%}
 {%     if GenerateOptionalParameters == false -%}
@@ -153,7 +155,9 @@
 {%         elseif operation.HasXmlBodyParameter -%}
                 var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
 {%         else -%}
+{%             if GeneratePreSerializationMethods -%}
                 BeforeRequestSerialization(ref {{ operation.ContentParameter.VariableName }});
+{%             endif -%}
                 var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}_settings.Value));
 {%         endif -%}
                 content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -7,7 +7,12 @@
 {% if InjectHttpClient -%}
     private {{ HttpClientType }} _httpClient;
 {% endif -%}
+{% if UseRequestAndResponseSerializationSettings -%}
+    private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _requestSettings;
+    private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _responseSettings;
+{% else -%}
     private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
+{% endif -%}
 
 {% if HasConfigurationClass -%}
     public {{ Class }}({{ ConfigurationClass }} configuration{% if InjectHttpClient %}, {{ HttpClientType }} httpClient{% endif %}) : base(configuration)
@@ -30,15 +35,22 @@
     public {{ Class }}()
     {
 {% endif -%}
-        _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(() => 
+        Newtonsoft.Json.JsonSerializerSettings settingsFactory({% if UseRequestAndResponseSerializationSettings %}bool isRequest{% endif %})
         {
             var settings = {{ JsonSerializerParameterCode }};
 {% if SerializeTypeInformation -%}
             settings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
 {% endif -%}
-            UpdateJsonSerializerSettings(settings);
+            UpdateJsonSerializerSettings(settings{% if UseRequestAndResponseSerializationSettings %}, isRequest{% endif %});
             return settings;
-        });
+        };
+
+{% if UseRequestAndResponseSerializationSettings -%}
+        _requestSettings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(() => settingsFactory(true));
+        _responseSettings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(() => settingsFactory(false));
+{% else -%}
+        _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(settingsFactory);
+{% endif -%}
         {% template Client.Class.Constructor %}
     }
 
@@ -50,18 +62,28 @@
     }
 
 {% endif -%}
-    {% if ExposeJsonSerializerSettings %}public{% else %}protected{% endif %} Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
+{% if ExposeJsonSerializerSettings %}
+{%     assign serializerSettingsAccessModifier = "public" -%}
+{% else -%}
+{%     assign serializerSettingsAccessModifier = "protected" -%}
+{% endif -%}
+{% if UseRequestAndResponseSerializationSettings -%}
+    {{ serializerSettingsAccessModifier }} Newtonsoft.Json.JsonSerializerSettings RequestJsonSerializerSettings { get { return _requestSettings.Value; } }
+    {{ serializerSettingsAccessModifier }} Newtonsoft.Json.JsonSerializerSettings ResponseJsonSerializerSettings { get { return _responseSettings.Value; } }
+{% else -%}
+    {{ serializerSettingsAccessModifier }} Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
+{% endif -%}
 
 {% if GenerateUpdateJsonSerializerSettingsMethod -%}
+{%     if UseRequestAndResponseSerializationSettings -%}
+    partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings, bool isRequest);
+{%     else -%}
     partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
+{%     endif -%}
 {% endif -%}
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, string url);
     partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
     partial void ProcessResponse({{ HttpClientType }} client, System.Net.Http.HttpResponseMessage response);
-{% if GeneratePreSerializationMethods -%}
-    partial void BeforeRequestSerialization<T>(ref T value);
-    partial void BeforeResponseDeserialization(ref string json);
-{% endif -%}
 
 {% for operation in Operations -%}
 {%     if GenerateOptionalParameters == false -%}
@@ -155,10 +177,7 @@
 {%         elseif operation.HasXmlBodyParameter -%}
                 var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
 {%         else -%}
-{%             if GeneratePreSerializationMethods -%}
-                BeforeRequestSerialization(ref {{ operation.ContentParameter.VariableName }});
-{%             endif -%}
-                var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}_settings.Value));
+                var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}{% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value));
 {%         endif -%}
                 content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
                 request_.Content = content_;

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -204,6 +204,14 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.GenerateUpdateJsonSerializerSettingsMethod = value; }
         }
 
+        [Argument(Name = "GeneratePreSerializationMethods", IsRequired = false,
+            Description = "Generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).")]
+        public bool GeneratePreSerializationMethods
+        {
+            get { return Settings.GeneratePreSerializationMethods; }
+            set { Settings.GeneratePreSerializationMethods = value; }
+        }
+
         [Argument(Name = "SerializeTypeInformation", IsRequired = false,
             Description = "Serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto, default: true).")]
         public bool SerializeTypeInformation

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -204,12 +204,12 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.GenerateUpdateJsonSerializerSettingsMethod = value; }
         }
 
-        [Argument(Name = "GeneratePreSerializationMethods", IsRequired = false,
-            Description = "Generate the BeforeRequestSerialization and BeforeResponseDeserialization method (default: false).")]
-        public bool GeneratePreSerializationMethods
+        [Argument(Name = "UseRequestAndResponseSerializationSettings", IsRequired = false,
+            Description = "Generate different request and response serialization settings (default: false).")]
+        public bool UseRequestAndResponseSerializationSettings
         {
-            get { return Settings.GeneratePreSerializationMethods; }
-            set { Settings.GeneratePreSerializationMethods = value; }
+            get { return Settings.UseRequestAndResponseSerializationSettings; }
+            set { Settings.UseRequestAndResponseSerializationSettings = value; }
         }
 
         [Argument(Name = "SerializeTypeInformation", IsRequired = false,


### PR DESCRIPTION
**BUG FIX:** #2580

1. Add a new partial method, `BeforeRequestSerialization<T>`, which can change either the `JsonSerializerSettings` or the content itself *prior* to any serialization occurring.
2. Add a new partial method, `BeforeResponseDeserialization<T>`, which can change either the `JsonSerializerSettings` or the serialized JSON *prior* to any deserialization occurring.

The big benefit of these methods is the ability to have different rules or contract resolution between the request and response (e.g. able to ignore missing required properties on responses, but not requests).