### PR TITLE
Bump Microsoft.AspNetCore.All to 2.2.8

### DIFF
--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />


### PR DESCRIPTION
This mitigates
CVE-2019-1075 (https://github.com/aspnet/Announcements/issues/373), re #2598.