### PR TITLE
[Ts] Add possibility to generate separate contracts & implementation 

### DIFF
--- a/src/NSwag.Commands/Commands/IMultipleOutputCommand.cs
+++ b/src/NSwag.Commands/Commands/IMultipleOutputCommand.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <license>https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md</license>
+//-----------------------------------------------------------------------
+
+
+using NConsole;
+using NSwag.CodeGeneration;
+using System.Collections.Generic;
+
+namespace NSwag.Commands
+{
+    public interface IMultipleOutputCommand : IConsoleCommand
+    {
+        Dictionary<ClientGeneratorOutputType, string> OutputFilePaths { get; set; }
+    }
+}

--- a/src/NSwag.Commands/Commands/OutputCommandBase.cs
+++ b/src/NSwag.Commands/Commands/OutputCommandBase.cs
@@ -10,14 +10,24 @@ using System;
 using System.Threading.Tasks;
 using NConsole;
 using Newtonsoft.Json;
+using NSwag.CodeGeneration;
+using System.Collections.Generic;
 
 namespace NSwag.Commands
 {
-    public abstract class OutputCommandBase : IOutputCommand
+    public abstract class OutputCommandBase : IOutputCommand, IMultipleOutputCommand
     {
         [Argument(Name = "Output", IsRequired = false, Description = "The output file path (optional).")]
         [JsonProperty("output", NullValueHandling = NullValueHandling.Include)]
-        public string OutputFilePath { get; set; }
+        public string OutputFilePath
+        {
+            get => OutputFilePaths.TryGetValue(ClientGeneratorOutputType.Full, out var value) ? value : null;
+            set => OutputFilePaths[ClientGeneratorOutputType.Full] = value;
+        }
+
+        [Argument(Name = "Output", IsRequired = false, Description = "The output file paths (optional). <DocumentPart, FilePath>")]
+        [JsonProperty("outputs", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<ClientGeneratorOutputType, string> OutputFilePaths { get; set; } = new Dictionary<ClientGeneratorOutputType, string>();
 
         public abstract Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host);
 

--- a/src/NSwag.Commands/NSwagDocument.cs
+++ b/src/NSwag.Commands/NSwagDocument.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NSwag.AssemblyLoader.Utilities;
+using NSwag.CodeGeneration;
 using NSwag.Commands.Generation;
 using NSwag.Commands.Generation.AspNetCore;
 using NSwag.Commands.Generation.WebApi;
@@ -79,7 +80,7 @@ namespace NSwag.Commands
         public override async Task<OpenApiDocumentExecutionResult> ExecuteAsync()
         {
             var document = await GenerateSwaggerDocumentAsync();
-            foreach (var codeGenerator in CodeGenerators.Items.Where(c => !string.IsNullOrEmpty(c.OutputFilePath)))
+            foreach (var codeGenerator in CodeGenerators.Items.Where(c => !string.IsNullOrEmpty(c.OutputFilePath) || c.OutputFilePaths.Any()))
             {
                 codeGenerator.Input = document;
                 await codeGenerator.RunAsync(null, null);
@@ -113,10 +114,10 @@ namespace NSwag.Commands
 
                 foreach (var command in clone.CodeGenerators.Items.Where(c => c != null))
                 {
-                    if (redirectOutput || string.IsNullOrEmpty(command.OutputFilePath))
+                    if (redirectOutput || !command.OutputFilePaths.Any())
                     {
                         var codeFilePath = baseFilename + "_" + command.GetType().Name + ".temp";
-                        command.OutputFilePath = codeFilePath;
+                        command.OutputFilePaths.Add(ClientGeneratorOutputType.Full, codeFilePath);
                         filenames.Add(codeFilePath);
                     }
                 }

--- a/src/NSwag.Commands/NSwagDocumentBase.cs
+++ b/src/NSwag.Commands/NSwagDocumentBase.cs
@@ -395,7 +395,19 @@ namespace NSwag.Commands
 
             foreach (var generator in CodeGenerators.Items.Concat(SwaggerGenerators.Items))
             {
-                generator.OutputFilePath = ConvertToAbsolutePath(generator.OutputFilePath);
+                if (generator.OutputFilePath != null)
+                {
+                    generator.OutputFilePath = ConvertToAbsolutePath(generator.OutputFilePath);
+                }
+
+                if (generator is IMultipleOutputCommand multipleOutputGenerator)
+                {
+                    var outputFileKeys = multipleOutputGenerator.OutputFilePaths.Keys.ToList();
+                    foreach (var outputFileKey in outputFileKeys)
+                    {
+                        multipleOutputGenerator.OutputFilePaths[outputFileKey] = ConvertToAbsolutePath(multipleOutputGenerator.OutputFilePaths[outputFileKey]);
+                    }
+                }
             }
         }
 
@@ -476,7 +488,19 @@ namespace NSwag.Commands
 
             foreach (var generator in CodeGenerators.Items.Where(i => i != null).Concat(SwaggerGenerators.Items))
             {
-                generator.OutputFilePath = ConvertToRelativePath(generator.OutputFilePath);
+                if (generator.OutputFilePath != null)
+                {
+                    generator.OutputFilePath = ConvertToRelativePath(generator.OutputFilePath);
+                }
+
+                if (generator is IMultipleOutputCommand multipleOutputGenerator)
+                {
+                    var outputFileKeys = multipleOutputGenerator.OutputFilePaths.Keys.ToList();
+                    foreach (var outputFileKey in outputFileKeys)
+                    {
+                        multipleOutputGenerator.OutputFilePaths[outputFileKey] = ConvertToRelativePath(multipleOutputGenerator.OutputFilePaths[outputFileKey]);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Hi, I did solve part of the #1398.

You can use it from `nswag.json` file like:
```json5
{
  "codeGenerators": {
    "openApiToTypeScriptClient": {
      "output": null, // works in the same manner as before (internally mapped to the 'outputs' field)
      "outputs": {
        "Contracts": "./restApi.contract.ts",
        "Implementation": "./restApi.implementation.ts"
      }
    }
  }
}
```