### PR TITLE
Allow custom json-based content type

### DIFF
--- a/src/NSwag.Core/OpenApiParameter.cs
+++ b/src/NSwag.Core/OpenApiParameter.cs
@@ -222,7 +222,7 @@ namespace NSwag
 
                 return consumes?.Any() == true &&
                        consumes.Any(p => p.Contains("application/xml")) &&
-                       consumes.Any(p => p.Contains("application/json")) == false;
+                       consumes.Any(p => p.StartsWith("application/") && p.EndsWith("json")) == false;
             }
         }
 
@@ -243,14 +243,14 @@ namespace NSwag
                     var consumes = parent.ActualConsumes;
                     return consumes?.Any() == true &&
                            consumes.Any(p => p.Contains("*/*")) == false && // supports json
-                           consumes.Any(p => p.Contains("application/json")) == false;
+                           consumes.Any(p => p.StartsWith("application/") && p.EndsWith("json")) == false;
                 }
                 else
                 {
                     var consumes = parent?.RequestBody?.Content;
                     return consumes?.Any() == true &&
                            consumes.Any(p => p.Key.Contains("*/*") && !p.Value.Schema.IsBinary) == false && // supports json
-                           consumes.Any(p => p.Key.Contains("application/json") && p.Value.Schema?.IsBinary != true) == false;
+                           consumes.Any(p => p.Key.StartsWith("application/") && p.Key.EndsWith("json") && p.Value.Schema?.IsBinary != true) == false;
                 }              
             }
         }


### PR DESCRIPTION
This PR allows for custom (vendor extension) json-based content types to be treated as json and not as binary. This fixes #2586.

Instead of using [StartsWith](https://docs.microsoft.com/en-us/dotnet/api/system.string.startswith) and [EndsWith](https://docs.microsoft.com/en-us/dotnet/api/system.string.endswith), one could also use [Regex.IsMatch](https://docs.microsoft.com/en-us/dotnet/csharp/how-to/search-strings#finding-specific-text-using-regular-expressions). However, I saw that the former is already used in OpenApiResponse.cs so I decided to keep it same-style.