### PR TITLE
added response content-type to NSwag.AspNet.WebApi.JsonExceptionFilterAttribute

### DIFF
--- a/src/NSwag.AspNet.WebApi/JsonExceptionFilterAttribute.cs
+++ b/src/NSwag.AspNet.WebApi/JsonExceptionFilterAttribute.cs
@@ -70,7 +70,7 @@ namespace NSwag.AspNet.WebApi
                 context.Response = new HttpResponseMessage
                 {
                     StatusCode = (HttpStatusCode)GetStatusCode(context.Exception, context),
-                    Content = new StringContent(json, Encoding.UTF8)
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
                 };
             }
             else


### PR DESCRIPTION
added reponse content-type "application/json" to NSwag.AspNet.WebApi.JsonExceptionFilterAttribute.

Fixes #2635