### PR TITLE
Fixed issue for OpenAPI 3 where collectionFormat was deprecated

### DIFF
--- a/src/NSwag.Generation.Tests/OpenApiDocumentGeneratorTests.cs
+++ b/src/NSwag.Generation.Tests/OpenApiDocumentGeneratorTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Reflection;
+using Namotion.Reflection;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using Xunit;
+
+namespace NSwag.Generation.Tests
+{
+    public class OpenApiDocumentGeneratorTests
+    {
+        public void HasArrayParameter(string[] foo) { }
+
+        private OpenApiParameter GetParameter(SchemaType schemaType)
+        {
+            var generatorSettings = new OpenApiDocumentGeneratorSettings
+            {
+                SchemaType = schemaType,
+                ReflectionService = new DefaultReflectionService()
+            };
+            var schemaResolver = new JsonSchemaResolver(new OpenApiDocument(), generatorSettings);
+            var generator = new OpenApiDocumentGenerator(generatorSettings, schemaResolver);
+            var methodInfo = typeof(OpenApiDocumentGeneratorTests).GetMethod("HasArrayParameter");
+
+            return generator.CreatePrimitiveParameter("foo", "bar", methodInfo.GetContextualParameters().First());
+        }
+
+        [Fact]
+        public void CreatePrimitiveParameter_QueryStringArray_OpenApi()
+        {
+            var parameter = GetParameter(SchemaType.OpenApi3);
+
+            Assert.True(parameter.Explode);
+            Assert.Equal(OpenApiParameterStyle.Form, parameter.Style);
+            Assert.Equal(OpenApiParameterCollectionFormat.Undefined, parameter.CollectionFormat);
+        }
+
+        [Fact]
+        public void CreatePrimitiveParameter_QueryStringArray_Swagger()
+        {
+            var parameter = GetParameter(SchemaType.Swagger2);
+
+            Assert.False(parameter.Explode);
+            Assert.Equal(OpenApiParameterStyle.Undefined, parameter.Style);
+            Assert.Equal(OpenApiParameterCollectionFormat.Multi, parameter.CollectionFormat);
+        }
+    }
+}

--- a/src/NSwag.Generation.Tests/OpenApiDocumentGeneratorTests.cs
+++ b/src/NSwag.Generation.Tests/OpenApiDocumentGeneratorTests.cs
@@ -9,7 +9,13 @@ namespace NSwag.Generation.Tests
 {
     public class OpenApiDocumentGeneratorTests
     {
-        public void HasArrayParameter(string[] foo) { }
+
+        public class TestController
+        {
+            public void HasArrayParameter(string[] foo)
+            {
+            }
+        }
 
         private OpenApiParameter GetParameter(SchemaType schemaType)
         {
@@ -20,7 +26,7 @@ namespace NSwag.Generation.Tests
             };
             var schemaResolver = new JsonSchemaResolver(new OpenApiDocument(), generatorSettings);
             var generator = new OpenApiDocumentGenerator(generatorSettings, schemaResolver);
-            var methodInfo = typeof(OpenApiDocumentGeneratorTests).GetMethod("HasArrayParameter");
+            var methodInfo = typeof(TestController).GetMethod("HasArrayParameter");
 
             return generator.CreatePrimitiveParameter("foo", "bar", methodInfo.GetContextualParameters().First());
         }

--- a/src/NSwag.Generation/OpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGenerator.cs
@@ -91,12 +91,6 @@ namespace NSwag.Generation
 
             operationParameter.Name = name;
             operationParameter.IsRequired = contextualParameter.ContextAttributes.FirstAssignableToTypeNameOrDefault("RequiredAttribute", TypeNameStyle.Name) != null;
-
-            if (typeDescription.Type.HasFlag(JsonObjectType.Array))
-            {
-                operationParameter.CollectionFormat = OpenApiParameterCollectionFormat.Multi;
-            }
-
             operationParameter.IsNullableRaw = typeDescription.IsNullable;
 
             if (description != string.Empty)
@@ -139,6 +133,12 @@ namespace NSwag.Generation
                 _settings.SchemaGenerator.ApplyDataAnnotations(operationParameter.Schema, typeDescription);
             }
 
+            if (typeDescription.Type.HasFlag(JsonObjectType.Array))
+            {
+                operationParameter.Style = OpenApiParameterStyle.Form;
+                operationParameter.Explode = true;
+            }
+
             return operationParameter;
         }
 
@@ -172,6 +172,11 @@ namespace NSwag.Generation
             {
                 operationParameter = _settings.SchemaGenerator.Generate<OpenApiParameter>(contextualParameter, _schemaResolver);
                 _settings.SchemaGenerator.ApplyDataAnnotations(operationParameter, typeDescription);
+            }
+
+            if (typeDescription.Type.HasFlag(JsonObjectType.Array))
+            {
+                operationParameter.CollectionFormat = OpenApiParameterCollectionFormat.Multi;
             }
 
             return operationParameter;


### PR DESCRIPTION
As mentioned here for OAS3 specification https://swagger.io/docs/specification/describing-parameters/#query-parameters

Query parameters no longer support `collectionFormat` and instead should use the `style` and `explode` properties to describe array type formatting

This fixes the issue for OAS3 documents while keeping the existing functionality for Swagger (OAS2) documents