### PR TITLE
Don't use DTO classes when generating interfaces

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -35,7 +35,11 @@ return response.blob().then(blob => { return { fileName: fileName, data: blob, s
 let result{{ response.StatusCode }}: any = null;
 {%         if Framework.IsAxios -%}
 let resultData{{ response.StatusCode }}  = _responseText;
+{%             if response.UseDtoClass -%}
 {{ response.DataConversionCode }}
+{%             else -%}
+result{{ response.StatusCode }} = JSON.parse(resultData{{ response.StatusCode }});
+{%             endif -%}
 {%         else -%}
 {%              if response.UseDtoClass or response.IsDateOrDateTime -%}
 let resultData{{ response.StatusCode }} = _responseText === "" ? null : {% if operation.HandleReferences %}jsonParse{% else %}JSON.parse{% endif %}(_responseText, this.jsonParseReviver);


### PR DESCRIPTION
Fixes #2341. The Typescript `DataConversionCode` [relies on a class to be generated](https://github.com/RicoSuter/NSwag/blob/85ae862fd6d68173a201a79e0ad06e0be2ec5de1/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGenerator.cs#L132). If there is no need to call this, as is the case when using interfaces, we can just parse the JSON result.