### PR TITLE
Merge 2xx responses with the same type (Issue #1259)

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
@@ -120,5 +120,69 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Assert.DoesNotContain("System.Threading.Tasks.Task<object>", code);
             Assert.Contains("class BusinessException", code);
         }
+
+        [Fact]
+        public async Task When_multiple_2xx_responses_of_same_type_they_are_merged_correctly()
+        {
+            // Arrange
+            var json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/v1/exceptions/get"": {
+      ""post"": {
+        ""operationId"": ""Exceptions_GetException"",
+        ""responses"": {
+          ""200"": {
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/BusinessException""
+                }
+              }
+            }
+          },
+          ""201"": {
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/BusinessException""
+                }
+              }
+            }
+          },
+          ""204"": {
+            ""description"":""No Content""
+          },
+          ""404"": {
+            ""description"":""Not Found""
+          }
+        }
+      }
+    }
+  }, 
+  ""components"": {
+    ""schemas"": {
+      ""BusinessException"": {
+        ""type"": ""object"",
+        ""additionalProperties"": false
+      }
+    }
+  }
+}";
+
+            // Act
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains(@"if (status_ == ""200"" || status_ == ""201"")", code);
+            Assert.Contains(@"if (status_ == ""204"")", code);
+            Assert.Contains(@"if (status_ == ""404"")", code);
+            Assert.Contains(@"if (status_ != ""200"" && status_ != ""204"")", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -263,7 +263,31 @@
                     ProcessResponse(client_, response_);
 
                     var status_ = ((int)response_.StatusCode).ToString();
-{%     for response in operation.Responses -%}
+{%     if operation.SameTypeSuccessResponses.size > 0 -%}
+                    if ({% for response in operation.SameTypeSuccessResponses -%}status_ == "{{ response.StatusCode }}"{% if response.CheckChunkedStatusCode %} || status_ == "206"{% endif %}{% if operation.SameTypeSuccessResponses.last.StatusCode != response.StatusCode %} || {% endif %}{% endfor -%}) 
+                    {   {% assign response = operation.SameTypeSuccessResponses.first %}
+                        {% template Client.Class.ProcessResponse %}
+                    }
+                    else
+{%     endif -%}
+{%     if operation.OtherSuccessResponses.size > 0 -%}
+                    if ({% for response in operation.OtherSuccessResponses -%}status_ == "{{ response.StatusCode }}"{% if response.CheckChunkedStatusCode %} || status_ == "206"{% endif %}{% if operation.OtherSuccessResponses.last.StatusCode != response.StatusCode %} || {% endif %}{% endfor -%}) 
+                    {
+{%         if operation.HasResultType -%}
+
+{%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
+                        return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, default({{ operation.UnwrappedResultType }})); 
+{%             else -%}
+                        return default({{ operation.UnwrappedResultType }});
+{%             endif -%}
+{%         elseif operation.WrapResponse -%}
+
+                        return new {{ ResponseClass }}((int)response_.StatusCode, headers_); 
+{%         endif -%}
+                    }
+                    else
+{%     endif -%}
+{%     for response in operation.OtherResponses -%}
                     if (status_ == "{{ response.StatusCode }}"{% if response.CheckChunkedStatusCode %} || status_ == "206"{% endif %}) 
                     {
                         {% template Client.Class.ProcessResponse %}

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    public class ResponseTests
+    {
+        [Fact]
+        public async Task When_multiple_2xx_responses_of_same_type_they_are_merged_correctly()
+        {
+            // Arrange
+            var json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/v1/exceptions/get"": {
+      ""post"": {
+        ""operationId"": ""Exceptions_GetException"",
+        ""responses"": {
+          ""200"": {
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/BusinessException""
+                }
+              }
+            }
+          },
+          ""201"": {
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/BusinessException""
+                }
+              }
+            }
+          },
+          ""204"": {
+            ""description"":""No Content""
+          },
+          ""404"": {
+            ""description"":""Not Found""
+          }
+        }
+      }
+    }
+  }, 
+  ""components"": {
+    ""schemas"": {
+      ""BusinessException"": {
+        ""type"": ""object"",
+        ""additionalProperties"": false
+      }
+    }
+  }
+}";
+            // Act
+            var document = await OpenApiDocument.FromJsonAsync(json);
+            var settings = new TypeScriptClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new TypeScriptClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("if (status === 200 || status === 201)", code);
+            Assert.Contains("else if (status === 204)", code);
+            Assert.Contains("else if (status === 404)", code);
+            Assert.Contains("else if (status !== 200 && status !== 204)", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
@@ -2,7 +2,15 @@
 {% if operation.HandleReferences and operation.RequiresMappings -%}
 let _mappings: { source: any, target: any }[] = [];
 {% endif -%}
-{% for response in operation.Responses -%}
+{% if operation.SameTypeSuccessResponses.size > 0 -%}
+if ({% for response in operation.SameTypeSuccessResponses -%}status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}{% if operation.SameTypeSuccessResponses.last.StatusCode != response.StatusCode %} || {% endif %}{% endfor -%}) { {% assign response = operation.SameTypeSuccessResponses.first %}
+    {% template Client.ProcessResponse.HandleStatusCode %}
+} else {% endif -%}
+{% if operation.OtherSuccessResponses.size > 0 -%}
+if ({% for response in operation.OtherSuccessResponses -%}status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}{% if operation.OtherSuccessResponses.last.StatusCode != response.StatusCode %} || {% endif %}{% endfor -%}) {
+    {% template Client.ProcessResponse.Return %}
+} else {% endif -%}
+{% for response in operation.OtherResponses  -%}
 if (status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}) {
     {% template Client.ProcessResponse.HandleStatusCode %}
 } else {% endfor -%}

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -160,6 +160,15 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets the success response.</summary>
         public TResponseModel SuccessResponse => Responses.FirstOrDefault(r => r.IsSuccess);
 
+        /// <summary>All IsSuccess responses</summary>
+        public IEnumerable<TResponseModel> SameTypeSuccessResponses => Responses.Where(r => r.IsSuccess).OrderBy(r => !r.IsPrimarySuccessResponse);
+
+        /// <summary>All 2xx responses with a different type</summary>
+        public IEnumerable<TResponseModel> OtherSuccessResponses => Responses.Where(r => r.IsOtherSuccess);
+
+        /// <summary>All other responses</summary>
+        public IEnumerable<TResponseModel> OtherResponses => Responses.Where(r => !r.IsSuccess && !r.IsOtherSuccess);
+
         /// <summary>Gets the responses.</summary>
         IEnumerable<ResponseModelBase> IOperationModel.Responses => Responses;
 

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -127,6 +127,27 @@ namespace NSwag.CodeGeneration.Models
             }
         }
 
+        /// <summary>Gets a value indicating whether this is a 2xx code with a different type from primary response.</summary>
+        public bool IsOtherSuccess
+        {
+            get
+            {
+                if (IsPrimarySuccessResponse)
+                {
+                    return false;
+                }
+
+                var primarySuccessResponse = _operationModel.Responses.FirstOrDefault(r => r.IsPrimarySuccessResponse);
+
+                if (primarySuccessResponse == null)
+                {
+                    return false;
+                }
+
+                return HttpUtilities.IsSuccessStatusCode(StatusCode) && primarySuccessResponse.Type != Type;
+            }
+        }
+
         /// <summary>Gets a value indicating whether this is an exceptional response.</summary>
         public bool ThrowsException => !IsSuccess;
 


### PR DESCRIPTION
I took a stab at #1259. 2xx responses with the same type as the primary success response are merged into a single block. Other 2xx responses use the fall through response. I ran the integration tests and from what I saw the output is the same as the current functionality when there is only a single 2xx response. Happy to make some changes if needed. Thanks!

Example generated code (From the two unit tests I added.)

C# Client

```csharp
...
var status_ = ((int)response_.StatusCode).ToString();
if (status_ == "200" || status_ == "201") 
{   
    var objectResponse_ = await ReadObjectResponseAsync<BusinessException>(response_, headers_).ConfigureAwait(false);
    return objectResponse_.Object;
}
else
if (status_ == "204") 
{

    return default(BusinessException);
}
else
if (status_ == "404") 
{
    string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
    throw new ApiException("Not Found", (int)response_.StatusCode, responseText_, headers_, null);
}
else
if (status_ != "200" && status_ != "204")
{
    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
    throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
}

return default(BusinessException);
...
```
TypeScript Client (Fetch)
```TypeScript 
...
if (status === 200 || status === 201) { 
    return response.text().then((_responseText) => {
    let result200: any = null;
    let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
    result200 = BusinessException.fromJS(resultData200);
    return result200;
    });
} else if (status === 204) {
    return Promise.resolve<BusinessException>(<any>null);
} else if (status === 404) {
    return response.text().then((_responseText) => {
    return throwException("Not Found", status, _responseText, _headers);
    });
} else if (status !== 200 && status !== 204) {
    return response.text().then((_responseText) => {
    return throwException("An unexpected server error occurred.", status, _responseText, _headers);
    });
}
return Promise.resolve<BusinessException>(<any>null);
...
```