### PR TITLE
Implement TypeScriptClientGeneratorSettings.UseLeafType

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/OperationParameterTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/OperationParameterTests.cs
@@ -2,9 +2,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using NJsonSchema;
-using NJsonSchema.Generation;
 using NSwag.Generation.WebApi;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NSwag.CodeGeneration.TypeScript.Tests
@@ -38,12 +40,16 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
         [Fact]
         public async Task When_query_parameter_is_enum_array_then_the_enum_is_referenced()
         {
+            var serializerSettings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> {new StringEnumConverter()}
+            };
+
             //// Arrange
             var settings = new WebApiOpenApiDocumentGeneratorSettings
             {
                 DefaultUrlTemplate = "api/{controller}/{action}/{id}",
-                DefaultEnumHandling = EnumHandling.String,
-                DefaultPropertyNameHandling = PropertyNameHandling.Default,
+                SerializerSettings = serializerSettings,
                 SchemaType = SchemaType.Swagger2,
             };
             var generator = new WebApiOpenApiDocumentGenerator(settings);

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -1,0 +1,91 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using NJsonSchema.CodeGeneration.TypeScript;
+using NJsonSchema.Converters;
+using NSwag.Generation.WebApi;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    public class TypeScriptDiscriminatorTests
+    {
+        [JsonConverter(typeof(JsonInheritanceConverter), "type")]
+        [KnownType(typeof(OneChild))]
+        [KnownType(typeof(SecondChild))]
+        public abstract class Base
+        {
+            public EBase Type { get; }
+        }
+
+        public enum EBase
+        {
+            OneChild,
+            SecondChild
+        }
+
+        public class OneChild : Base
+        {
+            public string A { get; }
+        }
+
+        public class SecondChild : Base
+        {
+            public string B { get; }
+        }
+
+        public class Nested
+        {
+            public Base Child { get; set; }
+        }
+
+        public class DiscriminatorController
+        {
+            [Route("foo")]
+            public string TestLeaf(Base param)
+            {
+                return null;
+            }
+            
+            [Route("bar")]
+            public string Test(OneChild param)
+            {
+                return null;
+            }
+            
+            [Route("baz")]
+            public string TestNested(Nested param)
+            {
+                return null;
+            }
+        }
+
+        [Fact]
+        public async Task When_parameter_is_abstract_then_generate_union()
+        {
+            //// Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<DiscriminatorController>();
+            var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                UseLeafType = true,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 1.4m,
+                    NullValue = TypeScriptNullValue.Undefined
+                }
+            });
+
+            var json = document.ToJson();
+
+            //// Act
+            var code = clientGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("test(param: OneChild)", code);
+            Assert.Contains("testLeaf(param: OneChild | SecondChild)", code);
+            Assert.Contains("child?: OneChild | SecondChild;", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptDiscriminatorTests.cs
@@ -69,9 +69,9 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             var document = await swaggerGenerator.GenerateForControllerAsync<DiscriminatorController>();
             var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
-                UseLeafType = true,
                 TypeScriptGeneratorSettings =
                 {
+                    UseLeafType = true,
                     TypeScriptVersion = 1.4m,
                     NullValue = TypeScriptNullValue.Undefined
                 }

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -178,6 +178,23 @@ namespace NSwag.CodeGeneration.TypeScript.Models
                 return "FileParameter";
             }
 
+            if (_settings.UseLeafType && schema.ActualDiscriminatorObject != null)
+            {
+                var types = schema.ActualDiscriminatorObject.Mapping
+                    .Select(x => new OpenApiParameter
+                    {
+                        Name = parameter.Name,
+                        Kind = parameter.Kind,
+                        IsRequired = parameter.IsRequired,
+                        IsNullableRaw = parameter.IsNullableRaw,
+                        Description = parameter.Description,
+                        Schema = x.Value
+                    })
+                    .Select(ResolveParameterType);
+
+                return string.Join(" | ", types);
+            }
+
             return base.ResolveParameterType(parameter);
         }
 

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -178,7 +178,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
                 return "FileParameter";
             }
 
-            if (_settings.UseLeafType && schema.ActualDiscriminatorObject != null)
+            if (_settings.TypeScriptGeneratorSettings.UseLeafType && schema.ActualDiscriminatorObject != null)
             {
                 var types = schema.ActualDiscriminatorObject.Mapping
                     .Select(x => new OpenApiParameter

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptParameterModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptParameterModel.cs
@@ -8,7 +8,6 @@
 
 using System.Collections.Generic;
 using NJsonSchema.CodeGeneration;
-using NJsonSchema.CodeGeneration.TypeScript;
 using NSwag.CodeGeneration.Models;
 
 namespace NSwag.CodeGeneration.TypeScript.Models

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -67,9 +67,6 @@ namespace NSwag.CodeGeneration.TypeScript
 
         /// <summary>Gets or sets the full name of the configuration class (<see cref="ClientBaseClass"/> must be set).</summary>
         public string ConfigurationClass { get; set; }
-        
-        /// <summary>Generate leaf types for an object with discriminator.</summary>
-        public bool UseLeafType { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to call 'transformOptions' on the base class or extension class.</summary>
         public bool UseTransformOptionsMethod { get; set; }

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -26,6 +26,7 @@ namespace NSwag.CodeGeneration.TypeScript
             PromiseType = PromiseType.Promise;
             BaseUrlTokenName = "API_BASE_URL";
             ImportRequiredTypes = true;
+            UseLeafType = false;
             QueryNullValue = "";
 
             TypeScriptGeneratorSettings = new TypeScriptGeneratorSettings
@@ -66,6 +67,9 @@ namespace NSwag.CodeGeneration.TypeScript
 
         /// <summary>Gets or sets the full name of the configuration class (<see cref="ClientBaseClass"/> must be set).</summary>
         public string ConfigurationClass { get; set; }
+        
+        /// <summary>Generate leaf types for an object with discriminator.</summary>
+        public bool UseLeafType { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to call 'transformOptions' on the base class or extension class.</summary>
         public bool UseTransformOptionsMethod { get; set; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -270,6 +270,13 @@ namespace NSwag.Commands.CodeGeneration
             get { return Settings.TypeScriptGeneratorSettings.EnumStyle; }
             set { Settings.TypeScriptGeneratorSettings.EnumStyle = value; }
         }
+        
+        [Argument(Name = "UseLeafType", IsRequired = false, Description = "Generate leaf types for an object with discriminator.")]
+        public bool UseLeafType
+        {
+            get { return Settings.TypeScriptGeneratorSettings.UseLeafType; }
+            set { Settings.TypeScriptGeneratorSettings.UseLeafType = value; }
+        }
 
         [Argument(Name = "ClassTypes", IsRequired = false, Description = "The type names which always generate plain TypeScript classes.")]
         public string[] ClassTypes

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -271,7 +271,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.TypeScriptGeneratorSettings.EnumStyle = value; }
         }
         
-        [Argument(Name = "UseLeafType", IsRequired = false, Description = "Generate leaf types for an object with discriminator.")]
+        [Argument(Name = "UseLeafType", IsRequired = false, Description = "Generate leaf types for an object with discriminator (default: false).")]
         public bool UseLeafType
         {
             get { return Settings.TypeScriptGeneratorSettings.UseLeafType; }

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
@@ -223,6 +223,12 @@
                                           ToolTip="TypeStyle"
                                           ItemsSource="{Binding EnumStyles}" Margin="0,0,0,12" />
 
+                                <CheckBox IsChecked="{Binding Command.UseLeafType, Mode=TwoWay}" 
+                                          ToolTip="UseLeafType" 
+                                          Margin="0,0,0,12">
+                                    <TextBlock Text="Generate leaf types for an object with discriminator" TextWrapping="Wrap" />
+                                </CheckBox>
+
                                 <TextBlock Text="Null value used in object initializers" FontWeight="Bold" Margin="0,0,0,6" />
                                 <ComboBox SelectedItem="{Binding Command.NullValue, Mode=TwoWay}" 
                                           ToolTip="NullValue"


### PR DESCRIPTION
This PR implement changes in NSwag related to https://github.com/RicoSuter/NJsonSchema/pull/1148.

It implements leaf types for client arguments. I do not think that leaf types can be useful for return types.

It can not pass before the NJsonSchema is updated.