### PR TITLE
Remove the exclamation mark to find embedded templates

### DIFF
--- a/src/NSwag.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NSwag.CodeGeneration/DefaultTemplateFactory.cs
@@ -36,6 +36,7 @@ namespace NSwag.CodeGeneration
         /// <returns>The template.</returns>
         protected override string GetEmbeddedLiquidTemplate(string language, string template)
         {
+            template = template.TrimEnd('!');
             var assembly = GetLiquidAssembly("NSwag.CodeGeneration." + language);
             var resourceName = "NSwag.CodeGeneration." + language + ".Templates." + template + ".liquid";
 


### PR DESCRIPTION
Hi @RicoSuter 

According to the PR created for NJsonSchema, I did the same for NSwag.
-> https://github.com/RicoSuter/NJsonSchema/pull/1150

Thanks!