### PR TITLE
Nullable query parameters

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptOperationParameterTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/TypeScriptOperationParameterTests.cs
@@ -8,10 +8,19 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
 {
     public class TypeScriptOperationParameterTests
     {
-        public class OptionalParameterController
+        public class NullableParameterController
         {
             [Route("foo")]
             public string Test(int a, int? b)
+            {
+                return null;
+            }
+        }
+
+        public class NullableOptionalParameterController
+        {
+            [Route("foo")]
+            public string Test(int a, int? b = null)
             {
                 return null;
             }
@@ -22,7 +31,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
         {
             //// Arrange
             var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
-            var document = await swaggerGenerator.GenerateForControllerAsync<OptionalParameterController>();
+            var document = await swaggerGenerator.GenerateForControllerAsync<NullableParameterController>();
             var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
                 TypeScriptGeneratorSettings =
@@ -39,6 +48,78 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
 
             //// Assert
             Assert.Contains("test(a: number, b: number | null)", code);
+        }
+
+        [Fact]
+        public async Task When_parameter_is_nullable_and_ts20_then_it_is_not_included_in_query_string()
+        {
+            //// Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<NullableParameterController>();
+            var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m,
+                    NullValue = TypeScriptNullValue.Undefined
+                }
+            });
+
+            var json = document.ToJson();
+
+            //// Act
+            var code = clientGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("else if(b !== null)", code);
+        }
+
+        [Fact]
+        public async Task When_parameter_is_nullable_optional_and_ts20_then_it_is_a_union_type_with_undefined()
+        {
+            //// Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<NullableOptionalParameterController>();
+            var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m,
+                    NullValue = TypeScriptNullValue.Undefined
+                }
+            });
+
+            var json = document.ToJson();
+
+            //// Act
+            var code = clientGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("test(a: number, b: number | null | undefined)", code);
+        }
+
+        [Fact]
+        public async Task When_parameter_is_nullable_optional_and_ts20_then_it_is_not_included_in_query_string()
+        {
+            //// Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<NullableOptionalParameterController>();
+            var clientGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m,
+                    NullValue = TypeScriptNullValue.Undefined
+                }
+            });
+
+            var json = document.ToJson();
+
+            //// Act
+            var code = clientGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("if (b !== undefined && b !== null)", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -25,7 +25,7 @@ else
 {%         if parameter.IsNullable -%}
 if ({{ parameter.VariableName }} === undefined)
     throw new Error("The parameter '{{ parameter.VariableName }}' must be defined.");
-else
+else if({{ parameter.VariableName }} !== null)
 {%         else -%}
 if ({{ parameter.VariableName }} === undefined || {{ parameter.VariableName }} === null)
     throw new Error("The parameter '{{ parameter.VariableName }}' must be defined and cannot be null.");
@@ -33,7 +33,7 @@ else
 {%         endif -%}
 {%     else -%}
 {%         if parameter.IsNullable -%}
-if ({{ parameter.VariableName }} !== undefined)
+if ({{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null)
 {%         else -%}
 if ({{ parameter.VariableName }} === null)
     throw new Error("The parameter '{{ parameter.VariableName }}' cannot be null.");

--- a/src/NSwag.Generation.WebApi.Tests/NSwag.Generation.WebApi.Tests.csproj
+++ b/src/NSwag.Generation.WebApi.Tests/NSwag.Generation.WebApi.Tests.csproj
@@ -143,7 +143,9 @@
     <Compile Include="OperationProcessors\ApiVersionProcessorWithWebApiTests.cs" />
     <Compile Include="Nullability\ParameterNullabilityTests.cs" />
     <Compile Include="Nullability\ResponseNullabilityTests.cs" />
+    <Compile Include="OperationProcessors\OpenApiQueryParametersOperationParameterProcessorTests.cs" />
     <Compile Include="OperationProcessors\SwaggerOperationProcessorAttributeTests.cs" />
+    <Compile Include="OperationProcessors\SwaggerQueryParametersOperationParameterProcessorTests.cs" />
     <Compile Include="RouteAttributeTests.cs" />
     <Compile Include="EnumTests.cs" />
     <Compile Include="FileParameterTests.cs" />

--- a/src/NSwag.Generation.WebApi.Tests/OperationProcessors/OpenApiQueryParametersOperationParameterProcessorTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/OperationProcessors/OpenApiQueryParametersOperationParameterProcessorTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace NSwag.Generation.WebApi.Tests.OperationProcessors
+{
+    [TestClass]
+    public class OpenApiQueryParametersOperationParameterProcessorTests
+    {
+        private class ComplexType
+        {
+            public int? IdInComplexType { get; set; }
+        }
+
+        private class TestController
+        {
+            [HttpGet]
+            [Route("getByPrimitive")]
+            public void GetByNullablePrimitiveType([FromUri] int? primitiveId)
+            {
+            }
+
+            [HttpGet]
+            [Route("getByReference")]
+            public void GetByReferenceTypeWithNullablePrimitiveType([FromUri] ComplexType complexType)
+            {
+            }
+        }
+
+        private WebApiOpenApiDocumentGenerator GetOpenApi3Generator()
+        {
+            WebApiOpenApiDocumentGeneratorSettings settings = new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.OpenApi3
+            };
+            WebApiOpenApiDocumentGenerator generator = new WebApiOpenApiDocumentGenerator(settings);
+
+            return generator;
+        }
+
+        [TestMethod]
+        public async Task When_nullable_primitive_query_parameter_exists_then_parameter_IsNullableRaw_is_null()
+        {
+            //// Arrange
+            WebApiOpenApiDocumentGenerator generator = this.GetOpenApi3Generator();
+
+            //// Act
+            OpenApiDocument document = await generator.GenerateForControllerAsync<TestController>();
+
+            OpenApiOperationDescription operationDescription = document.Operations.Single(o => 
+                o.Operation.OperationId.EndsWith(nameof(TestController.GetByNullablePrimitiveType)));
+                
+            OpenApiOperation operation = operationDescription.Operation;
+
+            //// Assert
+            Assert.IsNull(operation.Parameters.Single().IsNullableRaw);
+        }
+
+        [TestMethod]
+        public async Task When_complex_type_with_nullable_primitive_query_parameter_exists_then_parameter_IsNullableRaw_is_null()
+        {
+            //// Arrange
+            WebApiOpenApiDocumentGenerator generator = this.GetOpenApi3Generator();
+
+            //// Act
+            OpenApiDocument document = await generator.GenerateForControllerAsync<TestController>();
+
+            OpenApiOperationDescription operationDescription = document.Operations.Single(o =>
+                o.Operation.OperationId.EndsWith(nameof(TestController.GetByReferenceTypeWithNullablePrimitiveType)));
+
+            OpenApiOperation operation = operationDescription.Operation;
+
+            //// Assert
+            Assert.IsNull(operation.Parameters.Single().IsNullableRaw);
+        }
+    }
+}

--- a/src/NSwag.Generation.WebApi.Tests/OperationProcessors/SwaggerQueryParametersOperationParameterProcessorTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/OperationProcessors/SwaggerQueryParametersOperationParameterProcessorTests.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace NSwag.Generation.WebApi.Tests.OperationProcessors
+{
+    [TestClass]
+    public class SwaggerQueryParametersOperationParameterProcessorTests
+    {
+        private class ComplexType
+        {
+            public int? IdInComplexType { get; set; }
+        }
+
+        private class TestController
+        {
+            [HttpGet]
+            [Route("getByPrimitive")]
+            public void GetByNullablePrimitiveType([FromUri] int? primitiveId)
+            {
+            }
+
+            [HttpGet]
+            [Route("getByReference")]
+            public void GetByReferenceTypeWithNullablePrimitiveType([FromUri] ComplexType complexType)
+            {
+            }
+        }
+
+        private WebApiOpenApiDocumentGenerator GetOpenApi3Generator()
+        {
+            WebApiOpenApiDocumentGeneratorSettings settings = new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaType = SchemaType.Swagger2
+            };
+            WebApiOpenApiDocumentGenerator generator = new WebApiOpenApiDocumentGenerator(settings);
+
+            return generator;
+        }
+
+        [TestMethod]
+        public async Task When_nullable_primitive_query_parameter_exists_then_parameter_IsNullableRaw_is_true()
+        {
+            //// Arrange
+            WebApiOpenApiDocumentGenerator generator = this.GetOpenApi3Generator();
+
+            //// Act
+            OpenApiDocument document = await generator.GenerateForControllerAsync<TestController>();
+
+            OpenApiOperationDescription operationDescription = document.Operations.Single(o =>
+                o.Operation.OperationId.EndsWith(nameof(TestController.GetByNullablePrimitiveType)));
+
+            OpenApiOperation operation = operationDescription.Operation;
+
+            //// Assert
+            Assert.IsNotNull(operation.Parameters.Single().IsNullableRaw);
+            Assert.IsTrue(operation.Parameters.Single().IsNullableRaw.Value);
+        }
+
+        [TestMethod]
+        public async Task When_complex_type_with_nullable_primitive_query_parameter_exists_then_parameter_IsNullableRaw_is_true()
+        {
+            //// Arrange
+            WebApiOpenApiDocumentGenerator generator = this.GetOpenApi3Generator();
+
+            //// Act
+            OpenApiDocument document = await generator.GenerateForControllerAsync<TestController>();
+
+            OpenApiOperationDescription operationDescription = document.Operations.Single(o =>
+                o.Operation.OperationId.EndsWith(nameof(TestController.GetByReferenceTypeWithNullablePrimitiveType)));
+
+            OpenApiOperation operation = operationDescription.Operation;
+
+            //// Assert
+            Assert.IsNotNull(operation.Parameters.Single().IsNullableRaw);
+            Assert.IsTrue(operation.Parameters.Single().IsNullableRaw.Value);
+        }
+    }
+}

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -184,12 +184,7 @@ namespace NSwag.Generation.WebApi.Processors
                 {
                     operationParameter.Position = position;
                     position++;
-
-                    if (_settings.SchemaType == SchemaType.OpenApi3)
-                    {
-                        operationParameter.IsNullableRaw = null;
-                    }
-
+                    
                     ((Dictionary<ParameterInfo, OpenApiParameter>)context.Parameters)[contextualParameter.ParameterInfo] = operationParameter;
                 }
             }
@@ -210,10 +205,27 @@ namespace NSwag.Generation.WebApi.Processors
 
             RemoveUnusedPathParameters(context.OperationDescription, httpPath);
             UpdateConsumedTypes(context.OperationDescription);
+            UpdateNullableRawOperationParameters(context.OperationDescription, _settings.SchemaType);
 
             EnsureSingleBodyParameter(context.OperationDescription);
 
             return true;
+        }
+
+        /// <summary>
+        /// Sets the IsNullableRaw property of parameters to null for OpenApi3 schemas.
+        /// </summary>
+        /// <param name="operationDescription">Operation to check.</param>
+        /// <param name="schemaType">Schema type.</param>
+        private void UpdateNullableRawOperationParameters(OpenApiOperationDescription operationDescription, SchemaType schemaType)
+        {
+            if (schemaType == SchemaType.OpenApi3)
+            {
+                foreach (OpenApiParameter openApiParameter in operationDescription.Operation.Parameters)
+                {
+                    openApiParameter.IsNullableRaw = null;
+                }
+            }
         }
 
         private void EnsureSingleBodyParameter(OpenApiOperationDescription operationDescription)


### PR DESCRIPTION
### Description
These commits make a valid OpenAPI 3 specification when query parameters originate from a complex type and ignores parameters in the query string for TypeScript clients when their value is null.

### OpenAPI 3 specification
OpenAPI 3 parameter before fix:
- `{
            "name": "id",
            "in": "query",
            "schema": {
              "type": "integer",
              "format": "int32",
              "nullable": true
            },
            "nullable": true
}`

OpenAPI 3 parameter after fix (nullable on root level removed, which is invalid):
- `{
            "name": "id",
            "in": "query",
            "schema": {
              "type": "integer",
              "format": "int32",
              "nullable": true
            }
}`
### TypeScript client
Generated TypeScript query string before fix:
- `http://something.com/foo?parameter=null`
Generated TypeScript query string after fix: 
- `http://something.com/foo`
### Related issues
I believe these commits fix these issues:
- [Question regarding client TS generation and nullable query params](https://github.com/RicoSuter/NSwag/issues/2000)
- ["Null" string passed to controllers, despite option for custom null value](https://github.com/RicoSuter/NSwag/issues/1830)
