### PR TITLE
Use enums value (underlying type) rather than enum name

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -15,6 +15,8 @@
                     return attribute.Value != null ? attribute.Value : name;
                 }
             }
+			
+			return System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType())).ToString();
         }
     }
     else if (value is bool) {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -16,7 +16,7 @@
                 }
             }
 			
-			return System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType())).ToString();
+			return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
         }
     }
     else if (value is bool) {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -19,7 +19,8 @@
             return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
         }
     }
-    else if (value is bool) {
+    else if (value is bool) 
+    {
         return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
     }
     else if (value is byte[])

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -15,8 +15,8 @@
                     return attribute.Value != null ? attribute.Value : name;
                 }
             }
-			
-			return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+
+            return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
         }
     }
     else if (value is bool) {


### PR DESCRIPTION
For the enum 
```
[System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.11.0 (Newtonsoft.Json v12.0.0.2)")]
public enum CIPDownloadRequestEcad_model_required
{
    _0 = 0,
    _1 = 1,
    _2 = 2,
    _4 = 4,
    _7 = 7, 
}
```

produce the query string: `?ecad_model_required=0`
rather than: `?ecad_model_required=_0`

The api definition looks like so:
```
{
  "swagger": "2.0",
  "definitions": {
    "CIPDownloadRequest": {
      "type": "object",
      "properties": {
        "ecad_model_required": {
          "format": "int32",
          "enum": [
            0,
            1,
            2,
            4,
            7
          ],
          "type": "integer"
        }
      }
    }
  }
}
```
(full source: https://api.ultralibrarian.com/api-docs/v1/swagger.json)

String based enums use `EnumMemberAttribute` to determine which value to use, but other ones (number/int based) use `System.Convert.ToString(value, cultureInfo)` which uses the Enum name/label rather than the value. This PR addresses that by using the underlying value.