### PR TITLE
Fix build error when username contains space

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_NSwagCommand>$(NSwagExe)</_NSwagCommand>
     <_NSwagCommand
-        Condition="'$(MSBuildRuntimeType)' == 'Core'">dotnet --roll-forward-on-no-candidate-fx 2 $(NSwagDir_Core31)/dotnet-nswag.dll</_NSwagCommand>
+        Condition="'$(MSBuildRuntimeType)' == 'Core'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Core31)/dotnet-nswag.dll"</_NSwagCommand>
   </PropertyGroup>
 
   <!-- OpenApiReference support for C# -->


### PR DESCRIPTION
Fix for a failed build if username contains a space.

```
NSwag.ApiDescription.Client.targets(28,5): Unknown option: --roll-forward-on-no-candidate-fx
NSwag.ApiDescription.Client.targets(28,5): [MSB3073] The command "dotnet --roll-forward-on-no-candidate-fx 2 c:\Users\User Name\.nuget\packages\nswag.msbuild\13.2.5\build\../tools/NetCore31//dotnet-nswag.dll openapi2csclient ..." exited with code 1.
```