### PR TITLE
Support query params expansion when explode is true and style is form

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
@@ -1,0 +1,82 @@
+﻿using Xunit;
+
+namespace NSwag.CodeGeneration.CSharp.Tests
+{
+    public class QueryParameterTests
+    {
+        [Fact]
+        public void When_query_parameter_is_set_to_explode_and_style_is_form_object_parameters_are_expanded()
+        {
+            var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""1.0.0"",
+    ""title"": ""Query params tests""
+  },
+  ""servers"": [
+    {
+      ""url"": ""http://localhost:8080""
+    }
+  ],
+  ""paths"": {
+    ""/settings"": {
+      ""get"": {
+        ""summary"": ""List all settings"",
+        ""operationId"": ""listSettings"",
+        ""parameters"": [
+          {
+            ""name"": ""paging"",
+            ""in"": ""query"",
+            ""description"": ""list setting filter"",
+            ""required"": false,
+            ""style"": ""form"",
+            ""explode"": true,
+            ""schema"": {
+              ""$ref"": ""#/components/schemas/Paging""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""A paged array of settings""
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""Paging"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""page"": {
+            ""type"": ""integer"",
+            ""format"": ""int32""
+          },
+          ""limit"": {
+            ""type"": ""integer"",
+            ""format"": ""int32""
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+            var document = OpenApiDocument.FromJsonAsync(spec).Result;
+
+            //// Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"page\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(paging.Page, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+            Assert.Contains(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"limit\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(paging.Limit, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -27,6 +27,13 @@ if ({{parameter.Name}}.{{property.Name}} != null && {{parameter.Name}}.{{propert
     urlBuilder_.Append("&");
 }
 {%     endfor -%}
+{% elseif parameter.Explode and parameter.IsForm and parameter.IsObject -%}
+{%     for property in parameter.PropertyNames -%}
+if ({{parameter.Name}}.{{property.Name}} != null)
+{
+    urlBuilder_.Append(System.Uri.EscapeDataString("{{property.Key}}") + "=").Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+}
+{%     endfor -%}
 {% else -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% endif -%}

--- a/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
@@ -98,6 +98,9 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether the parameter is a deep object (OpenAPI 3).</summary>
         public bool IsDeepObject => _parameter.Style == OpenApiParameterStyle.DeepObject;
 
+        /// <summary>Gets a value indicating whether the parameter has form style.</summary>
+        public bool IsForm => _parameter.Style == OpenApiParameterStyle.Form;
+
         /// <summary>Gets the contained value property names (OpenAPI 3).</summary>
         public IEnumerable<PropertyModel> PropertyNames
         {
@@ -189,6 +192,9 @@ namespace NSwag.CodeGeneration.Models
         public bool IsObjectArray => IsArray &&
             (Schema.Item?.ActualSchema.Type == JsonObjectType.Object ||
              Schema.Item?.ActualSchema.IsAnyType == true);
+
+        /// <summary>Gets a value indicating whether the parameter is of type object</summary>
+        public bool IsObject => Schema.ActualSchema.Type == JsonObjectType.Object;
 
         /// <summary>Gets a value indicating whether the parameter is of type object.</summary>
         public bool IsBody => Kind == OpenApiParameterKind.Body;


### PR DESCRIPTION
According to the spec object properties should be serialized to query string parameters if `explode: true` and `style: form`:

https://swagger.io/docs/specification/serialization/#query

For example ` {"role": "admin", "firstName": "Alex"}` should be serialized as `/users?role=admin&firstName=Alex`

This should resolve #2807