### PR TITLE
Fixes #2820

### DIFF
--- a/src/NSwag.Core.Yaml.Tests/YamlDocumentTests.cs
+++ b/src/NSwag.Core.Yaml.Tests/YamlDocumentTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace NSwag.Core.Yaml.Tests
@@ -55,6 +56,34 @@ paths:
             Assert.NotNull(document);
             Assert.Equal("bar", document.Paths.First().Value.ExtensionData["x-swagger-router-controller"]);
             Assert.Contains("x-swagger-router-controller: bar", yaml);
+        }
+        
+        [Fact]
+        public async Task When_yaml_with_custom_property_which_is_an_object_is_loaded_then_document_is_not_null()
+        {
+          //// Arrange
+          var yaml = @"swagger: '2.0'
+info:
+  title: foo
+  version: '1.0'
+paths:
+  /bar:
+    x-swagger-router-controller:
+     bar: baz
+    get:
+      responses:
+        '200':
+          description: baz";
+
+          //// Act
+          var document = await OpenApiYamlDocument.FromYamlAsync(yaml);
+          yaml = document.ToYaml();
+
+          //// Assert
+          Assert.NotNull(document);
+          Assert.Equal(JObject.Parse(@"{""bar"": ""baz""}"), document.Paths.First().Value.ExtensionData["x-swagger-router-controller"]);
+          Assert.Equal("baz", document.Paths.First().Value["get"].Responses["200"].Description);
+          Assert.Contains("bar: baz", yaml);
         }
     }
 }

--- a/src/NSwag.Core.Yaml.Tests/YamlDocumentTests.cs
+++ b/src/NSwag.Core.Yaml.Tests/YamlDocumentTests.cs
@@ -57,7 +57,7 @@ paths:
             Assert.Equal("bar", document.Paths.First().Value.ExtensionData["x-swagger-router-controller"]);
             Assert.Contains("x-swagger-router-controller: bar", yaml);
         }
-        
+
         [Fact]
         public async Task When_yaml_with_custom_property_which_is_an_object_is_loaded_then_document_is_not_null()
         {

--- a/src/NSwag.Core/OpenApiPathItem.cs
+++ b/src/NSwag.Core/OpenApiPathItem.cs
@@ -60,7 +60,7 @@ namespace NSwag
         {
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
             {
-                var operations = (OpenApiPathItem)value;
+                var operations = (OpenApiPathItem) value;
                 writer.WriteStartObject();
 
                 if (operations.Summary != null)
@@ -105,7 +105,8 @@ namespace NSwag
                 writer.WriteEndObject();
             }
 
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                JsonSerializer serializer)
             {
                 if (reader.TokenType == JsonToken.Null)
                 {
@@ -120,38 +121,40 @@ namespace NSwag
 
                     if (propertyName == "summary")
                     {
-                        operations.Summary = (string)serializer.Deserialize(reader, typeof(string));
+                        operations.Summary = (string) serializer.Deserialize(reader, typeof(string));
                     }
                     else if (propertyName == "description")
                     {
-                        operations.Description = (string)serializer.Deserialize(reader, typeof(string));
+                        operations.Description = (string) serializer.Deserialize(reader, typeof(string));
                     }
                     else if (propertyName == "parameters")
                     {
-                        operations.Parameters = (Collection<OpenApiParameter>)serializer.Deserialize(reader, typeof(Collection<OpenApiParameter>));
+                        operations.Parameters =
+                            (Collection<OpenApiParameter>) serializer.Deserialize(reader,
+                                typeof(Collection<OpenApiParameter>));
                     }
                     else if (propertyName == "servers")
                     {
-                        operations.Servers = (Collection<OpenApiServer>)serializer.Deserialize(reader, typeof(Collection<OpenApiServer>));
+                        operations.Servers =
+                            (Collection<OpenApiServer>) serializer.Deserialize(reader,
+                                typeof(Collection<OpenApiServer>));
+                    }
+                    else if (propertyName.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (operations.ExtensionData == null)
+                        {
+                            operations.ExtensionData = new Dictionary<string, object>();
+                        }
+
+                        operations.ExtensionData[propertyName] = serializer.Deserialize(reader);
                     }
                     else
                     {
-                        try
-                        {
-                            var value = (OpenApiOperation)serializer.Deserialize(reader, typeof(OpenApiOperation));
-                            operations.Add(propertyName, value);
-                        }
-                        catch
-                        {
-                            if (operations.ExtensionData == null)
-                            {
-                                operations.ExtensionData = new Dictionary<string, object>();
-                            }
-
-                            operations.ExtensionData[propertyName] = serializer.Deserialize(reader);
-                        }
+                        var value = (OpenApiOperation) serializer.Deserialize(reader, typeof(OpenApiOperation));
+                        operations.Add(propertyName, value);
                     }
                 }
+
                 return operations;
             }
 

--- a/src/NSwag.Core/OpenApiPathItem.cs
+++ b/src/NSwag.Core/OpenApiPathItem.cs
@@ -60,7 +60,7 @@ namespace NSwag
         {
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
             {
-                var operations = (OpenApiPathItem) value;
+                var operations = (OpenApiPathItem)value;
                 writer.WriteStartObject();
 
                 if (operations.Summary != null)
@@ -105,8 +105,7 @@ namespace NSwag
                 writer.WriteEndObject();
             }
 
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-                JsonSerializer serializer)
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
                 if (reader.TokenType == JsonToken.Null)
                 {
@@ -121,23 +120,19 @@ namespace NSwag
 
                     if (propertyName == "summary")
                     {
-                        operations.Summary = (string) serializer.Deserialize(reader, typeof(string));
+                        operations.Summary = (string)serializer.Deserialize(reader, typeof(string));
                     }
                     else if (propertyName == "description")
                     {
-                        operations.Description = (string) serializer.Deserialize(reader, typeof(string));
+                        operations.Description = (string)serializer.Deserialize(reader, typeof(string));
                     }
                     else if (propertyName == "parameters")
                     {
-                        operations.Parameters =
-                            (Collection<OpenApiParameter>) serializer.Deserialize(reader,
-                                typeof(Collection<OpenApiParameter>));
+                        operations.Parameters = (Collection<OpenApiParameter>)serializer.Deserialize(reader, typeof(Collection<OpenApiParameter>));
                     }
                     else if (propertyName == "servers")
                     {
-                        operations.Servers =
-                            (Collection<OpenApiServer>) serializer.Deserialize(reader,
-                                typeof(Collection<OpenApiServer>));
+                        operations.Servers = (Collection<OpenApiServer>)serializer.Deserialize(reader, typeof(Collection<OpenApiServer>));
                     }
                     else if (propertyName.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
                     {
@@ -154,7 +149,6 @@ namespace NSwag
                         operations.Add(propertyName, value);
                     }
                 }
-
                 return operations;
             }
 


### PR DESCRIPTION
Fixes #2820

The problems is here: https://github.com/RicoSuter/NSwag/blob/872c1298248a0ec2c38cfdcc83088180f1c3b637/src/NSwag.Core/OpenApiPathItem.cs#L139-L152

The thing is that `JsonReader` is forward-only, you only have one shot at deserializing a fragment.

When the deserialization fails in the try block, there is no guarantee it can be retried in the catch block.

It kinda works when the reader points at a primitive (like a string or a number), which is a single token and is not really being advanced by the reader when the deserialization fails.

However if it's a complex thing, like an object, the reader advances to the end of the token (the trailing `}`) and further attempts at deserialization fail because the tokens are not balanced anymore. Hence the `Newtonsoft.Json.JsonSerializationException: Unexpected token while deserializing object: EndObject` in the error message.

I don't really think that catching the exception is the right way to deal with the specification extensions.

Once we are out of options handled earlier ("summary", "description" etc), it means that we are dealing either with an extension (which per specification is supposed to start with `x-`) or with a path operation (whose set of keys is a closed one)

Ideally we should treat everything that starts with an `x-` as an extension, and if it's not, it should be an operation.

We then should check that the operation is valid (is a `get`, `post` etc) and fail with a custom message if it's not.

But this might break backwards compatibility as some servers do allow crazy non-standard methods and people might be relying on them.

So I suggest a compromise: we check for `x-` in the prefix, and if we have it there, we treat it an extension. Otherwise we treat it as an operation and if `responses` and other required fields are not there, we let it throw and die of natural causes.

This also should fix #2649, although I didn't check it. 