### PR TITLE
Restore status validation, allow error response interception (axios)

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -69,9 +69,9 @@
         return this.instance.request(options_).catch((_error: any) => {
 {%     endif -%}
             if (isAxiosError(_error) && _error.response) {
-                return _error.response
+                return _error.response;
             } else {
-                throw _error
+                throw _error;
             }
         }).then((_response: AxiosResponse) => {
 {%     if UseTransformResultMethod -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -40,7 +40,6 @@
 
 {%     endif -%}
         let options_ = <AxiosRequestConfig>{
-            validateStatus: () => true,
 {%     if operation.HasBody -%}
             data: content_,
 {%     endif -%}
@@ -65,10 +64,16 @@
 {%     if UseTransformOptionsMethod -%}
         return this.transformOptions(options_).then(transformedOptions_ => {
             return this.instance.request(transformedOptions_);
-        }).then((_response: AxiosResponse) => {
+        }).catch((_error: any) => {
 {%     else -%}
-        return this.instance.request(options_).then((_response: AxiosResponse) => {
+        return this.instance.request(options_).catch((_error: any) => {
 {%     endif -%}
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response
+            } else {
+                throw _error
+            }
+        }).then((_response: AxiosResponse) => {
 {%     if UseTransformResultMethod -%}
             return this.transformResult(url_, _response, (_response: AxiosResponse) => this.process{{ operation.ActualOperationNameUpper }}(_response));
 {%     else -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -62,5 +62,10 @@ function blobToText(blob: Blob, q: ng.IQService): ng.IPromise<string> {
     });
 }
 
+{% elseif Framework.IsAxios -%}
+function isAxiosError(obj: any): obj is AxiosError {
+    return obj.isAxiosError === true;
+}
+
 {% endif -%}
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -44,7 +44,7 @@ import * as ng from 'angular';
 {%         endif -%}
 {%         if Framework.IsAxios -%}
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 {%         endif -%}
 {%         if Framework.IsKnockout -%}
 


### PR DESCRIPTION
PR for #2829.

#2806 prevents axios response interceptors from firing for error response codes (since no code was considered an error).

This change restores status validation and instead catches the response promise and continues if the error is an axios response error, otherwise it throws since the process method wouldn't be able to handle a non-response error anyway.

This allows axios interceptors to execute for error responses (such as retry logic, refreshing auth before re-trying, etc.) while still allowing the generated client process methods to process error responses in the same way as #2806.

Wouldn't mind getting some feedback on this, maybe @Tyrrrz or @MariuszKogut since they were involved in #2726 which kicked off the initial change.
