### PR TITLE
Add support for axios cancellation token

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
@@ -40,7 +40,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             //// Act
             var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
-                Template = TypeScriptTemplate.Fetch,
+                Template = TypeScriptTemplate.Axios,
                 GenerateClientInterfaces = true,
                 TypeScriptGeneratorSettings =
                 {
@@ -66,7 +66,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             //// Act
             var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
-                Template = TypeScriptTemplate.Fetch,
+                Template = TypeScriptTemplate.Axios,
                 GenerateClientInterfaces = true,
                 TypeScriptGeneratorSettings =
                 {
@@ -92,7 +92,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             //// Act
             var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
-                Template = TypeScriptTemplate.Fetch,
+                Template = TypeScriptTemplate.Axios,
                 TypeScriptGeneratorSettings =
                 {
                     TypeScriptVersion = 2.0m
@@ -104,6 +104,29 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             Assert.Contains("content_", code);
             Assert.DoesNotContain("FormData", code);
             Assert.Contains("\"Content-Type\": \"application/x-www-form-urlencoded\"", code);
+        }
+
+        [Fact]
+        public async Task Add_cancel_token_to_every_call()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+            var json = document.ToJson();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Axios,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("cancelToken?: CancelToken | undefined", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -32,7 +32,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}): Promise<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %} {% if operation.Parameters.size > 0 %},{%endif%} cancelToken?: CancelToken | undefined): Promise<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}
@@ -58,7 +58,8 @@
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 "Accept": "{{ operation.Produces }}"
 {%     endif -%}
-            }
+            },
+            cancelToken
         };
 
 {%     if UseTransformOptionsMethod -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -63,8 +63,8 @@ function blobToText(blob: Blob, q: ng.IQService): ng.IPromise<string> {
 }
 
 {% elseif Framework.IsAxios -%}
-function isAxiosError(obj: any): obj is AxiosError {
-    return obj.isAxiosError === true;
+function isAxiosError(obj: any | undefined): obj is AxiosError {
+    return obj && obj.isAxiosError === true;
 }
 
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -44,7 +44,7 @@ import * as ng from 'angular';
 {%         endif -%}
 {%         if Framework.IsAxios -%}
 
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
 {%         endif -%}
 {%         if Framework.IsKnockout -%}
 


### PR DESCRIPTION
Fixes #2844 

I have also noticed that src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs did not use the axios template. I have switched to axios to make sure, that everything works fine.

```
function isAxiosError(obj: any | undefined): obj is AxiosError {
  return obj && obj.isAxiosError === true
}
```

was tweaked, because I noticed, that the thrown error is undefined, if an ongoing was canceled.

Please let me know if I have to tweak something.

