### PR TITLE
Aligned OpenAPI code generation for file more with OpenAPI specification

### DIFF
--- a/src/NSwag.Generation.AspNetCore.Tests/Parameters/FormDataTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Parameters/FormDataTests.cs
@@ -72,6 +72,7 @@ namespace NSwag.Generation.AspNetCore.Tests.Parameters
           ""content"": {
             ""multipart/form-data"": {
               ""schema"": {
+                ""type"": ""object"",
                 ""properties"": {
                   ""Description"": {
                     ""type"": ""string"",

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -301,6 +301,7 @@ namespace NSwag.Generation.AspNetCore.Processors
             else
             {
                 var schema = CreateOrGetFormDataSchema(context);
+                schema.Type = JsonObjectType.Object;
                 schema.Properties[extendedApiParameter.ApiParameter.Name] = CreateFormDataProperty(context, extendedApiParameter, schema);
             }
         }


### PR DESCRIPTION
This PR modifies the multipart-form request for the request body schema to be an object instead of none, since this is more like the open api specification https://swagger.io/docs/specification/describing-request-body/file-upload/ 

This will also fix a problem with SwaggerUI where the browse button for file upload does not work, or does not appear. 