### PR TITLE
Added a `#nullable enable` directive

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -58,6 +58,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
             _settings.AdditionalContractNamespaceUsages?.Where(n => n != null).ToArray() :
             _settings.AdditionalNamespaceUsages?.Where(n => n != null).ToArray()) ?? new string[] { };
 
+        /// <summary>Gets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
+        public bool GenerateNullableReferenceTypes => _settings.CSharpGeneratorSettings.GenerateNullableReferenceTypes;
+
         /// <summary>Gets a value indicating whether to generate contract code.</summary>
         public bool GenerateContracts =>
             _outputType == ClientGeneratorOutputType.Full ||

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -107,6 +107,11 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether the operation has a result type.</summary>
         public bool HasResult => UnwrappedResultType != "void";
 
+        /// <summary>
+        /// The default value of the result type, i.e. default(T) or default(T)! depending on whether NRT are enabled.
+        /// </summary>
+        public string UnwrappedResultDefaultValue => $"default({UnwrappedResultType}){((_settings as CSharpClientGeneratorSettings)?.CSharpGeneratorSettings.GenerateNullableReferenceTypes == true ? "!" : "")}";
+
         /// <summary>Gets or sets the synchronous type of the result.</summary>
         public string SyncResultType
         {

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpTemplateModelBase.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpTemplateModelBase.cs
@@ -23,6 +23,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
             _settings = settings;
         }
 
+        /// <summary>Gets a value indicating whether the C#8 nullable reference types are enabled for this file.</summary>
+        public bool GenerateNullableReferenceTypes => _settings.CSharpGeneratorSettings.GenerateNullableReferenceTypes;
+
         /// <summary>Gets a value indicating whether to wrap success responses to allow full response access.</summary>
         public bool WrapResponses => _settings.WrapResponses;
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -1,8 +1,12 @@
-﻿private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+﻿{%              if GenerateNullableReferenceTypes -%}
+private string? ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
+{%              else -%}
+private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+{%              endif -%}
 {
     if (value is System.Enum)
     {
-        string name = System.Enum.GetName(value.GetType(), value);
+        var name = System.Enum.GetName(value.GetType(), value);
         if (name != null)
         {
             var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
@@ -21,7 +25,7 @@
     }
     else if (value is bool) 
     {
-        return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
+        return System.Convert.ToString(value, cultureInfo)?.ToLowerInvariant();
     }
     else if (value is byte[])
     {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -47,9 +47,9 @@ throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescri
 {% elseif response.IsSuccess -%}
 {%     if operation.HasResultType -%}
 {%         if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, default({{ operation.UnwrappedResultType }})); 
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%         else -%}
-return default({{ operation.UnwrappedResultType }});
+return {{ operation.UnwrappedResultDefaultValue }};
 {%         endif -%}
 {%     else -%}
 {%         if operation.WrapResponse -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -4,7 +4,11 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
 {
     if (response == null || response.Content == null)
     {
+{% if GenerateNullableReferenceTypes -%}
+        return new ObjectResponseResult<T>(default(T)!, string.Empty);
+{% else -%}
         return new ObjectResponseResult<T>(default(T), string.Empty);
+{% endif -%}
     }
 
     if (ReadResponseAsString)
@@ -13,7 +17,11 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         try
         {
             var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
+{% if GenerateNullableReferenceTypes -%}
+            return new ObjectResponseResult<T>(typedBody!, responseText);
+{% else -%}
             return new ObjectResponseResult<T>(typedBody, responseText);
+{% endif -%}
         }
         catch (Newtonsoft.Json.JsonException exception)
         {
@@ -31,7 +39,11 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
             {
                 var serializer = Newtonsoft.Json.JsonSerializer.Create({% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
                 var typedBody = serializer.Deserialize<T>(jsonTextReader);
+{% if GenerateNullableReferenceTypes -%}
+                return new ObjectResponseResult<T>(typedBody!, string.Empty);
+{% else -%}
                 return new ObjectResponseResult<T>(typedBody, string.Empty);
+{% endif -%}
             }
         }
         catch (Newtonsoft.Json.JsonException exception)

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -298,9 +298,9 @@
 {%         if operation.HasResultType -%}
         
 {%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
-                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, default({{ operation.UnwrappedResultType }})); 
+                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
 {%             else -%}
-                    return default({{ operation.UnwrappedResultType }});
+                    return {{ operation.UnwrappedResultDefaultValue }};
 {%             endif -%}
 {%         elseif operation.WrapResponse -%}
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -132,12 +132,20 @@ namespace {{ Namespace }}
     {
         public int StatusCode { get; private set; }
 
+{%              if GenerateNullableReferenceTypes -%}
+        public string? Response { get; private set; }
+{%              else -%}
         public string Response { get; private set; }
+{%              endif -%}
 
         public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
-        public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException) 
-            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + response.Substring(0, response.Length >= 512 ? 512 : response.Length), innerException)
+{%              if GenerateNullableReferenceTypes -%}
+        public {{ exceptionClassName }}(string message, int statusCode, string? response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception? innerException)
+{%              else -%}
+        public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException)
+{%              endif -%}
+            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + ((response == null) ? "(null)" : response.Substring(0, response.Length >= 512 ? 512 : response.Length)), innerException)
         {
             StatusCode = statusCode;
             Response = response; 
@@ -155,7 +163,11 @@ namespace {{ Namespace }}
     {
         public TResult Result { get; private set; }
 
-        public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException) 
+{%              if GenerateNullableReferenceTypes -%}
+        public {{ exceptionClassName }}(string message, int statusCode, string? response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception? innerException) 
+{%              else -%}
+        public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException)
+{%              endif -%}
             : base(message, statusCode, response, headers, innerException)
         {
             Result = result;

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -4,6 +4,10 @@
 // </auto-generated>
 //----------------------
 
+{% if GenerateNullableReferenceTypes -%}
+#nullable enable
+
+{% endif -%}
 {% for usage in NamespaceUsages -%}
 using {{ usage }};
 {% endfor -%}


### PR DESCRIPTION
Added a #nullable enable directive in generated C# source only if GenerateNullableReferenceTypes is set to true.

Added nullable reference annotations for generated code if needed.

Related to https://github.com/RicoSuter/NJsonSchema/pull/1201