### PR TITLE
Axios Safe JSON parsing

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
@@ -2,6 +2,8 @@
 using Xunit;
 using NSwag.Generation.WebApi;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Globalization;
 
 namespace NSwag.CodeGeneration.TypeScript.Tests
 {
@@ -17,6 +19,12 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             [HttpPost]
             public void AddMessage([FromBody]Foo message)
             {
+            }
+
+            [HttpGet]
+            public Foo GetMessage([FromBody] int id)
+            {
+                throw new NotImplementedException();
             }
         }
         
@@ -127,6 +135,54 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
 
             //// Assert
             Assert.Contains("cancelToken?: CancelToken | undefined", code);
+        }
+        
+        [Fact]
+        public async Task When_typestyle_is_interface_without_handlereferences_will_have_parse_trycatch()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<DiscussionController>();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Axios,
+                PromiseType = PromiseType.Promise,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeStyle = NJsonSchema.CodeGeneration.TypeScript.TypeScriptTypeStyle.Interface,
+                    HandleReferences = false
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("try { resultData200 =", code);
+        }
+
+        [Fact]
+        public async Task When_typestyle_is_interface_with_handlereferences_will_have_jsonParse()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<DiscussionController>();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Axios,
+                PromiseType = PromiseType.Promise,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeStyle = NJsonSchema.CodeGeneration.TypeScript.TypeScriptTypeStyle.Interface,
+                    HandleReferences = true
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("jsonParse(", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -37,8 +37,11 @@ let result{{ response.StatusCode }}: any = null;
 let resultData{{ response.StatusCode }}  = _responseText;
 {%             if response.UseDtoClass -%}
 {{ response.DataConversionCode }}
+{%             elseif operation.HandleReferences -%}
+resultData{{ response.StatusCode }} = _responseText === "" ? null : <{{ response.Type }}>jsonParse(_responseText, this.jsonParseReviver);
 {%             else -%}
-result{{ response.StatusCode }} = JSON.parse(resultData{{ response.StatusCode }});
+try { resultData{{ response.StatusCode }} = (_responseText === "" ? null : <{{ response.Type }}>JSON.parse(_responseText, this.jsonParseReviver)); } 
+catch(err) { resultData{{ response.StatusCode }} = _responseText; }
 {%             endif -%}
 {%         else -%}
 {%              if response.UseDtoClass or response.IsDateOrDateTime -%}


### PR DESCRIPTION
JSON.parse will throw on any input that isn't a string. Interceptors may change the data to return as a valid JS object/array/etc even if the client instance was controlled enough to ensure that every returned response data point is a JSON parseable string.

While not perfect, it will simply return the object it has in the case that it throws an error. This update also adds in the jsonParse function call for HandleReferences in case an override wants to be provided though code.

One mention of the issue here. https://github.com/RicoSuter/NSwag/commit/5d548d7b88f49c073bdd9e5296ee069cfdd3dba2#r37786449