### PR TITLE
Reworked C# client response handling

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -5,7 +5,7 @@ private string? ConvertToString(object? value, System.Globalization.CultureInfo 
 private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
 {%              endif -%}
 {
-    if (value is null)
+    if (value == null)
     {
         return null;
     }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -1,9 +1,15 @@
 ﻿{%              if GenerateNullableReferenceTypes -%}
+[return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
 private string? ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
 {%              else -%}
 private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
 {%              endif -%}
 {
+    if (value is null)
+    {
+        return null;
+    }
+
     if (value is System.Enum)
     {
         var name = System.Enum.GetName(value.GetType(), value);
@@ -25,17 +31,18 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
     }
     else if (value is bool) 
     {
-        return System.Convert.ToString(value, cultureInfo)?.ToLowerInvariant();
+        return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
     }
     else if (value is byte[])
     {
         return System.Convert.ToBase64String((byte[]) value);
     }
-    else if (value != null && value.GetType().IsArray)
+    else if (value.GetType().IsArray)
     {
         var array = System.Linq.Enumerable.OfType<object>((System.Array) value);
         return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
     }
 
-    return System.Convert.ToString(value, cultureInfo);
+    var result = System.Convert.ToString(value, cultureInfo);
+    return (result is null) ? string.Empty : result;
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -7,7 +7,7 @@ client_ = null; response_ = null; // response and client are disposed by FileRes
 return fileResponse_;
 {%         else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_).ConfigureAwait(false);
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object);
+throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
 {%         endif -%}
 {%     elsif response.IsPlainText -%}
 var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -21,6 +21,12 @@ return result_;
 {%         endif -%}
 {%     else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_).ConfigureAwait(false);
+{%         if response.IsNullable == false -%}
+if (objectResponse_.Object == null)
+{
+    throw new {{ ExceptionClass }}("Response was null, but return type is not declared as nullable", status_, objectResponse_.Text, headers_, null);
+}
+{%         endif -%}
 {%         if response.IsSuccess -%}
 {%             if operation.WrapResponse -%}
 return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, objectResponse_.Object); 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -2,19 +2,19 @@
 {%     if response.IsFile -%}
 {%         if response.IsSuccess -%}
 var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
-var fileResponse_ = new FileResponse((int)response_.StatusCode, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
+var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
 client_ = null; response_ = null; // response and client are disposed by FileResponse
 return fileResponse_;
 {%         else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_).ConfigureAwait(false);
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object);
+throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object);
 {%         endif -%}
 {%     elsif response.IsPlainText -%}
 var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
 var result_ = ({{ response.Type }})System.Convert.ChangeType(responseData_, typeof({{ response.Type }}));
 {%         if response.IsSuccess -%}
 {%             if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, result_); 
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_); 
 {%             else -%}
 return result_; 
 {%             endif -%}
@@ -23,7 +23,7 @@ return result_;
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_).ConfigureAwait(false);
 {%         if response.IsSuccess -%}
 {%             if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, objectResponse_.Object); 
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, objectResponse_.Object); 
 {%             else -%}
 return objectResponse_.Object; 
 {%             endif -%}
@@ -31,34 +31,34 @@ return objectResponse_.Object;
 {%         if response.IsSuccess == false -%}
 {%             if response.InheritsExceptionSchema -%}
 var responseObject_ = objectResponse_.Object != null ? objectResponse_.Object : new {{ response.Type }}();
-responseObject_.Data.Add("HttpStatus", status_);
+responseObject_.Data.Add("HttpStatus", status_.ToString());
 responseObject_.Data.Add("HttpHeaders", headers_);
 responseObject_.Data.Add("HttpResponse", objectResponse_.Text);
 {%                 if WrapDtoExceptions -%}
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, objectResponse_.Text, headers_, responseObject_);
+throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, responseObject_);
 {%                 else -%}
 throw responseObject_;
 {%                 endif -%}
 {%             else -%}
-throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
 {%             endif -%}
 {%         endif -%}
 {%     endif -%}
 {% elseif response.IsSuccess -%}
 {%     if operation.HasResultType -%}
 {%         if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, {{ operation.UnwrappedResultDefaultValue }});
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%         else -%}
 return {{ operation.UnwrappedResultDefaultValue }};
 {%         endif -%}
 {%     else -%}
 {%         if operation.WrapResponse -%}
-return new {{ ResponseClass }}((int)response_.StatusCode, headers_); 
+return new {{ ResponseClass }}(status_, headers_); 
 {%         else -%}
 return;
 {%         endif -%}
 {%     endif -%}
 {% else -%}{% comment %} implied: `if !response.HasType` so just read it as text {% endcomment %}
 string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, responseText_, headers_, null);
+throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, responseText_, headers_, null);
 {% endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -24,7 +24,7 @@ var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(respons
 {%         if response.IsNullable == false -%}
 if (objectResponse_.Object == null)
 {
-    throw new {{ ExceptionClass }}("Response was null, but return type is not declared as nullable", status_, objectResponse_.Text, headers_, null);
+    throw new {{ ExceptionClass }}("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
 }
 {%         endif -%}
 {%         if response.IsSuccess -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -7,7 +7,7 @@ urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Ap
 {% elseif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% elseif parameter.IsArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString((item_ != null) ? item_ : "", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append((item_ == null) ? "" : System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% elseif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
@@ -21,7 +21,7 @@ if ({{parameter.Name}}.{{property.Name}} != null && {{parameter.Name}}.{{propert
     urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]") + "=");
     foreach (var p_ in {{parameter.Name}}.{{property.Name}})
     {
-        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString((p_ != null) ? p_ : "", System.Globalization.CultureInfo.InvariantCulture))).Append(",");
+        urlBuilder_.Append((p_ == null) ? "" : System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(",");
     }
     urlBuilder_.Length--;
     urlBuilder_.Append("&");

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -7,7 +7,7 @@ urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Ap
 {% elseif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% elseif parameter.IsArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString((item_ != null) ? item_ : "", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% elseif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
@@ -21,7 +21,7 @@ if ({{parameter.Name}}.{{property.Name}} != null && {{parameter.Name}}.{{propert
     urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]") + "=");
     foreach (var p_ in {{parameter.Name}}.{{property.Name}})
     {
-        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(",");
+        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString((p_ != null) ? p_ : "", System.Globalization.CultureInfo.InvariantCulture))).Append(",");
     }
     urlBuilder_.Length--;
     urlBuilder_.Append("&");

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -267,9 +267,9 @@
 
                     ProcessResponse(client_, response_);
 
-                    var status_ = ((int)response_.StatusCode).ToString();
+                    var status_ = (int)response_.StatusCode;
 {%     for response in operation.Responses -%}
-                    if (status_ == "{{ response.StatusCode }}"{% if response.CheckChunkedStatusCode %} || status_ == "206"{% endif %}) 
+                    if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
                     {
                         {% template Client.Class.ProcessResponse %}
                     }
@@ -284,28 +284,44 @@
 {%         elseif operation.HasSuccessResponse -%}
                     {
                         var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                        throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", (int)response_.StatusCode, responseData_, headers_, null);
+                        throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", status_, responseData_, headers_, null);
                     }
-{%         endif -%}
-{%     else -%}
-                    if (status_ != "200" && status_ != "204")
-                    {
-                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                        throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
-                    }
-{%     endif -%}
-{%     if operation.HasDefaultResponse == false or (operation.DefaultResponse.HasType == false and operation.HasSuccessResponse == false) -%}
-{%         if operation.HasResultType -%}
-        
+{%        elseif operation.HasResultType -%}
 {%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
-                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>((int)response_.StatusCode, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
+                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
 {%             else -%}
                     return {{ operation.UnwrappedResultDefaultValue }};
 {%             endif -%}
 {%         elseif operation.WrapResponse -%}
-
-                    return new {{ ResponseClass }}((int)response_.StatusCode, headers_); 
+                    return new {{ ResponseClass }}(status_, headers_); 
 {%         endif -%}
+{%     else -%}
+{%         if operation.HasSuccessResponse == false -%}
+{% comment %} 
+    If the success response has already been explicitely declared, there is no need for this default code (because handled above).
+    Otherwise, return default values on success because we don't want to throw on "unknown status code".
+    Success is always expected
+{% endcomment -%}
+                    if (status_ == 200 || status_ == 204)
+                    {
+{%             if operation.HasResultType -%}
+{%                 if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
+                        return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
+{%                 else -%}
+                        return {{ operation.UnwrappedResultDefaultValue }};
+{%                 endif -%}
+{%             elseif operation.WrapResponse -%}
+                        return new {{ ResponseClass }}(status_, headers_); 
+{%             else -%}{% comment %} This method isn't expected to return a value. Just return. {% endcomment -%}
+                        return;
+{%             endif -%}
+                    }
+                    else
+{%         endif -%}
+                    {
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                        throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                    }
 {%     endif -%}
                 }
                 finally

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -32,16 +32,24 @@ namespace {{ Namespace }}
     public partial class FileParameter
     {
         public FileParameter(System.IO.Stream data)
-            : this (data, null)
+            : this (data, null, null)
         {
         }
 
+{%          if GenerateNullableReferenceTypes -%}
+        public FileParameter(System.IO.Stream data, string? fileName)
+{%          else -%}
         public FileParameter(System.IO.Stream data, string fileName)
+{%          endif -%}
             : this (data, fileName, null)
         {
         }
 
+{%          if GenerateNullableReferenceTypes -%}
+        public FileParameter(System.IO.Stream data, string? fileName, string? contentType)
+{%          else -%}
         public FileParameter(System.IO.Stream data, string fileName, string contentType)
+{%          endif -%}
         {
             Data = data;
             FileName = fileName;
@@ -50,9 +58,15 @@ namespace {{ Namespace }}
 
         public System.IO.Stream Data { get; private set; }
 
+{%          if GenerateNullableReferenceTypes -%}
+        public string? FileName { get; private set; }
+
+        public string? ContentType { get; private set; }
+{%          else -%}
         public string FileName { get; private set; }
 
         public string ContentType { get; private set; }
+{%          endif -%}
     }
 
 {%     endif -%}
@@ -60,8 +74,13 @@ namespace {{ Namespace }}
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
     public partial class FileResponse : System.IDisposable
     {
-        private System.IDisposable _client; 
-        private System.IDisposable _response; 
+{%          if GenerateNullableReferenceTypes -%}
+        private System.IDisposable? _client;
+        private System.IDisposable? _response;
+{%          else -%}
+        private System.IDisposable _client;
+        private System.IDisposable _response;
+{%          endif -%}
 
         public int StatusCode { get; private set; }
 
@@ -74,7 +93,11 @@ namespace {{ Namespace }}
             get { return StatusCode == 206; }
         }
 
+{%          if GenerateNullableReferenceTypes -%}
+        public FileResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.IO.Stream stream, System.IDisposable? client, System.IDisposable? response)
+{%          else -%}
         public FileResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.IO.Stream stream, System.IDisposable client, System.IDisposable response)
+{%          endif -%}
         {
             StatusCode = statusCode; 
             Headers = headers; 
@@ -85,8 +108,7 @@ namespace {{ Namespace }}
 
         public void Dispose() 
         {
-            if (Stream != null)
-                Stream.Dispose();
+            Stream.Dispose();
             if (_response != null)
                 _response.Dispose();
             if (_client != null)
@@ -164,7 +186,7 @@ namespace {{ Namespace }}
         public TResult Result { get; private set; }
 
 {%              if GenerateNullableReferenceTypes -%}
-        public {{ exceptionClassName }}(string message, int statusCode, string? response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception? innerException) 
+        public {{ exceptionClassName }}(string message, int statusCode, string? response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception? innerException)
 {%              else -%}
         public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException)
 {%              endif -%}


### PR DESCRIPTION
This PR reworks how the response parsing works in the generated C# client:

- Keeps `status_` as an `int`, instead of applying `.ToString()` and comparing strings.
- Uses the `status_` where `(int)response_.StatusCode` was used
- Reordered code in the if/else sequence, fixes #2944 (see below)

Before:
```cs
var status_ = ((int)response_.StatusCode).ToString();
if (status_ == "200") 
{
    var objectResponse_ = await ReadObjectResponseAsync<ApiModel>(response_, headers_).ConfigureAwait(false);
    return objectResponse_.Object;
}
else
if (status_ != "200" && status_ != "204")
{
    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
    throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
}

return default(ApiModel)!
```

The status code 200 was controlled twice, and `default(ApiModel)!` was returned while a null was not expected (#2944 )

The new code looks like this:

```cs
var status_ = (int)response_.StatusCode;
if (status_ == 200)
{
    var objectResponse_ = await ReadObjectResponseAsync<ApiModel>(response_, headers_).ConfigureAwait(false);
    return objectResponse_.Object;
}
else
{
    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
    throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
}
```

now, the `else` is the default case where the "unexpected HTTP status code" exception is thrown. There is no need to `return default(T)!;` anymore.


I tried to be careful not to break things, and as far as I know, there is only one thing that might break:
If there is an explicit success status code declared in the openApi definition, the `else if (status_ == 200 || status_ == 204)` that returns a `default(T)!` (or a wrapped instance) is not written anymore, and it will fall in the default `else` case.
In that case where a 200 is declared, but the server returns a 204 (undeclared), the code will no longer return `null` but will throw an "unexpected HTTP status code". I'd argue that this is cleaner and, in fact, expected : the fix is to declare the 204 on the server side.
