### PR TITLE
Fix for File Parameter interface not generated in some instances

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/BinaryTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/BinaryTests.cs
@@ -58,7 +58,7 @@ components:
         }
 
         [Fact]
-        public async Task WhenSpecContainsFormData_ThenFormDataIsUsedInTypeScript()
+        public async Task WhenSpecContainsFormDataInSingleMultipartFile_ThenFormDataIsUsedInTypeScript()
         {
             var json = @"{
   ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
@@ -106,6 +106,35 @@ components:
         }
       }
     },
+    
+  },
+  ""components"": {}
+}";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings());
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("const content_ = new FormData();", code);
+            Assert.Contains("interface FileParameter", code);
+            Assert.Contains("content_.append(\"file\", file.data, file.fileName ? file.fileName : \"file\");", code);
+        }
+
+
+        [Fact]
+        public async Task WhenSpecContainsFormDataInMultipartFileArray_ThenFormDataIsUsedInTypeScript()
+        {
+            var json = @"{
+  ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""My Title"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
     ""/api/FileUpload/UploadFiles"": {
       ""post"": {
         ""tags"": [
@@ -147,6 +176,34 @@ components:
         }
       }
     },
+    
+  },
+  ""components"": {}
+}";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings());
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("const content_ = new FormData();", code);
+            Assert.Contains("interface FileParameter", code);
+            Assert.Contains("content_.append(\"files\", item_.data, item_.fileName ? item_.fileName : \"files\")", code);
+        }
+
+        [Fact]
+        public async Task WhenSpecContainsFormDataInNestedMultipartForm_ThenFormDataIsUsedInTypeScript()
+        {
+            var json = @"{
+  ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""title"": ""My Title"",
+    ""version"": ""1.0.0""
+  },
+  ""paths"": {
     ""/api/FileUpload/UploadAttachment"": {
       ""post"": {
         ""tags"": [
@@ -212,7 +269,8 @@ components:
             //// Assert
             Assert.Contains("const content_ = new FormData();", code);
             Assert.Contains("interface FileParameter", code);
-            Assert.Contains("content_.append(\"file\", file.data, file.fileName ? file.fileName : \"file\");", code);
+            Assert.Contains("content_.append(\"Contents\", contents.data, contents.fileName ? contents.fileName : \"Contents\");", code);
         }
+
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -127,7 +127,11 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         public bool RequiresFileParameterInterface =>
             !_settings.TypeScriptGeneratorSettings.ExcludedTypeNames.Contains("FileParameter") &&
             (_document.Operations.Any(o => o.Operation.ActualParameters.Any(p => p.ActualTypeSchema.IsBinary)) ||
-             _document.Operations.Any(o => o.Operation?.RequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true || c.Value.Schema?.ActualProperties.Any(p => p.Value.IsBinary) == true) == true));
+             _document.Operations.Any(o => o.Operation?.RequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true || 
+                                                                                       c.Value.Schema?.ActualProperties.Any(p => p.Value.IsBinary || 
+                                                                                                                                 p.Value.Item?.IsBinary == true ||
+                                                                                                                                 p.Value.Items.Any(i => i.IsBinary)
+                                                                                                                                 ) == true) == true));
 
         /// <summary>Gets a value indicating whether the FileResponse interface should be rendered.</summary>
         public bool RequiresFileResponseInterface =>


### PR DESCRIPTION
- Split the Binary tests into 3 so each endpoint can be generated properly without missing the FileParameter interface
- changed RequiresFileParameterInterface logic so it checks isBinary on arrays and nested objects

Fixes [#2973](https://github.com/RicoSuter/NSwag/issues/2973)