### PR TITLE
Added option to use standard C# naming conventions (and more)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ src/packages/**
 .editorconfig
 /samples/packages
 /src/NSwag.Console/Properties/launchSettings.json
+
+# Ignore files from JetBrainds Rider
+/src/.idea/

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -29,6 +29,7 @@ namespace NSwag.CodeGeneration.CSharp
             UseRequestAndResponseSerializationSettings = false;
             QueryNullValue = "";
             GenerateBaseUrlProperty = true;
+            DecorateAsyncMethods = true;
             ExposeJsonSerializerSettings = false;
             InjectHttpClient = true;
             ProtectedMethods = new string[0];
@@ -78,6 +79,9 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether to generate synchronous methods (not recommended, default: false).</summary>
         public bool GenerateSyncMethods { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether to decorate Async methods with the Async suffix.</summary>
+        public bool DecorateAsyncMethods { get; set; }
 
         /// <summary>
         /// Gets or sets the HttpClient type which will be used in the generation of the client code. By default the System.Net.Http.HttpClient

--- a/src/NSwag.CodeGeneration.CSharp/CSharpEnumNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpEnumNameGenerator.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------
+// <copyright file="SwaggerToCSharpGeneratorSettings.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+//     Copyright (c) AMain.com. All rights reserved.
+// </copyright>
+// <license>https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+// <author>Kendall Bennett, kendallb@amain.com</author>
+//-----------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>
+    /// Custom enum name generator to not have underscores in the name
+    /// </summary>
+    public class CSharpEnumNameGenerator : IEnumNameGenerator
+    {
+        private static readonly Regex InvalidNameCharactersPattern = new Regex(@"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]");
+
+        /// <summary>Generates the enumeration name/key of the given enumeration entry.</summary>
+        /// <param name="index">The index of the enumeration value (check <see cref="JsonSchema.Enumeration" /> and <see cref="JsonSchema.EnumerationNames" />).</param>
+        /// <param name="name">The name/key.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="schema">The schema.</param>
+        /// <returns>The enumeration name.</returns>
+        public string Generate(int index, string name, object value, JsonSchema schema)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return "Empty";
+            }
+
+            switch (name)
+            {
+                case "=":
+                    name = "Eq";
+                    break;
+                case "!=":
+                    name = "Ne";
+                    break;
+                case ">":
+                    name = "Gt";
+                    break;
+                case "<":
+                    name = "Lt";
+                    break;
+                case ">=":
+                    name = "Ge";
+                    break;
+                case "<=":
+                    name = "Le";
+                    break;
+                case "~=":
+                    name = "Approx";
+                    break;
+            }
+
+            if (name.StartsWith("-"))
+            {
+                name = "Minus" + name.Substring(1);
+            }
+
+            if (name.StartsWith("+"))
+            {
+                name = "Plus" + name.Substring(1);
+            }
+
+            if (name.StartsWith("_-"))
+            {
+                name = "__" + name.Substring(2);
+            }
+
+            return InvalidNameCharactersPattern.Replace(ConversionUtilities.ConvertToUpperCamelCase(name
+                .Replace(":", "-").Replace(@"""", @"").Replace('_', '-'), true), "_");
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
@@ -6,17 +6,19 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Reflection;
 using Newtonsoft.Json;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
 using NJsonSchema.CodeGeneration.CSharp;
-using System.Reflection;
 
 namespace NSwag.CodeGeneration.CSharp
 {
     /// <summary>Settings for the <see cref="CSharpGeneratorBase"/>.</summary>
     public abstract class CSharpGeneratorBaseSettings : ClientGeneratorBaseSettings
     {
+        private bool _cSharpNamingConvention;
+
         /// <summary>Initializes a new instance of the <see cref="CSharpClientGeneratorSettings"/> class.</summary>
         protected CSharpGeneratorBaseSettings()
         {
@@ -48,6 +50,22 @@ namespace NSwag.CodeGeneration.CSharp
         /// <summary>Gets the code generator settings.</summary>
         [JsonIgnore]
         public override CodeGeneratorSettingsBase CodeGeneratorSettings => CSharpGeneratorSettings;
+
+        /// <summary>Gets or sets a value indicating whether to generate C# style naming (default: false).</summary>
+        public bool CSharpNamingConvention
+        {
+            get => _cSharpNamingConvention;
+            set
+            {
+                _cSharpNamingConvention = value;
+
+                // Install the C# style name generators if desired
+                if (!_cSharpNamingConvention) return;
+                CSharpGeneratorSettings.PropertyNameGenerator = new CSharpPropertyNameGenerator();
+                CSharpGeneratorSettings.TypeNameGenerator = new CSharpTypeNameGenerator();
+                CSharpGeneratorSettings.EnumNameGenerator = new CSharpEnumNameGenerator();
+            }
+        }
 
         /// <summary>Gets or sets the additional namespace usages.</summary>
         public string[] AdditionalNamespaceUsages { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------
+// <copyright file="SwaggerToCSharpGeneratorSettings.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+//     Copyright (c) AMain.com. All rights reserved.
+// </copyright>
+// <license>https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+// <author>Kendall Bennett, kendallb@amain.com</author>
+//-----------------------------------------------------------------------
+
+using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>
+    /// Custom property name generator to not have underscores in the name
+    /// </summary>
+    /// <summary>Generates the property name for a given CSharp <see cref="JsonSchemaProperty"/>.</summary>
+    public sealed class CSharpPropertyNameGenerator : IPropertyNameGenerator
+    {
+        /// <summary>Generates the property name.</summary>
+        /// <param name="property">The property.</param>
+        /// <returns>The new name.</returns>
+        public string Generate(JsonSchemaProperty property)
+        {
+            return ConversionUtilities.ConvertToUpperCamelCase(property.Name
+                    .Replace("\"", string.Empty)
+                    .Replace("@", string.Empty)
+                    .Replace("?", string.Empty)
+                    .Replace("$", string.Empty)
+                    .Replace("[", string.Empty)
+                    .Replace("]", string.Empty)
+                    .Replace(".", "-")
+                    .Replace("=", "-")
+                    .Replace("+", "plus")
+                    .Replace("_", "-"), true)
+                .Replace("*", "Star")
+                .Replace(":", "_")
+                .Replace("-", "_")
+                .Replace("#", "_");
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/CSharpTypeNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpTypeNameGenerator.cs
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------
+// <copyright file="SwaggerToCSharpGeneratorSettings.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+//     Copyright (c) AMain.com. All rights reserved.
+// </copyright>
+// <license>https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+// <author>Kendall Bennett, kendallb@amain.com</author>
+//-----------------------------------------------------------------------
+
+using System.Linq;
+using NJsonSchema;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>
+    /// Custom type name generator to not have underscores in the name
+    /// </summary>
+    public class CSharpTypeNameGenerator : DefaultTypeNameGenerator
+    {
+        /// <summary>Generates the type name for the given schema.</summary>
+        /// <param name="schema">The schema.</param>
+        /// <param name="typeNameHint">The type name hint.</param>
+        /// <returns>The type name.</returns>
+        protected override string Generate(JsonSchema schema, string typeNameHint)
+        {
+            if (string.IsNullOrEmpty(typeNameHint) && schema.HasTypeNameTitle)
+                typeNameHint = schema.Title;
+            var input = typeNameHint?.Split('.').Last() ?? "Anonymous";
+            return ConversionUtilities.ConvertToUpperCamelCase(input.Replace('_', '-'), true);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -81,6 +81,30 @@ namespace NSwag.CodeGeneration.CSharp.Models
                 .ToList();
         }
 
+        /// <summary>Gets or sets the name of the operation.</summary>
+        private string CSharpOperationName
+        {
+            get
+            {
+                var operationName = OperationName;
+                if (_settings.CSharpNamingConvention)
+                {
+                    operationName = operationName.Replace('_', '-');
+                }
+                return ConversionUtilities.ConvertToUpperCamelCase(operationName, false);
+            }
+        }
+
+        /// <summary>Gets or sets the async suffix of the operation.</summary>
+        public string AsyncSuffix
+        {
+            get
+            {
+                var settings = _settings as CSharpClientGeneratorSettings;
+                return settings != null && (settings.DecorateAsyncMethods || settings.GenerateSyncMethods) ? "Async" : "";
+            }
+        }
+
         /// <summary>Gets the method's access modifier.</summary>
         public string MethodAccessModifier
         {
@@ -88,7 +112,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
             {
                 var controllerName = _settings.GenerateControllerName(ControllerName);
                 var settings = _settings as CSharpClientGeneratorSettings;
-                if (settings != null && settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToUpperCamelCase(OperationName, false) + "Async") == true)
+                if (settings != null && settings.ProtectedMethods?.Contains(controllerName + "." + CSharpOperationName + AsyncSuffix) == true)
                 {
                     return "protected";
                 }
@@ -98,8 +122,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
         }
 
         /// <summary>Gets the actual name of the operation (language specific).</summary>
-        public override string ActualOperationName => ConversionUtilities.ConvertToUpperCamelCase(OperationName, false)
-            + (MethodAccessModifier == "protected" ? "Core" : string.Empty);
+        public override string ActualOperationName => CSharpOperationName + (MethodAccessModifier == "protected" ? "Core" : string.Empty);
 
         /// <summary>Gets a value indicating whether this operation is rendered as interface method.</summary>
         public bool IsInterfaceMethod => MethodAccessModifier == "public";

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -18,7 +18,7 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
             var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
             if (field != null)
             {
-                var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute)) 
+                var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
                     as System.Runtime.Serialization.EnumMemberAttribute;
                 if (attribute != null)
                 {
@@ -29,7 +29,7 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
             return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
         }
     }
-    else if (value is bool) 
+    else if (value is bool)
     {
         return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
     }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -2,7 +2,7 @@
 {%     if response.IsFile -%}
 {%         if response.IsSuccess -%}
 var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
-var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
+var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_);
 client_ = null; response_ = null; // response and client are disposed by FileResponse
 return fileResponse_;
 {%         else -%}
@@ -14,9 +14,9 @@ var responseData_ = response_.Content == null ? null : await response_.Content.R
 var result_ = ({{ response.Type }})System.Convert.ChangeType(responseData_, typeof({{ response.Type }}));
 {%         if response.IsSuccess -%}
 {%             if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_); 
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_);
 {%             else -%}
-return result_; 
+return result_;
 {%             endif -%}
 {%         endif -%}
 {%     else -%}
@@ -29,9 +29,9 @@ if (objectResponse_.Object == null)
 {%         endif -%}
 {%         if response.IsSuccess -%}
 {%             if operation.WrapResponse -%}
-return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, objectResponse_.Object); 
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, objectResponse_.Object);
 {%             else -%}
-return objectResponse_.Object; 
+return objectResponse_.Object;
 {%             endif -%}
 {%         endif -%}
 {%         if response.IsSuccess == false -%}
@@ -59,7 +59,7 @@ return {{ operation.UnwrappedResultDefaultValue }};
 {%         endif -%}
 {%     else -%}
 {%         if operation.WrapResponse -%}
-return new {{ ResponseClass }}(status_, headers_); 
+return new {{ ResponseClass }}(status_, headers_);
 {%         else -%}
 return;
 {%         endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -18,19 +18,19 @@
     public {{ Class }}({{ ConfigurationClass }} configuration{% if InjectHttpClient %}, {{ HttpClientType }} httpClient{% endif %}) : base(configuration)
     {
 {%     if InjectHttpClient -%}
-        _httpClient = httpClient; 
+        _httpClient = httpClient;
 {%     endif -%}
 {% elseif UseBaseUrl and HasBaseUrl == false -%}
     public {{ Class }}(string baseUrl{% if InjectHttpClient -%}, {{ HttpClientType }} httpClient{% endif %})
     {
-        BaseUrl = baseUrl; 
+        BaseUrl = baseUrl;
 {%     if InjectHttpClient -%}
-        _httpClient = httpClient; 
+        _httpClient = httpClient;
 {%     endif -%}
 {% elseif InjectHttpClient -%}
     public {{ Class }}({{ HttpClientType }} httpClient)
     {
-        _httpClient = httpClient; 
+        _httpClient = httpClient;
 {% else -%}
     public {{ Class }}()
     {
@@ -55,7 +55,7 @@
     }
 
 {% if UseBaseUrl and GenerateBaseUrlProperty -%}
-    public string BaseUrl 
+    public string BaseUrl
     {
         get { return _baseUrl; }
         set { _baseUrl = value; }
@@ -89,9 +89,9 @@
 {%     if GenerateOptionalParameters == false -%}
     {% template Client.Method.Documentation %}
     {% template Client.Method.Annotations %}
-    {{ operation.MethodAccessModifier }} {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %})
+    {{ operation.MethodAccessModifier }} {{ operation.ResultType }} {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %})
     {
-        return {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None);
+        return {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None);
     }
 
 {%     endif -%}
@@ -100,14 +100,14 @@
     {% template Client.Method.Annotations %}
     {{ operation.MethodAccessModifier }} {{ operation.SyncResultType }} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %})
     {
-        {% if operation.HasResult or operation.WrapResponse %}return {% endif %}System.Threading.Tasks.Task.Run(async () => await {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None)).GetAwaiter().GetResult();
+        {% if operation.HasResult or operation.WrapResponse %}return {% endif %}System.Threading.Tasks.Task.Run(async () => await {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None)).GetAwaiter().GetResult();
     }
 
 {%     endif -%}
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     {% template Client.Method.Documentation %}
     {% template Client.Method.Annotations %}
-    {{ operation.MethodAccessModifier }} async {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}, {% endfor %}System.Threading.CancellationToken cancellationToken{% if GenerateOptionalParameters %} = default(System.Threading.CancellationToken){% endif %})
+    {{ operation.MethodAccessModifier }} async {{ operation.ResultType }} {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}, {% endfor %}System.Threading.CancellationToken cancellationToken{% if GenerateOptionalParameters %} = default(System.Threading.CancellationToken){% endif %})
     {
 {%     for parameter in operation.PathParameters -%}
 {%         if parameter.IsNullable == false and parameter.IsRequired -%}
@@ -142,7 +142,7 @@
 {%     endfor -%}
 {%     for parameter in operation.QueryParameters -%}
 {%         if parameter.IsOptional -%}
-        if ({{ parameter.VariableName }} != null) 
+        if ({{ parameter.VariableName }} != null)
         {
             {% template Client.Class.QueryParameter %}
         }
@@ -283,21 +283,21 @@
                     }
 {%         elseif operation.HasSuccessResponse -%}
                     {
-                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                         throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", status_, responseData_, headers_, null);
                     }
 {%        elseif operation.HasResultType -%}
 {%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
-                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
+                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%             else -%}
                     return {{ operation.UnwrappedResultDefaultValue }};
 {%             endif -%}
 {%         elseif operation.WrapResponse -%}
-                    return new {{ ResponseClass }}(status_, headers_); 
+                    return new {{ ResponseClass }}(status_, headers_);
 {%         endif -%}
 {%     else -%}
 {%         if operation.HasSuccessResponse == false -%}
-{% comment %} 
+{% comment %}
     If the success response has already been explicitely declared, there is no need for this default code (because handled above).
     Otherwise, return default values on success because we don't want to throw on "unknown status code".
     Success is always expected
@@ -306,12 +306,12 @@
                     {
 {%             if operation.HasResultType -%}
 {%                 if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" -%}
-                        return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }}); 
+                        return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%                 else -%}
                         return {{ operation.UnwrappedResultDefaultValue }};
 {%                 endif -%}
 {%             elseif operation.WrapResponse -%}
-                        return new {{ ResponseClass }}(status_, headers_); 
+                        return new {{ ResponseClass }}(status_, headers_);
 {%             else -%}{% comment %} This method isn't expected to return a value. Just return. {% endcomment -%}
                         return;
 {%             endif -%}
@@ -319,7 +319,7 @@
                     else
 {%         endif -%}
                     {
-                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                         throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
                     }
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
@@ -6,7 +6,7 @@ public partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ Client
 {%   if GenerateOptionalParameters == false -%}
     {% template Client.Method.Documentation %}
     {% template Client.Method.Annotations %}
-    {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %});
+    {{ operation.ResultType }} {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %});
 
 {%   endif -%}
 {%   if GenerateSyncMethods -%}
@@ -18,7 +18,7 @@ public partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ Client
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     {% template Client.Method.Documentation %}
     {% template Client.Method.Annotations %}
-    {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}, {% endfor %}System.Threading.CancellationToken cancellationToken{% if GenerateOptionalParameters %} = default(System.Threading.CancellationToken){% endif %});
+    {{ operation.ResultType }} {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}, {% endfor %}System.Threading.CancellationToken cancellationToken{% if GenerateOptionalParameters %} = default(System.Threading.CancellationToken){% endif %});
 
 {% endfor -%}
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -17,7 +17,7 @@ public interface I{{ Class }}Controller
 {%         if operation.IsDeprecated -%}
     [System.Obsolete]
 {%         endif -%}
-    {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.TypeInControllerInterface }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional and parameter.HasDefault == false %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken){% endif %});
+    {{ operation.ResultType }} {{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.TypeInControllerInterface }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional and parameter.HasDefault == false %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken){% endif %});
 
 {%      endfor -%}
 }
@@ -62,7 +62,7 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
     public {% if operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsQuery %}[{{ AspNetNamespace }}.{% if IsAspNetCore -%}FromQuery{% else -%}FromUri{% endif -%}{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsHeader %}[{% if IsAspNetCore -%}{{ AspNetNamespace }}.{% endif -%}FromHeader{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsBody and parameter.IsBinaryBody == false %}[{{ AspNetNamespace }}.FromBody] {% endif %}{% if GenerateModelValidationAttributes and parameter.IsRequired %}[{{ RequiredAttributeType }}] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})
     {
 {%         if operation.WrapResponse -%}
-        var result = await _implementation.{{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.HasDefault %} ?? {{parameter.Default}}{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}cancellationToken{% endif %}).ConfigureAwait(false);
+        var result = await _implementation.{{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.HasDefault %} ?? {{parameter.Default}}{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}cancellationToken{% endif %}).ConfigureAwait(false);
 
         var status = (System.Net.HttpStatusCode)result.StatusCode;
         HttpResponseMessage response = Request.CreateResponse(status{% if operation.UnwrappedResultType != "void" %}, result.Result{% endif %});
@@ -72,7 +72,7 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
 
         return response;
 {%         else -%}
-        return _implementation.{{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.HasDefault %} ?? {{parameter.Default}}{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}cancellationToken{% endif %});
+        return _implementation.{{ operation.ActualOperationName }}{{ operation.AsyncSuffix }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.HasDefault %} ?? {{parameter.Default}}{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}cancellationToken{% endif %});
 {%         endif -%}
     }
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -21,7 +21,7 @@ using {{ usage }};
 namespace {{ Namespace }}
 {
     using System = global::System;
-    
+
     {{ Clients | tab }}
 
 {% if GenerateContracts -%}
@@ -99,14 +99,14 @@ namespace {{ Namespace }}
         public FileResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.IO.Stream stream, System.IDisposable client, System.IDisposable response)
 {%          endif -%}
         {
-            StatusCode = statusCode; 
-            Headers = headers; 
-            Stream = stream; 
-            _client = client; 
+            StatusCode = statusCode;
+            Headers = headers;
+            Stream = stream;
+            _client = client;
             _response = response;
         }
 
-        public void Dispose() 
+        public void Dispose()
         {
             Stream.Dispose();
             if (_response != null)
@@ -125,10 +125,10 @@ namespace {{ Namespace }}
         public int StatusCode { get; private set; }
 
         public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
-        
-        public {{ responseClassName }}(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers) 
+
+        public {{ responseClassName }}(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
         {
-            StatusCode = statusCode; 
+            StatusCode = statusCode;
             Headers = headers;
         }
     }
@@ -137,8 +137,8 @@ namespace {{ Namespace }}
     public partial class {{ responseClassName }}<TResult> : {{ responseClassName }}
     {
         public TResult Result { get; private set; }
-        
-        public {{ responseClassName }}(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result) 
+
+        public {{ responseClassName }}(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result)
             : base(statusCode, headers)
         {
             Result = result;
@@ -170,7 +170,7 @@ namespace {{ Namespace }}
             : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + ((response == null) ? "(null)" : response.Substring(0, response.Length >= 512 ? 512 : response.Length)), innerException)
         {
             StatusCode = statusCode;
-            Response = response; 
+            Response = response;
             Headers = headers;
         }
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/JsonExceptionConverter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/JsonExceptionConverter.liquid
@@ -4,21 +4,21 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
     private readonly Newtonsoft.Json.Serialization.DefaultContractResolver _defaultContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver();
     private readonly System.Collections.Generic.IDictionary<string, System.Reflection.Assembly> _searchedNamespaces;
     private readonly bool _hideStackTrace = false;
-    
+
     public JsonExceptionConverter()
     {
         _searchedNamespaces = new System.Collections.Generic.Dictionary<string, System.Reflection.Assembly> { { typeof({{ ExceptionModelClass }}).Namespace, System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof({{ ExceptionModelClass }})).Assembly } };
     }
-    
+
     public override bool CanWrite => true;
-    
+
     public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
     {
         var exception = value as System.Exception;
         if (exception != null)
         {
             var resolver = serializer.ContractResolver as Newtonsoft.Json.Serialization.DefaultContractResolver ?? _defaultContractResolver;
-    
+
             var jObject = new Newtonsoft.Json.Linq.JObject();
             jObject.Add(resolver.GetResolvedPropertyName("discriminator"), exception.GetType().Name);
             jObject.Add(resolver.GetResolvedPropertyName("Message"), exception.Message);
@@ -26,7 +26,7 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
             jObject.Add(resolver.GetResolvedPropertyName("Source"), exception.Source);
             jObject.Add(resolver.GetResolvedPropertyName("InnerException"),
                 exception.InnerException != null ? Newtonsoft.Json.Linq.JToken.FromObject(exception.InnerException, serializer) : null);
-    
+
             foreach (var property in GetExceptionProperties(value.GetType()))
             {
                 var propertyValue = property.Key.GetValue(exception);
@@ -36,37 +36,37 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
                         Newtonsoft.Json.Linq.JToken.FromObject(propertyValue, serializer)));
                 }
             }
-    
+
             value = jObject;
         }
-    
+
         serializer.Serialize(writer, value);
     }
-    
+
     public override bool CanConvert(System.Type objectType)
     {
         return System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(System.Exception)).IsAssignableFrom(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType));
     }
-    
+
     public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
     {
         var jObject = serializer.Deserialize<Newtonsoft.Json.Linq.JObject>(reader);
         if (jObject == null)
             return null;
-    
+
         var newSerializer = new Newtonsoft.Json.JsonSerializer();
         newSerializer.ContractResolver = (Newtonsoft.Json.Serialization.IContractResolver)System.Activator.CreateInstance(serializer.ContractResolver.GetType());
-    
+
         var field = GetField(typeof(Newtonsoft.Json.Serialization.DefaultContractResolver), "_sharedCache");
         if (field != null)
             field.SetValue(newSerializer.ContractResolver, false);
-    
+
         dynamic resolver = newSerializer.ContractResolver;
         if (System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(newSerializer.ContractResolver.GetType(), "IgnoreSerializableAttribute") != null)
             resolver.IgnoreSerializableAttribute = true;
         if (System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperty(newSerializer.ContractResolver.GetType(), "IgnoreSerializableInterface") != null)
             resolver.IgnoreSerializableInterface = true;
-    
+
         Newtonsoft.Json.Linq.JToken token;
         if (jObject.TryGetValue("discriminator", System.StringComparison.OrdinalIgnoreCase, out token))
         {
@@ -87,11 +87,11 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
                             break;
                         }
                     }
-    
+
                 }
             }
         }
-    
+
         var value = jObject.ToObject(objectType, newSerializer);
         foreach (var property in GetExceptionProperties(value.GetType()))
         {
@@ -106,15 +106,15 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
                     field.SetValue(value, propertyValue);
             }
         }
-    
+
         SetExceptionFieldValue(jObject, "Message", value, "_message", resolver, newSerializer);
         SetExceptionFieldValue(jObject, "StackTrace", value, "_stackTraceString", resolver, newSerializer);
         SetExceptionFieldValue(jObject, "Source", value, "_source", resolver, newSerializer);
         SetExceptionFieldValue(jObject, "InnerException", value, "_innerException", resolver, serializer);
-    
+
         return value;
     }
-    
+
     private System.Reflection.FieldInfo GetField(System.Type type, string fieldName)
     {
         var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(type).GetDeclaredField(fieldName);
@@ -122,22 +122,22 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
             return GetField(System.Reflection.IntrospectionExtensions.GetTypeInfo(type).BaseType, fieldName);
         return field;
     }
-    
+
     private System.Collections.Generic.IDictionary<System.Reflection.PropertyInfo, string> GetExceptionProperties(System.Type exceptionType)
     {
         var result = new System.Collections.Generic.Dictionary<System.Reflection.PropertyInfo, string>();
-        foreach (var property in System.Linq.Enumerable.Where(System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperties(exceptionType), 
+        foreach (var property in System.Linq.Enumerable.Where(System.Reflection.RuntimeReflectionExtensions.GetRuntimeProperties(exceptionType),
             p => p.GetMethod?.IsPublic == true))
         {
             var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute<Newtonsoft.Json.JsonPropertyAttribute>(property);
             var propertyName = attribute != null ? attribute.PropertyName : property.Name;
-    
+
             if (!System.Linq.Enumerable.Contains(new[] { "Message", "StackTrace", "Source", "InnerException", "Data", "TargetSite", "HelpLink", "HResult" }, propertyName))
                 result[property] = propertyName;
         }
         return result;
     }
-    
+
     private void SetExceptionFieldValue(Newtonsoft.Json.Linq.JObject jObject, string propertyName, object value, string fieldName, Newtonsoft.Json.Serialization.IContractResolver resolver, Newtonsoft.Json.JsonSerializer serializer)
     {
         var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(System.Exception)).GetDeclaredField(fieldName);

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -31,6 +31,13 @@ namespace NSwag.Commands.CodeGeneration
         {
         }
 
+        [Argument(Name = "CSharpNamingConvention", IsRequired = false, Description = "Use C# style naming conventions for classes, properties and enumerations (PascalCase).")]
+        public bool CSharpNamingConvention
+        {
+            get { return Settings.CSharpNamingConvention; }
+            set { Settings.CSharpNamingConvention = value; }
+        }
+
         [Argument(Name = "ClientBaseClass", IsRequired = false, Description = "The client base class (empty for no base class).")]
         public string ClientBaseClass
         {
@@ -152,6 +159,14 @@ namespace NSwag.Commands.CodeGeneration
         {
             get { return Settings.GenerateSyncMethods; }
             set { Settings.GenerateSyncMethods = value; }
+        }
+
+        [Argument(Name = "DecorateAsyncMethods", IsRequired = false,
+            Description = "Specifies whether to generate the Async suffix for Async methods.")]
+        public bool DecorateAsyncMethods
+        {
+            get { return Settings.DecorateAsyncMethods; }
+            set { Settings.DecorateAsyncMethods = value; }
         }
 
         [Argument(Name = nameof(ExposeJsonSerializerSettings), IsRequired = false,

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -1,7 +1,7 @@
 ﻿<codeGenerators:CodeGeneratorViewBase x:Class="NSwagStudio.Views.CodeGenerators.SwaggerToCSharpClientGeneratorView"
                                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                                       xmlns:converters="clr-namespace:MyToolkit.Converters;assembly=MyToolkit.Extended"
                                       xmlns:localConverters="clr-namespace:NSwagStudio.Converters"
@@ -12,7 +12,7 @@
                                       xmlns:dialogs="clr-namespace:MyToolkit.Dialogs;assembly=MyToolkit.Extended"
                                       xmlns:codeGenerators="clr-namespace:NSwagStudio.Views.CodeGenerators"
                                       xmlns:views="clr-namespace:NSwagStudio.Views.CodeGenerators.Views"
-                                      mc:Ignorable="d" 
+                                      mc:Ignorable="d"
                                       d:DesignHeight="800" d:DesignWidth="800">
 
     <UserControl.Resources>
@@ -25,7 +25,7 @@
 
     <TabControl TabStripPlacement="Left" Margin="8" Name="TabControl" DataContext="{StaticResource ViewModel}">
         <TabItem Header="Settings" HeaderTemplate="{StaticResource RotatedTabItem}">
-            <ScrollViewer x:Name="ScrollViewer" VerticalScrollBarVisibility="Visible" 
+            <ScrollViewer x:Name="ScrollViewer" VerticalScrollBarVisibility="Visible"
                           HorizontalScrollBarVisibility="Hidden"
                           IsEnabled="{Binding IsLoading, Converter={StaticResource NotConverter}}">
                 <StackPanel Margin="8,8,8,0" Width="{Binding ElementName=ScrollViewer, Path=ActualWidth, Converter={StaticResource NumberAdditionConverter}, ConverterParameter=-32}">
@@ -33,55 +33,55 @@
 
                     <TextBlock Text="Namespace" FontWeight="Bold"
                                Margin="0,0,0,6" />
-                    <TextBox Text="{Binding Command.Namespace, Mode=TwoWay}" 
+                    <TextBox Text="{Binding Command.Namespace, Mode=TwoWay}"
                              ToolTip="Namespace"
                              Margin="0,0,0,12" />
 
-                    <TextBlock Text="Additional Namespace Usages (comma separated)" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Additional Namespace Usages (comma separated)"
+                               FontWeight="Bold"
                                Margin="0,0,0,6" />
-                    <TextBox Text="{Binding Command.AdditionalNamespaceUsages, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
-                             ToolTip="AdditionalNamespaceUsages" 
+                    <TextBox Text="{Binding Command.AdditionalNamespaceUsages, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}"
+                             ToolTip="AdditionalNamespaceUsages"
                              Margin="0,0,0,12" />
 
-                    <CheckBox IsChecked="{Binding Command.GenerateContractsOutput, Mode=TwoWay}" 
+                    <CheckBox IsChecked="{Binding Command.GenerateContractsOutput, Mode=TwoWay}"
                               ToolTip="GenerateContractsOutput"
-                              Content="Generate contracts output" 
+                              Content="Generate contracts output"
                               Margin="0,0,0,12" />
 
                     <StackPanel Visibility="{Binding Command.GenerateContractsOutput, Converter={StaticResource VisibilityConverter}}">
                         <TextBlock Text="Contracts Namespace"
-                                   FontWeight="Bold" 
+                                   FontWeight="Bold"
                                    Margin="0,0,0,6" />
                         <TextBox Text="{Binding Command.ContractsNamespace, Mode=TwoWay}"
                                  ToolTip="ContractsNamespace"
                                  Margin="0,0,0,12" />
 
-                        <TextBlock Text="Additional Contract Namespace Usages (comma separated)" 
-                                   FontWeight="Bold" 
+                        <TextBlock Text="Additional Contract Namespace Usages (comma separated)"
+                                   FontWeight="Bold"
                                    Margin="0,0,0,6" />
-                        <TextBox Text="{Binding Command.AdditionalContractNamespaceUsages, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
-                                 ToolTip="AdditionalContractNamespaceUsages" 
+                        <TextBox Text="{Binding Command.AdditionalContractNamespaceUsages, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}"
+                                 ToolTip="AdditionalContractNamespaceUsages"
                                  Margin="0,0,0,12" />
                     </StackPanel>
 
-                    <CheckBox IsChecked="{Binding Command.GenerateExceptionClasses, Mode=TwoWay}" 
-                              Content="Generate exception classes (when disabled, exception classes must be imported)" 
+                    <CheckBox IsChecked="{Binding Command.GenerateExceptionClasses, Mode=TwoWay}"
+                              Content="Generate exception classes (when disabled, exception classes must be imported)"
                               ToolTip="GenerateExceptionClasses"
                               Margin="0,0,0,12" />
 
                     <StackPanel Visibility="{Binding Command.GenerateExceptionClasses, Converter={StaticResource VisibilityConverter}}">
-                        <TextBlock Text="Exception class name (may contain the '{controller}' placeholder)" 
-                                   FontWeight="Bold" 
+                        <TextBlock Text="Exception class name (may contain the '{controller}' placeholder)"
+                                   FontWeight="Bold"
                                    Margin="0,0,0,6" />
-                        <TextBox Text="{Binding Command.ExceptionClass, Mode=TwoWay}" 
+                        <TextBox Text="{Binding Command.ExceptionClass, Mode=TwoWay}"
                                  ToolTip="ExceptionClass"
                                  Margin="0,0,0,12" />
                     </StackPanel>
 
                     <GroupBox Header="Client" Margin="0,0,0,12">
                         <StackPanel Margin="4,8,4,-8">
-                            <CheckBox IsChecked="{Binding Command.GenerateClientClasses, Mode=TwoWay}" 
+                            <CheckBox IsChecked="{Binding Command.GenerateClientClasses, Mode=TwoWay}"
                                       ToolTip="GenerateClientClasses"
                                       Content="Generate Client Classes" Margin="0,0,0,12" />
 
@@ -91,7 +91,7 @@
                                     <LineBreak />
                                     The {controller} placeholder of the Class Name is replaced by generated client name (depends on the OperationGenerationMode strategy).
                                 </TextBlock>
-                                <ComboBox SelectedItem="{Binding Command.OperationGenerationMode, Mode=TwoWay}" 
+                                <ComboBox SelectedItem="{Binding Command.OperationGenerationMode, Mode=TwoWay}"
                                           ToolTip="OperationGenerationMode"
                                           ItemsSource="{Binding OperationGenerationModes}" Margin="0,0,0,12" />
 
@@ -99,49 +99,58 @@
                                 <TextBox Text="{Binding Command.ClassName, Mode=TwoWay}" ToolTip="ClassName" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Client class access modifier" FontWeight="Bold" Margin="0,0,0,6" />
-                                <TextBox Text="{Binding Command.ClientClassAccessModifier, Mode=TwoWay}" 
+                                <TextBox Text="{Binding Command.ClientClassAccessModifier, Mode=TwoWay}"
                                          ToolTip="ClientClassAccessModifier" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Methods with a protected access modifier to use in partial methods ('classname.methodname', comma separated)" FontWeight="Bold" Margin="0,0,0,6" />
-                                <TextBox Text="{Binding Command.ProtectedMethods, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
+                                <TextBox Text="{Binding Command.ProtectedMethods, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}"
                                          ToolTip="ProtectedMethods" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.UseBaseUrl, Mode=TwoWay}" 
-                                          Content="Use the base URL for the request" 
+                                <CheckBox IsChecked="{Binding Command.CSharpNamingConvention, Mode=TwoWay}"
+                                          Content="Use C# style naming conventions for classes, properties and enumerations (PascalCase)."
+                                          ToolTip="CSharpNamingConvention" Margin="0,0,0,12" />
+
+                                <CheckBox IsChecked="{Binding Command.UseBaseUrl, Mode=TwoWay}"
+                                          Content="Use the base URL for the request"
                                           ToolTip="UseBaseUrl" Margin="0,0,0,12" />
-                                
-                                <CheckBox IsChecked="{Binding Command.GenerateBaseUrlProperty, Mode=TwoWay}" 
+
+                                <CheckBox IsChecked="{Binding Command.GenerateBaseUrlProperty, Mode=TwoWay}"
                                           Visibility="{Binding Command.UseBaseUrl, Converter={StaticResource VisibilityConverter}}"
-                                          Content="Generate the BaseUrl property (must be defined on the base class otherwise)" 
+                                          Content="Generate the BaseUrl property (must be defined on the base class otherwise)"
                                           ToolTip="GenerateBaseUrlProperty" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.GenerateOptionalParameters, Mode=TwoWay}" 
+                                <CheckBox IsChecked="{Binding Command.GenerateOptionalParameters, Mode=TwoWay}"
                                           ToolTip="GenerateOptionalParameters"
                                           Content="Generate optional parameters (reorder parameters (required first, optional at the end) and generate optional parameters)" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Excluded Parameter Names (comma separated)." FontWeight="Bold" Margin="0,0,0,12" />
-                                <TextBox ToolTip="ExcludedParameterNames" 
-                                         Text="{Binding Command.ExcludedParameterNames, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
+                                <TextBox ToolTip="ExcludedParameterNames"
+                                         Text="{Binding Command.ExcludedParameterNames, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}"
                                          Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.GenerateSyncMethods, Mode=TwoWay}" 
-                                          Content="Generate synchronous methods (not recommended)" 
+                                <CheckBox IsChecked="{Binding Command.GenerateSyncMethods, Mode=TwoWay}"
+                                          Content="Generate synchronous methods (not recommended)"
                                           ToolTip="GenerateSyncMethods" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.ExposeJsonSerializerSettings, Mode=TwoWay}" 
-                                          Content="Expose the JsonSerializerSettings property" 
+                                <CheckBox IsChecked="{Binding Command.DecorateAsyncMethods, Mode=TwoWay}"
+                                          Content="Append Async suffix on Async methods"
+                                          Visibility="{Binding Command.GenerateSyncMethods, Converter={StaticResource NotConverter}}"
+                                          ToolTip="DecorateAsyncMethods" Margin="0,0,0,12" />
+
+                                <CheckBox IsChecked="{Binding Command.ExposeJsonSerializerSettings, Mode=TwoWay}"
+                                          Content="Expose the JsonSerializerSettings property"
                                           ToolTip="ExposeJsonSerializerSettings" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.InjectHttpClient, Mode=TwoWay}" 
+                                <CheckBox IsChecked="{Binding Command.InjectHttpClient, Mode=TwoWay}"
                                           ToolTip="InjectHttpClient"
                                           Content="Inject HttpClient via constructor (life cycle is managed by the caller)" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.DisposeHttpClient, Mode=TwoWay}" 
+                                <CheckBox IsChecked="{Binding Command.DisposeHttpClient, Mode=TwoWay}"
                                           ToolTip="DisposeHttpClient"
                                           Visibility="{Binding Command.InjectHttpClient, Converter={StaticResource NotConverter}}"
                                           Content="Dispose the HttpClient (life cycle must be handled by the base class and CreateHttpClientAsync())" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.GenerateClientInterfaces, Mode=TwoWay}" 
+                                <CheckBox IsChecked="{Binding Command.GenerateClientInterfaces, Mode=TwoWay}"
                                           ToolTip="GenerateClientInterfaces"
                                           Content="Generate interfaces for Client classes" Margin="0,0,0,12" />
 
@@ -151,7 +160,7 @@
                                          Visibility="{Binding Command.GenerateClientInterfaces, Converter={StaticResource VisibilityConverter}}"
                                          ToolTip="ClientBaseInterface" Margin="0,0,0,12" />
 
-                                <CheckBox IsChecked="{Binding Command.SerializeTypeInformation, Mode=TwoWay}" 
+                                <CheckBox IsChecked="{Binding Command.SerializeTypeInformation, Mode=TwoWay}"
                                           ToolTip="SerializeTypeInformation"
                                           Content="Serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto)" Margin="0,0,0,12" />
 
@@ -165,17 +174,17 @@
                                 <TextBox Text="{Binding Command.ParameterDateFormat, Mode=TwoWay}" ToolTip="ParameterDateFormat" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Null value used for query parameters which are null" FontWeight="Bold" Margin="0,0,0,6" />
-                                <TextBox Text="{Binding Command.QueryNullValue, Mode=TwoWay}" 
+                                <TextBox Text="{Binding Command.QueryNullValue, Mode=TwoWay}"
                                          ToolTip="QueryNullValue" Margin="0,0,0,12" />
 
                                 <GroupBox Header="Base Class and Configuration Class" Margin="0,0,0,12">
                                     <StackPanel Margin="4,8,4,-8">
                                         <TextBlock Text="Base Class Name (optional)" FontWeight="Bold" Margin="0,0,0,6" />
-                                        <TextBox Text="{Binding Command.ClientBaseClass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                        <TextBox Text="{Binding Command.ClientBaseClass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  ToolTip="ClientBaseClass" Margin="0,0,0,12" />
 
                                         <StackPanel Visibility="{Binding Command.ClientBaseClass, Converter={StaticResource VisibilityConverter}}">
-                                            <CheckBox IsChecked="{Binding Command.UseHttpClientCreationMethod, Mode=TwoWay}" Margin="0,0,0,12" 
+                                            <CheckBox IsChecked="{Binding Command.UseHttpClientCreationMethod, Mode=TwoWay}" Margin="0,0,0,12"
                                                         Visibility="{Binding Command.InjectHttpClient, Converter={StaticResource NotConverter}}"
                                                         ToolTip="UseHttpClientCreationMethod">
                                                 <TextBlock Text="Call the CreateHttpClientAsync method on the client base class to create a new HttpClient instance" TextWrapping="Wrap" />
@@ -186,8 +195,8 @@
                                                 <TextBlock Text="Call the CreateHttpRequestMessageAsync method on the client base class to create a new HttpRequestMessage instance" TextWrapping="Wrap" />
                                             </CheckBox>
 
-                                            <CheckBox IsChecked="{Binding Command.GenerateUpdateJsonSerializerSettingsMethod, Mode=TwoWay}" 
-                                                        Content="Generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise)." 
+                                            <CheckBox IsChecked="{Binding Command.GenerateUpdateJsonSerializerSettingsMethod, Mode=TwoWay}"
+                                                        Content="Generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise)."
                                                         ToolTip="GenerateUpdateJsonSerializerSettingsMethod"
                                                         Margin="0,0,0,12" />
 
@@ -200,21 +209,21 @@
 
                                 <GroupBox Header="Response Wrapping" Margin="0,0,0,12">
                                     <StackPanel Margin="4,8,4,-8">
-                                        <CheckBox IsChecked="{Binding Command.WrapDtoExceptions, Mode=TwoWay}" 
+                                        <CheckBox IsChecked="{Binding Command.WrapDtoExceptions, Mode=TwoWay}"
                                               ToolTip="WrapDtoExceptions"
                                               Content="Wrap DTO exceptions in a SwaggerException instance" Margin="0,0,0,12" />
 
-                                        <CheckBox IsChecked="{Binding Command.WrapResponses, Mode=TwoWay}" 
+                                        <CheckBox IsChecked="{Binding Command.WrapResponses, Mode=TwoWay}"
                                               ToolTip="WrapResponses"
                                               Content="Wrap success responses to allow full response access" Margin="0,0,0,12" />
 
                                         <StackPanel Visibility="{Binding Command.WrapResponses, Converter={StaticResource VisibilityConverter}}">
                                             <TextBlock Text="Methods where responses are wrapped (empty for all, 'ControllerName.MethodName', comma separated)" FontWeight="Bold" Margin="0,0,0,6" />
-                                            <TextBox ToolTip="WrapResponseMethods" 
-                                                     Text="{Binding Command.WrapResponseMethods, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
+                                            <TextBox ToolTip="WrapResponseMethods"
+                                                     Text="{Binding Command.WrapResponseMethods, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}"
                                                      Margin="0,0,0,12" />
 
-                                            <CheckBox IsChecked="{Binding Command.GenerateResponseClasses, Mode=TwoWay}" 
+                                            <CheckBox IsChecked="{Binding Command.GenerateResponseClasses, Mode=TwoWay}"
                                                   ToolTip="GenerateResponseClasses"
                                                   Content="Generate response classes (when disabled, response classes must be imported)" Margin="0,0,0,12" />
 
@@ -275,14 +284,14 @@
                         <StackPanel Margin="4,8,4,-8">
                             <TextBlock Text="Output file path (empty: no file output)" FontWeight="Bold" Margin="0,0,0,6" />
                             <dialogs:FileSavePicker DefaultExtension=".cs" Filter="CSharp Files (.cs)|*.cs"
-                                            FilePath="{Binding Command.OutputFilePath, Mode=TwoWay}" 
+                                            FilePath="{Binding Command.OutputFilePath, Mode=TwoWay}"
                                             ToolTip="Output"
                                             Margin="0,0,0,12" />
 
                             <StackPanel Visibility="{Binding Command.GenerateContractsOutput, Converter={StaticResource VisibilityConverter}}">
                                 <TextBlock Text="Contracts output file path (empty: single output file output)" FontWeight="Bold" Margin="0,0,0,6" />
                                 <dialogs:FileSavePicker DefaultExtension=".cs" Filter="CSharp Files (.cs)|*.cs"
-                                                FilePath="{Binding Command.ContractsOutputFilePath, Mode=TwoWay}" 
+                                                FilePath="{Binding Command.ContractsOutputFilePath, Mode=TwoWay}"
                                                 ToolTip="ContractsOutput"
                                                 Margin="0,0,0,12" />
                             </StackPanel>


### PR DESCRIPTION
Added options to use standard C# naming conventions as well as the ability to generate a client without the Async suffix on functions when Async is the only API method supported. Also trimmed new lines from all the .liquid files to avoid conflicts on dangling spaces in diffs in the future.