### PR TITLE
Fixes for NuGet package cache

### DIFF
--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -87,9 +87,14 @@ namespace NSwag.Commands
 
         private static string[] LoadDefaultNugetCache()
         {
-            var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "HOMEPATH" : "HOME";
-            var home = Environment.GetEnvironmentVariable(envHome);
-            var path = Path.Combine(home, ".nuget", "packages");
+            var path = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+
+            if (String.IsNullOrEmpty(path))
+            {
+                var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME";
+                var home = Environment.GetEnvironmentVariable(envHome);
+                path = Path.Combine(home, ".nuget", "packages");
+            }
 
             return new[] { Path.GetFullPath(path) };
         }


### PR DESCRIPTION
Respects the NUGET_PACKAGES environment variable and falls back to the USERPROFILE environment variable instead of HOMEPATH on Windows machines.
Fixes #1646.