### PR TITLE
Prevent dispose of HttpClient in FileResponse

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -111,8 +111,10 @@ namespace {{ Namespace }}
             Stream.Dispose();
             if (_response != null)
                 _response.Dispose();
+{%     if InjectHttpClient == false and DisposeHttpClient -%}
             if (_client != null)
                 _client.Dispose();
+{%     endif -%}
         }
     }
 


### PR DESCRIPTION
This PR adresses #2981 

The if Statement is the same as in the Client Template (Check for InjectHttpClient == false and DisposeHttpClient == true)

https://github.com/RicoSuter/NSwag/blob/fb48ea9e48ef8ccacf9e7b8fa35af1f1dfa0c81b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid#L336-L339