### PR TITLE
Fixed potential NullReferenceException due to a race condition

### DIFF
--- a/src/NSwag.AssemblyLoader/CustomAssemblyLoadContext.cs
+++ b/src/NSwag.AssemblyLoader/CustomAssemblyLoadContext.cs
@@ -26,7 +26,7 @@ namespace NSwag.AssemblyLoader
 
         internal Dictionary<string, Assembly> Assemblies { get; } = new Dictionary<string, Assembly>();
 
-        internal List<string> AllReferencePaths { get; set; }
+        internal List<string> AllReferencePaths { get; set; } = new List<string>();
 
         public Assembly Resolve(AssemblyName args)
         {


### PR DESCRIPTION
While using the CommandLine project, my VisualStudio hit a breakpoint because this was not initialized in `TryLoadByVersion`.

This will likely help too if the assembly is annotated with NRT someday.