### PR TITLE
Fixed code generation for FileResponse

### DIFF
--- a/src/NSwag.AssemblyLoader/CustomAssemblyLoadContext.cs
+++ b/src/NSwag.AssemblyLoader/CustomAssemblyLoadContext.cs
@@ -26,7 +26,7 @@ namespace NSwag.AssemblyLoader
 
         internal Dictionary<string, Assembly> Assemblies { get; } = new Dictionary<string, Assembly>();
 
-        internal List<string> AllReferencePaths { get; set; }
+        internal List<string> AllReferencePaths { get; set; } = new List<string>();
 
         public Assembly Resolve(AssemblyName args)
         {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -2,7 +2,7 @@
 {%     if response.IsFile -%}
 {%         if response.IsSuccess -%}
 var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
-var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
+var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient or !DisposeHttpClient %}null{% else %}client_{% endif %}, response_); 
 disposeClient_ = false; disposeResponse_ = false; // response and client are disposed by FileResponse
 return fileResponse_;
 {%         else -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -3,7 +3,7 @@
 {%         if response.IsSuccess -%}
 var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
 var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
-client_ = null; response_ = null; // response and client are disposed by FileResponse
+disposeClient_ = false; disposeResponse_ = false; // response and client are disposed by FileResponse
 return fileResponse_;
 {%         else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_).ConfigureAwait(false);
@@ -16,7 +16,7 @@ var result_ = ({{ response.Type }})System.Convert.ChangeType(responseData_, type
 {%             if operation.WrapResponse -%}
 return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_); 
 {%             else -%}
-return result_; 
+return result_;
 {%             endif -%}
 {%         endif -%}
 {%     else -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -161,6 +161,11 @@
 {%     else -%}
         var client_ = new {{ HttpClientType }}();
 {%     endif -%}
+{%     if InjectHttpClient == false and DisposeHttpClient -%}
+        var disposeClient_ = true;
+{%     else -%}
+        var disposeClient_ = false;
+{%     endif -%}
         try
         {
 {%     if UseHttpRequestMessageCreationMethod -%}
@@ -256,6 +261,7 @@
 
                 {% template Client.Class.BeforeSend %}
                 var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                var disposeResponse_ = true;
                 try
                 {
                     var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
@@ -326,17 +332,15 @@
                 }
                 finally
                 {
-                    if (response_ != null)
+                    if (disposeResponse_)
                         response_.Dispose();
                 }
             }
         }
         finally
         {
-{%     if InjectHttpClient == false and DisposeHttpClient -%}
-            if (client_ != null)
+            if (disposeClient_)
                 client_.Dispose();
-{%     endif -%}
         }
     }
 


### PR DESCRIPTION
When enabling NullReferenceTypes generation with an API that can return a FileResponse, the code tried to set `client_ = null` and `response_ = null`, which is now disallowed.

Instead, I introduce two booleans `disposeClient_` and `disposeResponse_` that controls whether the variables must be disposed at the end.

By fixing this issue, I found a that the FileResponse gets the client only if InjectHttpClient is false, which is not consistent with this condition in the Client.Class.liquid:
```cs
{%     if InjectHttpClient == false and DisposeHttpClient -%}
```

I decided to fix it there, and I then found #3009 and #2981 . This fixes #2981.


Note : This PR is based on #3015, the first commit exists in both branches.