### PR TITLE
openApiToCSharpController: fixed invalid ActionResult for binaries

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerOperationModel.cs
@@ -34,9 +34,14 @@ namespace NSwag.CodeGeneration.CSharp.Models
             {
                 if (_settings.UseActionResultType)
                 {
-                    return SyncResultType == "void"
-                        ? "System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult>"
-                        : "System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<" + SyncResultType + ">>";
+                    switch (SyncResultType)
+                    {
+                        case "void":
+                        case "FileResult":
+                            return "System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult>";
+                        default:
+                            return "System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<" + SyncResultType + ">>";
+                    }
                 }
 
                 return base.ResultType;


### PR DESCRIPTION
This fixes #2900. An invalid `System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<FileResult>>` for binaries is generated when `useActionResultType` is set to `true`. This does not work on runtime and causes an exception.

I decided to generate a general `IActionResult` rather than a `FileResult`, since this gives more flexibility. This is open to discussion however.