### PR TITLE
Set OpenApiControllerAttribute usage to class

### DIFF
--- a/src/NSwag.Annotations/OpenApiControllerAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiControllerAttribute.cs
@@ -11,7 +11,7 @@ using System;
 namespace NSwag.Annotations
 {
     /// <summary>Describes the controller.</summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class)]
     public class OpenApiControllerAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="OpenApiOperationAttribute"/> class.</summary>


### PR DESCRIPTION
I tried overriding the logic for generating the operation id because I'm using a generic controller. This resulted in a bad formatted operation id which broke the typescript client on generation. While trying to override it I stumbled upon [this code](https://github.com/RicoSuter/NSwag/blob/cc990244c427176112c297967209f6e666a23992/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs#L412) that generates the operation id by using the `OpenApiControllerAttribute`. However this code grabs the attributes from the declared controller and not the method. Currently the usage for `OpenApiControllerAttribute` is set to `Method`, which breaks this logic completely. Setting the usage to `Class` should resolve this issue.

My current workaround is to create my own `OpenApiControllerAttribute` which inherits from the original one but sets the proper `AttributeUsage`.