### PR TITLE
Fixed complex parameter generation for custom json content types.

### DIFF
--- a/src/NSwag.Core/OpenApiParameter.cs
+++ b/src/NSwag.Core/OpenApiParameter.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using NJsonSchema;
 
@@ -25,6 +26,8 @@ namespace NSwag
         private IDictionary<string, OpenApiExample> _examples;
         private bool _explode;
         private int? _position;
+
+        private static readonly Regex AppJsonRegex = new Regex(@"application\/(\S+?)?\+?json;?(\S+)?");
 
         [JsonIgnore]
         internal OpenApiOperation ParentOperation => Parent as OpenApiOperation;
@@ -222,7 +225,7 @@ namespace NSwag
 
                 return consumes?.Any() == true &&
                        consumes.Any(p => p.Contains("application/xml")) &&
-                       consumes.Any(p => p.StartsWith("application/") && p.EndsWith("json")) == false;
+                       consumes.Any(p => AppJsonRegex.IsMatch(p)) == false;
             }
         }
 
@@ -245,7 +248,7 @@ namespace NSwag
                            (Schema?.IsBinary != false || 
                             consumes.Contains("multipart/form-data")) &&
                            consumes?.Any(p => p.Contains("*/*")) == false &&
-                           consumes?.Any(p => p.StartsWith("application/") && p.EndsWith("json")) == false;
+                           consumes.Any(p => AppJsonRegex.IsMatch(p)) == false;
                 }
                 else
                 {
@@ -253,7 +256,7 @@ namespace NSwag
                     return (consumes?.Any(p => p.Key == "multipart/form-data") == true ||
                             consumes?.Any(p => p.Value.Schema?.IsBinary != false) == true) &&
                            consumes.Any(p => p.Key.Contains("*/*") && p.Value.Schema?.IsBinary != true) == false &&
-                           consumes.Any(p => p.Key.StartsWith("application/") && p.Key.EndsWith("json") && p.Value.Schema?.IsBinary != true) == false;
+                           consumes.Any(p => AppJsonRegex.IsMatch(p.Key) && p.Value.Schema?.IsBinary != true) == false;
                 }
             }
         }

--- a/src/NSwag.Core/OpenApiResponse.cs
+++ b/src/NSwag.Core/OpenApiResponse.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using NJsonSchema;
 using NJsonSchema.References;
@@ -17,6 +18,8 @@ namespace NSwag
     /// <summary>The Swagger response.</summary>
     public class OpenApiResponse : JsonReferenceBase<OpenApiResponse>, IJsonReference
     {
+        private static readonly Regex AppJsonRegex = new Regex(@"application\/(\S+?)?\+?json;?(\S+)?");
+
         /// <summary>Gets or sets the extension data (i.e. additional properties which are not directly defined by the JSON object).</summary>
         [JsonExtensionData]
         public IDictionary<string, object> ExtensionData { get; set; }
@@ -131,7 +134,7 @@ namespace NSwag
                                                         c.Value.Schema?.ActualSchema.IsBinary != false) &&
                         !ActualResponse.Content.Keys.Any(p => p.Contains("application/json")) &&
                         !ActualResponse.Content.Keys.Any(p => p.Contains("text/plain")) &&
-                        !ActualResponse.Content.Keys.Any(p => p.StartsWith("application/") && p.EndsWith("+json"));
+                        !ActualResponse.Content.Keys.Any(p => AppJsonRegex.IsMatch(p));
 
                     if (contentIsBinary)
                     {
@@ -152,7 +155,7 @@ namespace NSwag
                          Schema?.ActualSchema.IsBinary != false) && // is binary only if there is no JSON schema defined
                         actualProduces?.Any(p => p.Contains("application/json")) != true &&
                         actualProduces?.Any(p => p.Contains("text/plain")) != true &&
-                        actualProduces?.Any(p => p.StartsWith("application/") && p.EndsWith("+json")) != true;
+                        actualProduces?.Any(p => AppJsonRegex.IsMatch(p)) != true;
 
                     if (producesIsBinary)
                     {


### PR DESCRIPTION
This PR restores support for mime-type parameters for json-based content types. I takes the suggestion from the previous PR #2633 and uses [Regex.IsMatch](https://docs.microsoft.com/en-us/dotnet/csharp/how-to/search-strings#finding-specific-text-using-regular-expressions). Additionally, OpenApiResponse.cs is updated to have consistency as was mentioned in the previous PR as well.