### PR TITLE
Fix incorrect assignment bug #3078

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -26,9 +26,9 @@
 {%     endif -%}
         this.http = http;
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularJSClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularJSClient.liquid
@@ -21,9 +21,9 @@
         this.http = $http;
         this.q = $q;
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -19,9 +19,9 @@
 {%     endif -%}
         this.instance = instance ? instance : axios.create();
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -24,7 +24,7 @@
 {%     if UseGetBaseUrlMethod -%}
         this.baseUrl = this.getBaseUrl("{{ BaseUrl }}", baseUrl);
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/JQueryCallbacksClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/JQueryCallbacksClient.liquid
@@ -18,9 +18,9 @@
         super({% if HasConfigurationClass %}configuration{% endif %});
 {%     endif -%}
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/JQueryPromisesClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/JQueryPromisesClient.liquid
@@ -19,9 +19,9 @@
         super({% if HasConfigurationClass %}configuration{% endif %});
 {%     endif -%}
 {%     if UseGetBaseUrlMethod -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : this.getBaseUrl("{{ BaseUrl }}");
 {%     else -%}
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "{{ BaseUrl }}";
 {%     endif -%}
     }
 {% endif -%}

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngular.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngular.ts
@@ -33,7 +33,7 @@ export class GeoClient extends MyBaseClass {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null): Observable<void> {
@@ -621,7 +621,7 @@ export class PersonsClient extends MyBaseClass {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll(): Observable<Person[] | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngularJS.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAngularJS.ts
@@ -18,7 +18,7 @@ export class GeoClient {
     constructor($http: ng.IHttpService, $q: ng.IQService, baseUrl?: string) {
         this.http = $http;
         this.q = $q;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null): ng.IPromise<void> {
@@ -486,7 +486,7 @@ export class PersonsClient {
     constructor($http: ng.IHttpService, $q: ng.IQService, baseUrl?: string) {
         this.http = $http;
         this.q = $q;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll(): ng.IPromise<Person[] | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAurelia.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsAurelia.ts
@@ -18,7 +18,7 @@ export class GeoClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : <any>window;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null): Promise<void> {
@@ -428,7 +428,7 @@ export class PersonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : <any>window;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll(): Promise<Person[] | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsFetch.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsFetch.ts
@@ -423,7 +423,7 @@ export class PersonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : <any>window;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll(): Promise<Person[] | null> {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryCallbacks.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryCallbacks.ts
@@ -15,7 +15,7 @@ export class GeoClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null, onSuccess?: () => void, onFail?: (exception: string, reason: string) => void): JQueryXHR {
@@ -613,7 +613,7 @@ export class PersonsClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll(onSuccess?: (result: Person[] | null) => void, onFail?: (exception: string, reason: string) => void): JQueryXHR {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromises.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromises.ts
@@ -15,7 +15,7 @@ export class GeoClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null) {
@@ -635,7 +635,7 @@ export class PersonsClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll() {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromisesKO.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsJQueryPromisesKO.ts
@@ -17,7 +17,7 @@ export class GeoClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     fromBodyTest(location: GeoPoint | null) {
@@ -637,7 +637,7 @@ export class PersonsClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:13452";
     }
 
     getAll() {

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsPetStoreFetch.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsPetStoreFetch.ts
@@ -14,7 +14,7 @@ export class Client {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : <any>window;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://petstore.swagger.io/v2";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://petstore.swagger.io/v2";
     }
 
     /**

--- a/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsUberFetch.ts
+++ b/src/NSwag.Integration.TypeScriptWeb/scripts/serviceClientsUberFetch.ts
@@ -14,7 +14,7 @@ export class Client {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : <any>window;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.uber.com/v1";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.uber.com/v1";
     }
 
     /**

--- a/src/NSwag.Sample.NetCoreAngular/ClientApp/app/githubServices.ts
+++ b/src/NSwag.Sample.NetCoreAngular/ClientApp/app/githubServices.ts
@@ -28,7 +28,7 @@ export class GitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -15551,7 +15551,7 @@ export class PublicGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -15813,7 +15813,7 @@ export class RateGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -15881,7 +15881,7 @@ export class CodeGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -15961,7 +15961,7 @@ export class CommitGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -16041,7 +16041,7 @@ export class PunchGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**
@@ -16121,7 +16121,7 @@ export class ReceivedGitHubClient {
 
     constructor(@Inject(Http) http: Http, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.github.com";
     }
 
     /**

--- a/src/NSwag.Sample.NetCoreAngular/ClientApp/app/services.ts
+++ b/src/NSwag.Sample.NetCoreAngular/ClientApp/app/services.ts
@@ -41,7 +41,7 @@ export class DateService extends ServiceBase {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
     }
 
     addDays(date: moment.Moment, days: number): Observable<moment.Moment> {
@@ -168,7 +168,7 @@ export class EnumerationService extends ServiceBase {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
     }
 
     reverseQueryEnumList(fileTypes: FileType[] | null | undefined): Observable<FileType[] | null> {
@@ -238,7 +238,7 @@ export class FileService extends ServiceBase {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
     }
 
     getFile(fileName: string | null): Observable<FileResponse | null> {
@@ -304,7 +304,7 @@ export class SampleDataService extends ServiceBase {
     constructor(@Inject(HttpClient) http: HttpClient, @Optional() @Inject(API_BASE_URL) baseUrl?: string) {
         super();
         this.http = http;
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
     }
 
     weatherForecasts(): Observable<WeatherForecast[] | null> {

--- a/src/NSwag.Sample.NetCoreAurelia/ClientApp/clients.ts
+++ b/src/NSwag.Sample.NetCoreAurelia/ClientApp/clients.ts
@@ -16,7 +16,7 @@ export class SampleDataClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
         this.http = http ? http : <any>window;
     }
 


### PR DESCRIPTION
There is a bug detailed by @CRidge here around incorrect assignment following the nullish coalescing change: https://github.com/RicoSuter/NSwag/issues/3078

That bug was introduced by my PR: https://github.com/RicoSuter/NSwag/pull/3065

The nature of the bug was that it was creating: 

`this.baseUrl !== undefined && baseUrl !== null ? baseUrl : ...`

Where it should have been creating: 

`this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : ...`

This PR fixes it.  My apologies.