### PR TITLE
Features/allow ref in path item - test and ref fix

### DIFF
--- a/src/NSwag.Core.Tests/Serialization/PathItemTest/PathItemWithRef.json
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTest/PathItemWithRef.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Path Item With Ref",
+    "description": "Testing external $ref on path items"
+  },
+  "paths": {
+    "/aValidPath": {
+      "$ref": "./refs/PathItem.json#/aValidPath"
+    }
+  }
+}

--- a/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
@@ -3,7 +3,7 @@
     "get": {
       "responses": {
         "200": {
-          "description": "Path reference in external file can be serialized"
+          "description": "Path reference in external file can be resolved"
         }
       }
     }

--- a/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
@@ -3,7 +3,7 @@
     "get": {
       "responses": {
         "200": {
-          "description": "Path reference in external file can serialized"
+          "description": "Path reference in external file can be serialized"
         }
       }
     }

--- a/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTest/refs/PathItem.json
@@ -1,0 +1,11 @@
+{
+  "aValidPath": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "Path reference in external file can serialized"
+        }
+      }
+    }
+  }
+}

--- a/src/NSwag.Core.Tests/Serialization/PathItemTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTests.cs
@@ -1,14 +1,51 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using NJsonSchema;
+using NJsonSchema.Generation;
 using Xunit;
 
 namespace NSwag.Core.Tests.Serialization
 {
     public class PathItemTests
     {
+        private const string aValidPath = "/aValidPath";
+
         [Fact]
-        public async Task Foo()
+        public async Task PathItem_With_External_Ref_Can_Be_Serialized()
         {
-            var json = @""; // TODO
+            string refPath = GetTestDirectory() + "/Serialization/PathItemTest/refs/PathItem.json";
+            JsonSchema refPathItem = await JsonSchema.FromFileAsync(refPath);
+
+            string path = GetTestDirectory() + "/Serialization/PathItemTest/PathItemWithRef.json";
+
+            OpenApiDocument result = await OpenApiDocument.FromFileAsync(path,
+					  schema4 =>
+					  {
+						  JsonSchemaResolver schemaResolver = new JsonSchemaResolver(
+							 schema4,
+							 new JsonSchemaGeneratorSettings());
+
+						  var resolver = new JsonReferenceResolver(schemaResolver);
+						  // someone referencing "definitions.schema.json? Use this content instead
+						  resolver.AddDocumentReference(refPath, refPathItem);
+
+						  return resolver;
+					  });
+
+            var resultPaths = result.Paths;
+            var resultPathItem = resultPaths[aValidPath];
+            var actualPathItem = resultPathItem.ActualPathItem;
+            var resultOperation = actualPathItem["get"];
+            Assert.True(resultOperation.ActualResponses.ContainsKey("200"));
+        }
+
+        private string GetTestDirectory()
+        {
+            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            return Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
         }
     }
 }

--- a/src/NSwag.Core.Tests/Serialization/PathItemTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/PathItemTests.cs
@@ -2,8 +2,6 @@
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
-using NJsonSchema;
-using NJsonSchema.Generation;
 using Xunit;
 
 namespace NSwag.Core.Tests.Serialization
@@ -15,30 +13,15 @@ namespace NSwag.Core.Tests.Serialization
         [Fact]
         public async Task PathItem_With_External_Ref_Can_Be_Serialized()
         {
-            string refPath = GetTestDirectory() + "/Serialization/PathItemTest/refs/PathItem.json";
-            JsonSchema refPathItem = await JsonSchema.FromFileAsync(refPath);
-
             string path = GetTestDirectory() + "/Serialization/PathItemTest/PathItemWithRef.json";
 
-            OpenApiDocument result = await OpenApiDocument.FromFileAsync(path,
-					  schema4 =>
-					  {
-						  JsonSchemaResolver schemaResolver = new JsonSchemaResolver(
-							 schema4,
-							 new JsonSchemaGeneratorSettings());
+            OpenApiDocument doc = await OpenApiDocument.FromFileAsync(path);
 
-						  var resolver = new JsonReferenceResolver(schemaResolver);
-						  // someone referencing "definitions.schema.json? Use this content instead
-						  resolver.AddDocumentReference(refPath, refPathItem);
-
-						  return resolver;
-					  });
-
-            var resultPaths = result.Paths;
-            var resultPathItem = resultPaths[aValidPath];
-            var actualPathItem = resultPathItem.ActualPathItem;
-            var resultOperation = actualPathItem["get"];
-            Assert.True(resultOperation.ActualResponses.ContainsKey("200"));
+            var paths = doc.Paths;
+            var pathItem = paths[aValidPath];
+            var actualPathItem = pathItem.ActualPathItem;
+            var getOperation = actualPathItem["get"];
+            Assert.True(getOperation.ActualResponses.ContainsKey("200"));
         }
 
         private string GetTestDirectory()

--- a/src/NSwag.Core/OpenApiPathItem.cs
+++ b/src/NSwag.Core/OpenApiPathItem.cs
@@ -191,6 +191,11 @@ namespace NSwag
 
                         operations.ExtensionData[propertyName] = serializer.Deserialize(reader);
                     }
+                    else if (propertyName.Contains("$ref"))
+					{
+                        string refPath = serializer.Deserialize(reader).ToString();
+                        ((IJsonReferenceBase)operations).ReferencePath = refPath;
+                    }
                     else
                     {
                         var value = (OpenApiOperation)serializer.Deserialize(reader, typeof(OpenApiOperation));


### PR DESCRIPTION
Unit test for pathItem ref in external file, explicitly set IJsonReferenceBase.ReferencePath of OpenApiPathItem to fix exception