### PR TITLE
[TS] Add AbortSignal to fetch template

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
@@ -105,5 +105,52 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             Assert.DoesNotContain("FormData", code);
             Assert.Contains("\"Content-Type\": \"application/x-www-form-urlencoded\"", code);
         }
+
+        [Fact]
+        public async Task When_abort_signal()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+            var json = document.ToJson();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Fetch,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.7m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("signal?: AbortSignal | undefined", code);
+        }
+
+        [Fact]
+        public async Task When_no_abort_signal()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+            var json = document.ToJson();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Fetch,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain("signal?: AbortSignal | undefined", code);
+            Assert.DoesNotContain("signal", code);;
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
@@ -118,6 +118,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
             {
                 Template = TypeScriptTemplate.Fetch,
+                UseAbortSignal = true,
                 TypeScriptGeneratorSettings =
                 {
                     TypeScriptVersion = 2.7m

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
@@ -108,6 +108,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether the target TypeScript version supports strict null checks.</summary>
         public bool SupportsStrictNullChecks => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.0m;
 
+        /// <summary>Gets a value indicating whether the target TypeScript version supports AbortController</summary>
+        public bool SupportsAbortController => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.7m;
+
         /// <summary>Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException instance.</summary>
         public bool WrapDtoExceptions => _settings.WrapDtoExceptions;
 

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
@@ -108,9 +108,6 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether the target TypeScript version supports strict null checks.</summary>
         public bool SupportsStrictNullChecks => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.0m;
 
-        /// <summary>Gets a value indicating whether the target TypeScript version supports AbortController</summary>
-        public bool SupportsAbortController => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.7m;
-
         /// <summary>Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException instance.</summary>
         public bool WrapDtoExceptions => _settings.WrapDtoExceptions;
 
@@ -119,5 +116,8 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets whether the export keyword should be added to all classes and enums.</summary>
         public bool ExportTypes => _settings.TypeScriptGeneratorSettings.ExportTypes;
+
+        /// <summary>Gets a value indicating whether to use the AbortSignal (Fetch template only, default: false).</summary>
+        public bool UseAbortSignal => _settings.UseAbortSignal;
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -90,6 +90,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether the target TypeScript version supports strict null checks.</summary>
         public bool SupportsStrictNullChecks => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.0m;
 
+        /// <summary>Gets a value indicating whether the target TypeScript version supports AbortController</summary>
+        public bool SupportsAbortController => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.7m;
+
         /// <summary>Gets a value indicating whether to handle references.</summary>
         public bool HandleReferences => _settings.TypeScriptGeneratorSettings.HandleReferences;
 

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -90,9 +90,6 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether the target TypeScript version supports strict null checks.</summary>
         public bool SupportsStrictNullChecks => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.0m;
 
-        /// <summary>Gets a value indicating whether the target TypeScript version supports AbortController</summary>
-        public bool SupportsAbortController => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 2.7m;
-
         /// <summary>Gets a value indicating whether to handle references.</summary>
         public bool HandleReferences => _settings.TypeScriptGeneratorSettings.HandleReferences;
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -35,7 +35,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if SupportsAbortController %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}
@@ -47,7 +47,7 @@
             body: content_,
 {%     endif -%}
             method: "{{ operation.HttpMethodUpper | upcase }}",
-{%     if SupportsAbortController -%}
+{%     if UseAbortSignal -%}
             signal,
 {%     endif -%}
             headers: {

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -35,7 +35,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}): Promise<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if SupportsAbortController %}{% if operation.Parameters.size > 0 %},{% endif %} signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}
@@ -47,6 +47,9 @@
             body: content_,
 {%     endif -%}
             method: "{{ operation.HttpMethodUpper | upcase }}",
+{%     if SupportsAbortController -%}
+            signal,
+{%     endif -%}
             headers: {
 {%     for parameter in operation.HeaderParameters -%}
                 "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "",

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -35,7 +35,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if SupportsAbortController %}{% if operation.Parameters.size > 0 %},{% endif %} signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if SupportsAbortController %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -91,6 +91,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the name of the exception class (default 'ApiException').</summary>
         public string ExceptionClass { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether to use the AbortSignal (Fetch template only, default: false).</summary>
+        public bool UseAbortSignal { get; set; } = false;
+
         // TODO: Angular specific => move
 
         /// <summary>Gets or sets the HTTP service class (applies only for the Angular template, default: HttpClient).</summary>


### PR DESCRIPTION
This adds support for [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for Fetch template
I've mostly followed [this PR](https://github.com/RicoSuter/NSwag/pull/2846/) for axios

One thing I'm concerned about is that it seems like `AbortSignal` typings were [added](https://github.com/microsoft/TypeScript/issues/19418) in TypeScript 2.7, so I wonder if signal generation should be opt-in through some kind of setting 