### PR TITLE
Fixes an issue where nullable ENUM query parameter had double OneOf -schema

### DIFF
--- a/src/NSwag.Generation.WebApi.Tests/Nullability/ParameterNullabilityTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/Nullability/ParameterNullabilityTests.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using NJsonSchema;
 using NJsonSchema.Annotations;
 
@@ -33,5 +35,42 @@ namespace NSwag.Generation.WebApi.Tests.Nullability
             Assert.IsFalse(document.Operations.First().Operation.Parameters[0].IsNullable(SchemaType.Swagger2));
             Assert.IsTrue(document.Operations.First().Operation.Parameters[1].IsNullable(SchemaType.Swagger2));
         }
+        }
+
+        public class NullableSchemaTestController : Controller
+        {
+
+            public enum MyEnum
+            {
+                Foo = 1,
+                Bar = 20
+            }
+
+            [Route("Abc")]
+            [HttpGet]
+            public object Abc(
+                string foo, 
+                MyEnum? bar = null, 
+                List<MyEnum?> manyBars = null
+            )
+            {
+                return null;
+            }
+        }
+
+        [TestMethod]
+        public async Task Get_NullableQueryParamEnums_ShouldHaveSingleOneOf()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings() { SchemaType = SchemaType.OpenApi3, AllowNullableBodyParameters = false });
+
+            //// Act
+            var document = await generator.GenerateForControllerAsync<NullableSchemaTestController>();
+            var json = document.ToJson(SchemaType.OpenApi3, Formatting.None);
+
+            //// Assert
+            // Verify there is no double OneOf - OneOf schema on second parameter
+            // Verify there is no requestBody on GET operation
+            Assert.AreEqual("{\"x-generator\":\"NSwag v13.8.2.0 (NJsonSchema v10.2.2.0 (Newtonsoft.Json v9.0.0.0))\",\"openapi\":\"3.0.0\",\"info\":{\"title\":\"My Title\",\"version\":\"1.0.0\"},\"paths\":{\"/Abc\":{\"get\":{\"tags\":[\"NullableSchemaTest\"],\"operationId\":\"NullableSchemaTest_Abc\",\"parameters\":[{\"name\":\"foo\",\"in\":\"query\",\"required\":true,\"schema\":{\"type\":\"string\",\"nullable\":true},\"x-position\":1},{\"name\":\"bar\",\"in\":\"query\",\"schema\":{\"oneOf\":[{\"nullable\":true,\"$ref\":\"#/components/schemas/MyEnum\"}]},\"x-position\":2},{\"name\":\"manyBars\",\"in\":\"query\",\"style\":\"form\",\"explode\":true,\"schema\":{\"type\":\"array\",\"nullable\":true,\"items\":{\"nullable\":true,\"oneOf\":[{\"$ref\":\"#/components/schemas/MyEnum\"}]}},\"x-position\":3}],\"responses\":{\"200\":{\"description\":\"\",\"content\":{\"application/json\":{\"schema\":{\"nullable\":true}}}}}}}},\"components\":{\"schemas\":{\"MyEnum\":{\"type\":\"integer\",\"description\":\"\",\"x-enumNames\":[\"Foo\",\"Bar\"],\"enum\":[1,20]}}}}", json);
     }
 }

--- a/src/NSwag.Generation.WebApi.Tests/Nullability/ParameterNullabilityTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/Nullability/ParameterNullabilityTests.cs
@@ -35,7 +35,6 @@ namespace NSwag.Generation.WebApi.Tests.Nullability
             Assert.IsFalse(document.Operations.First().Operation.Parameters[0].IsNullable(SchemaType.Swagger2));
             Assert.IsTrue(document.Operations.First().Operation.Parameters[1].IsNullable(SchemaType.Swagger2));
         }
-        }
 
         public class NullableSchemaTestController : Controller
         {
@@ -66,11 +65,15 @@ namespace NSwag.Generation.WebApi.Tests.Nullability
 
             //// Act
             var document = await generator.GenerateForControllerAsync<NullableSchemaTestController>();
+
+            document.Generator = null; // Remove version string for easier assertion
+
             var json = document.ToJson(SchemaType.OpenApi3, Formatting.None);
 
             //// Assert
             // Verify there is no double OneOf - OneOf schema on second parameter
             // Verify there is no requestBody on GET operation
-            Assert.AreEqual("{\"x-generator\":\"NSwag v13.8.2.0 (NJsonSchema v10.2.2.0 (Newtonsoft.Json v9.0.0.0))\",\"openapi\":\"3.0.0\",\"info\":{\"title\":\"My Title\",\"version\":\"1.0.0\"},\"paths\":{\"/Abc\":{\"get\":{\"tags\":[\"NullableSchemaTest\"],\"operationId\":\"NullableSchemaTest_Abc\",\"parameters\":[{\"name\":\"foo\",\"in\":\"query\",\"required\":true,\"schema\":{\"type\":\"string\",\"nullable\":true},\"x-position\":1},{\"name\":\"bar\",\"in\":\"query\",\"schema\":{\"oneOf\":[{\"nullable\":true,\"$ref\":\"#/components/schemas/MyEnum\"}]},\"x-position\":2},{\"name\":\"manyBars\",\"in\":\"query\",\"style\":\"form\",\"explode\":true,\"schema\":{\"type\":\"array\",\"nullable\":true,\"items\":{\"nullable\":true,\"oneOf\":[{\"$ref\":\"#/components/schemas/MyEnum\"}]}},\"x-position\":3}],\"responses\":{\"200\":{\"description\":\"\",\"content\":{\"application/json\":{\"schema\":{\"nullable\":true}}}}}}}},\"components\":{\"schemas\":{\"MyEnum\":{\"type\":\"integer\",\"description\":\"\",\"x-enumNames\":[\"Foo\",\"Bar\"],\"enum\":[1,20]}}}}", json);
+            Assert.AreEqual("{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"My Title\",\"version\":\"1.0.0\"},\"paths\":{\"/Abc\":{\"get\":{\"tags\":[\"NullableSchemaTest\"],\"operationId\":\"NullableSchemaTest_Abc\",\"parameters\":[{\"name\":\"foo\",\"in\":\"query\",\"required\":true,\"schema\":{\"type\":\"string\",\"nullable\":true},\"x-position\":1},{\"name\":\"bar\",\"in\":\"query\",\"schema\":{\"oneOf\":[{\"nullable\":true,\"$ref\":\"#/components/schemas/MyEnum\"}]},\"x-position\":2},{\"name\":\"manyBars\",\"in\":\"query\",\"style\":\"form\",\"explode\":true,\"schema\":{\"type\":\"array\",\"nullable\":true,\"items\":{\"nullable\":true,\"oneOf\":[{\"$ref\":\"#/components/schemas/MyEnum\"}]}},\"x-position\":3}],\"responses\":{\"200\":{\"description\":\"\",\"content\":{\"application/json\":{\"schema\":{\"nullable\":true}}}}}}}},\"components\":{\"schemas\":{\"MyEnum\":{\"type\":\"integer\",\"description\":\"\",\"x-enumNames\":[\"Foo\",\"Bar\"],\"enum\":[1,20]}}}}", json);
+        }
     }
 }

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -155,7 +155,9 @@ namespace NSwag.Generation.WebApi.Processors
                                         }
                                     }
                                 }
-                                else if (fromBodyAttribute != null || (fromUriAttribute == null && _settings.IsAspNetCore == false))
+                                else if (
+                                    context.OperationDescription.Method != OpenApiOperationMethod.Get && 
+                                    (fromBodyAttribute != null || (fromUriAttribute == null && _settings.IsAspNetCore == false)))
                                 {
                                     operationParameter = AddBodyParameter(context, bodyParameterName, contextualParameter);
                                 }

--- a/src/NSwag.Generation/OpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGenerator.cs
@@ -117,15 +117,7 @@ namespace NSwag.Generation
                 if (hasSchemaAnnotations || typeDescription.IsNullable)
                 {
                     operationParameter.Schema.IsNullableRaw = true;
-
-                    if (_settings.AllowReferencesWithProperties)
-                    {
-                        operationParameter.Schema.Reference = referencedSchema.ActualSchema;
-                    }
-                    else
-                    {
-                        operationParameter.Schema.Reference = new JsonSchema { IsNullableRaw = true, Reference = referencedSchema.ActualSchema };
-                    }
+                    operationParameter.Schema.Reference = referencedSchema.ActualSchema;
                 }
                 else
                 {

--- a/src/NSwag.Generation/OpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGenerator.cs
@@ -124,7 +124,7 @@ namespace NSwag.Generation
                     }
                     else
                     {
-                        operationParameter.Schema.OneOf.Add(new JsonSchema { Reference = referencedSchema.ActualSchema });
+                        operationParameter.Schema.Reference = new JsonSchema { IsNullableRaw = true, Reference = referencedSchema.ActualSchema };
                     }
                 }
                 else


### PR DESCRIPTION
Fixes an issue where nullable ENUM query parameter had double OneOf -schema
Fixes an issue where nullable collection of Enums query parameter was defined as request body in GET method