### PR TITLE
Updated ConvertToString to always return a non-nullable string

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
@@ -66,7 +66,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile();
 
             //// Assert
-            Assert.Contains(@"foreach (var item_ in elementId) { urlBuilder_.Append(System.Uri.EscapeDataString(""elementId"") + ""="").Append((item_ == null) ? """" : System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(""&""); }", code);
+            Assert.Contains(@"foreach (var item_ in elementId) { urlBuilder_.Append(System.Uri.EscapeDataString(""elementId"") + ""="").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(""&""); }", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -1,13 +1,12 @@
 ﻿{%              if GenerateNullableReferenceTypes -%}
-[return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("value")]
-private string? ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
+private string ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
 {%              else -%}
 private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
 {%              endif -%}
 {
     if (value == null)
     {
-        return null;
+        return "";
     }
 
     if (value is System.Enum)

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -7,7 +7,7 @@ urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Ap
 {% elseif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% elseif parameter.IsArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append((item_ == null) ? "" : System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% elseif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
@@ -21,7 +21,7 @@ if ({{parameter.Name}}.{{property.Name}} != null && {{parameter.Name}}.{{propert
     urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]") + "=");
     foreach (var p_ in {{parameter.Name}}.{{property.Name}})
     {
-        urlBuilder_.Append((p_ == null) ? "" : System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(",");
+        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(",");
     }
     urlBuilder_.Length--;
     urlBuilder_.Append("&");


### PR DESCRIPTION
Broadens compatibility with older frameworks (like netstandard 2.0) that doesn't support `NotNullIfNotNull`.

I checked all usages of ConvertToString to avoid breaking changes:

https://github.com/RicoSuter/NSwag/blob/3787156acfc9ec6b519289d54fad312d1963da4b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid#L10
was guarded by `(item_ == null) ? "" : ` . I removed the check for simplicity, because it will return an empty string. No functional change here


https://github.com/RicoSuter/NSwag/blob/3787156acfc9ec6b519289d54fad312d1963da4b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid#L15 Already guarded by an if, no change here


https://github.com/RicoSuter/NSwag/blob/3787156acfc9ec6b519289d54fad312d1963da4b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid#L24 Removed the check the same way as above.


https://github.com/RicoSuter/NSwag/blob/3787156acfc9ec6b519289d54fad312d1963da4b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid#L43 Null are filtered out by the line above, no change.


https://github.com/RicoSuter/NSwag/blob/ec30ee0c862ee345e869e8a0da5b82155cdc5294/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid#L12 Would throw an `ArgumentNullException` if a null was given. Now transforms the null to "". Not sure if that's checked upstream or whether nobody faced the issue. Or maybe they just convert all their null parameters to "" by themself.


https://github.com/RicoSuter/NSwag/blob/cffdb99fd36e39cb7a3441336d9472e32cda40e1/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid#L4 Seems to be OK :  https://github.com/dotnet/runtime/blob/0e402bcd28f38a3b65720474dcd7a338cab0841d/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs#L139

https://github.com/RicoSuter/NSwag/blob/6ce40aa83b5b46f98fb089a0622cd55bf9d777c7/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid#L216 Not executed if it is null


https://github.com/RicoSuter/NSwag/blob/6ce40aa83b5b46f98fb089a0622cd55bf9d777c7/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid#L249 If I read it correctly, it cannot be null in that block

