### PR TITLE
Change ConvertToString to handle the possibility of System.Convert.ToString returning null

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -26,7 +26,8 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
                 }
             }
 
-            return System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+            var converted = System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+            return converted == null ? string.Empty : converted;
         }
     }
     else if (value is bool) 


### PR DESCRIPTION
refs #3108 - ```System.Convert.ToString()``` is documented as being able to return null, but ```ConvertToString()``` isn't supposed to return null in this case, which provokes a ```CS8825``` warning with some compiler versions.

I'm not sure if this specific case (converting an enum) will return null in any normal case, but in case it does, this change adopts the approach used in the default case at the end of the function, which is to return string.Empty rather than null in this case.