### PR TITLE
Disable CS8073 warnings in the generated C# client files

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -17,6 +17,7 @@ using {{ usage }};
 #pragma warning disable 472 // Disable "CS0472 The result of the expression is always 'false' since a value of type 'Int32' is never equal to 'null' of type 'Int32?'
 #pragma warning disable 1573 // Disable "CS1573 Parameter '...' has no matching param tag in the XML comment for ...
 #pragma warning disable 1591 // Disable "CS1591 Missing XML comment for publicly visible type or member ..."
+#pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"
 
 namespace {{ Namespace }}
 {


### PR DESCRIPTION
refs #3127 

It's not as 'clean' as changing the code generation to remove the null checks for value types alltogether, but it is inkeeping with the existing suppression of CS0472 which silences similar warnings for parameters of types like ```int```, so maybe it's acceptable at least in the short term?

Just a thought really (the currently generated code breaks the build for a project I work on that has WarningsAsErrors enabled if you try to build it againt .NET 5, so it's helpful to get something done with it)