### PR TITLE
Fix npm package for .NET5

### DIFF
--- a/build/01_Build.bat
+++ b/build/01_Build.bat
@@ -15,6 +15,7 @@ xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp2.1/publish" "%~dp0/
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp2.2/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore22" /E /I /y
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp3.0/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore30" /E /I /y
 xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/netcoreapp3.1/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/NetCore31" /E /I /y
+xcopy "%~dp0/../src/NSwag.ConsoleCore/bin/release/net5.0/publish" "%~dp0/../src/NSwag.Npm/bin/binaries/Net50" /E /I /y
 
 REM Package nuspecs
 "%~dp0/nuget.exe" pack "%~dp0/../src/NSwag.MSBuild/NSwag.MSBuild.nuspec" || goto :error


### PR DESCRIPTION
Fixes #3166
Just copies the binary to net50 directory
See https://github.com/RicoSuter/NSwag/pull/3115/files#r523072120

I realize this is a bit of a drive-by pull request. If it doesn't look obviously correct just let me know and I'll dig into it properly