### PR TITLE
Update Header template to respect ParameterDateTimeFormat parameter

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
@@ -1,5 +1,7 @@
 {% if parameter.IsStringArray -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
+{% elseif parameter.IsDateTime -%}
+request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 {% else -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
 {% endif -%}


### PR DESCRIPTION
The API I'm working with requires all dates to be formatted specifically, which works with parameters set in the URL (path).  When used in headers, however, this setting isn't taken into account anymore, and I get the result of this:

https://github.com/RicoSuter/NSwag/blob/d82f58859ac62a4f8729727ae66af6b2c4600ebe/src/NSwag.Integration.Console/ServiceClients.cs#L959

There may be more possible cases for HeaderParameter (see [PathParameter.liquid](https://github.com/RicoSuter/NSwag/blob/master/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid)), but my schema doesn't contain any of these other cases.

I've solved this myself locally by using TemplateDirectory, but I figured this may help somebody like me in the future with the same issue.