### PR TITLE
Change c# template to suppot MSBUILD14.0

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -44,5 +44,5 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
     }
 
     var result = System.Convert.ToString(value, cultureInfo);
-    return (result is null) ? string.Empty : result;
+    return result == null ? "" : result;
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -44,5 +44,5 @@ private string ConvertToString(object value, System.Globalization.CultureInfo cu
     }
 
     var result = System.Convert.ToString(value, cultureInfo);
-    return result == null ? "" : result;
+    return (result is null) ? string.Empty : result;
 }


### PR DESCRIPTION
(result is null) is not supported on MSBUILD 14.0 (used by Visual Studio 2015). Therfore changed to (result == null).

Fixes #3183 