### PR TITLE
Fixed issue #2545: Client generation in NSwagStudio exceptions

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
@@ -120,5 +120,62 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Assert.DoesNotContain("System.Threading.Tasks.Task<object>", code);
             Assert.Contains("class BusinessException", code);
         }
+
+        [Fact]
+        public async Task When_same_response_is_referenced_multiple_times_in_operation_then_class_is_generated()
+        {
+            string json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/v1/exceptions/get"": {
+      ""get"": {
+        ""operationId"": ""Exceptions_GetException"",
+        ""responses"": {
+          ""200"": {
+            ""$ref"": ""#/components/responses/BusinessExceptionResponse"",
+            },
+          ""400"": {
+            ""$ref"": ""#/components/responses/BusinessExceptionResponse"",
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""BusinessException"": {
+        ""type"": ""object"",
+        ""additionalProperties"": false
+      }
+    },
+    ""responses"": {
+      ""BusinessExceptionResponse"": {
+        ""description"": ""List of NSwagStudio bugs"",
+        ""content"": {
+          ""application/json"": {
+            ""schema"": {
+              ""type"": ""array"",
+              ""items"": {
+                ""$ref"": ""#/components/schemas/BusinessException""
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            //// Act
+            Assert.Contains("System.Threading.Tasks.Task<System.Collections.Generic.ICollection<BusinessException>>", code);
+            Assert.Contains("class BusinessException", code);
+        }
     }
 }

--- a/src/NSwag.Core/OpenApiResponse.cs
+++ b/src/NSwag.Core/OpenApiResponse.cs
@@ -120,7 +120,7 @@ namespace NSwag
         /// <returns>The result.</returns>
         public bool IsBinary(OpenApiOperation operation)
         {
-            if (operation.ActualResponses.SingleOrDefault(r => r.Value == this).Key != "204")
+            if (operation.ActualResponses.Any(r => r.Value == this && r.Key != "204"))
             {
                 if (ActualResponse.Content.Any())
                 {


### PR DESCRIPTION
Description of the symptoms in the issue. 
Problem: The modified offending line, is assuming that a response schema can be used only once in an operation. Case where this is false: when there are multiple error responses that return the same structure.
Solution: changed to Any() construct and validated that there isat least one response that isn't 203.
Tests: added from the issue (modified).

Fixes #2545