### PR TITLE
Fix issue #3208 - headers should not be URI encoded

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
@@ -1,7 +1,7 @@
 {% if parameter.IsStringArray -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
 {% elseif parameter.IsDateTime -%}
-request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
+request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
 {% else -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
 {% endif -%}


### PR DESCRIPTION
My previous pull request [#3174](https://github.com/RicoSuter/NSwag/pull/3174) mistakenly URI-encoded the datetime header.  This issue is pointed out in #3208.

My original pull request worked for me, but #3208 is correct in that the date should not be encoded (no other headers are).