### PR TITLE
Fixing FormData generated for typescript with array property (v13.10.0)

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/ArrayParameterTests.cs
@@ -68,5 +68,80 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             //// Assert
             Assert.Contains(@"elementId.forEach(item => { url_ += ""elementId="" + encodeURIComponent("""" + item) + ""&""; });", code);
         }
+
+
+        [Fact]
+        public async Task when_content_is_formdata_with_property_array_then_content_should_be_added_in_foreach_in_typescript()
+        {
+            var json = @"{
+              ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+              ""openapi"": ""3.0.0"",
+              ""info"": {
+                ""title"": ""My Title"",
+                ""version"": ""1.0.0""
+              },
+              ""paths"": {
+                ""/api/FileUpload/UploadFile"": {
+                  ""post"": {
+                    ""tags"": [
+                      ""FileUpload""
+                    ],
+                    ""operationId"": ""FileUpload_UploadFile"",
+                    ""requestBody"": {
+                      ""content"": {
+                        ""multipart/form-data"": {
+                          ""schema"": {
+                            ""properties"": {
+                              ""file"": {
+                                ""type"": ""string"",
+                                ""format"": ""binary""
+                              },
+                              ""arrayOfIds"": {
+                                ""uniqueItems"": true,
+                                ""type"": ""array"",
+                                ""items"": {
+                                  ""type"": ""string""
+                                },
+                                ""description"": ""Hash Set of of strings in the DTO request"",
+                                ""nullable"": true
+                              },
+                              ""test"": {
+                                ""type"": ""string""
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    ""responses"": {
+                      ""200"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""application/octet-stream"": {
+                            ""schema"": {
+                              ""type"": ""string"",
+                              ""format"": ""binary""
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+    
+              },
+              ""components"": {}
+            }";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings());
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("const content_ = new FormData();", code);
+            Assert.Contains("arrayOfIds.forEach(item_ => content_.append(\"arrayOfIds\", item_.toString());", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -59,6 +59,8 @@ else
 {%                 endif -%}
 {%             elseif parameter.IsDateOrDateTime -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toJSON());
+{%             elseif parameter.IsArray -%}
+    {{ parameter.VariableName }}.forEach(item_ => content_.append("{{ parameter.Name }}", item_.toString());
 {%             else -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toString());
 {%             endif -%}


### PR DESCRIPTION
The scenario is when the content type is form-data and there is an array property in the schema it was generating something like:
content_.append("arrayOfIds", arrayOfIds.toString());
Which was wrong because in the Api request it was always an array of one item with the string concat in comma.
To fix this I've changed the template to check if the parameter is an array it should generate the typescript contract with the code:
arrayOfIds.forEach(item_ => content_.append("arrayOfIds", item_.toString());

