### PR TITLE
#3258 changed an else if to an else for nullable query parameters

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -25,7 +25,7 @@ else
 {%         if parameter.IsNullable -%}
 if ({{ parameter.VariableName }} === undefined)
     throw new Error("The parameter '{{ parameter.VariableName }}' must be defined.");
-else if({{ parameter.VariableName }} !== null)
+else
 {%         else -%}
 if ({{ parameter.VariableName }} === undefined || {{ parameter.VariableName }} === null)
     throw new Error("The parameter '{{ parameter.VariableName }}' must be defined and cannot be null.");


### PR DESCRIPTION
Unfortunately im not sure how to test this, so i haven't but this should fix the issue.

if the param is undefined an error should definitely be shown but if a null is passed the null should be added to the url (because its a nullable param)