### PR TITLE
Update Microsoft.AspNetCore.Mvc.* references in NSwag.AspNetCore to 1.0.6

### DIFF
--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -18,8 +18,8 @@
     <!-- Execute PopulateNuspec fairly late. -->
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);PopulateNuspec</GenerateNuspecDependsOn>
 
-    <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.4</MicrosoftAspNetCoreMvcCorePackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.4</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
+    <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.6</MicrosoftAspNetCoreMvcCorePackageVersion>
+    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.6</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.4</MicrosoftAspNetCoreStaticFilesPackageVersion>
     <MicrosoftExtensionsApiDescriptionServerPackageVersion>3.0.0</MicrosoftExtensionsApiDescriptionServerPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>


### PR DESCRIPTION
Hi,

A project that I work on which uses NSwag.AspNetCore (13.9.4) has recently been run through Whitesource, and that has complained that it depends on Microsoft.AspNetCore.Mvc.Core version 1.0.4, which suffers from [CVE-2017-8700](https://github.com/aspnet/announcements/issues/279).

The Microsoft announcement says that CVE was fixed in the 1.0.6 update, so this is a simple go at silencing the warning by updating the dependencies to that version.