### PR TITLE
Adding support to the object parameter for multipart/form-data

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
@@ -68,5 +68,81 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             //// Assert
             Assert.Contains(@"foreach (var item_ in elementId) { urlBuilder_.Append(System.Uri.EscapeDataString(""elementId"") + ""="").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(""&""); }", code);
         }
+        
+        [Fact]
+        public async Task when_content_is_formdata_with_property_array_then_content_should_be_added_in_foreach_in_csharp()
+        {
+            var json = @"{
+              ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+              ""openapi"": ""3.0.0"",
+              ""info"": {
+                ""title"": ""My Title"",
+                ""version"": ""1.0.0""
+              },
+              ""paths"": {
+                ""/api/FileUpload/UploadFile"": {
+                  ""post"": {
+                    ""tags"": [
+                      ""FileUpload""
+                    ],
+                    ""operationId"": ""FileUpload_UploadFile"",
+                    ""requestBody"": {
+                      ""content"": {
+                        ""multipart/form-data"": {
+                          ""schema"": {
+                            ""properties"": {
+                              ""file"": {
+                                ""type"": ""string"",
+                                ""format"": ""binary""
+                              },
+                              ""arrayOfIds"": {
+                                ""uniqueItems"": true,
+                                ""type"": ""array"",
+                                ""items"": {
+                                  ""type"": ""string""
+                                },
+                                ""description"": ""Hash Set of of strings in the DTO request"",
+                                ""nullable"": true
+                              },
+                              ""test"": {
+                                ""type"": ""string""
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    ""responses"": {
+                      ""200"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""application/octet-stream"": {
+                            ""schema"": {
+                              ""type"": ""string"",
+                              ""format"": ""binary""
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+    
+              },
+              ""components"": {}
+            }";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
+            Assert.Contains("foreach (var item_ in arrayOfIds)", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(item_), \"arrayOfIds\");", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace NSwag.CodeGeneration.CSharp.Tests
+{
+    public class ObjectParameterTests
+    {
+        [Fact]
+        public async Task when_content_is_formdata_with_property_object_then_content_should_be_json_csharp()
+        {
+            var json = @"{
+              ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+              ""openapi"": ""3.0.0"",
+              ""info"": {
+                ""title"": ""My Title"",
+                ""version"": ""1.0.0""
+              },
+              ""paths"": {
+                ""/api/FileUpload/UploadFile"": {
+                  ""post"": {
+                    ""tags"": [
+                      ""FileUpload""
+                    ],
+                    ""operationId"": ""FileUpload_UploadFile"",
+                    ""requestBody"": {
+                      ""content"": {
+                        ""multipart/form-data"": {
+                          ""schema"": {
+                            ""properties"": {
+                              ""file"": {
+                                ""type"": ""string"",
+                                ""format"": ""binary""
+                              },
+                              ""propertyDto"": {
+                                ""type"": ""object"",
+                                ""description"": ""Configurable properties""
+                              },
+                              ""test"": {
+                                ""type"": ""string""
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    ""responses"": {
+                      ""200"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""application/octet-stream"": {
+                            ""schema"": {
+                              ""type"": ""string"",
+                              ""format"": ""binary""
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+    
+              },
+              ""components"": {}
+            }";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(propertyDto)), \"propertyDto\");", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -249,6 +249,14 @@
                         content_{{ parameter.VariableName }}_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse({{ parameter.VariableName }}.ContentType);
                     content_.Add(content_{{ parameter.VariableName }}_, "{{ parameter.Name }}", {{ parameter.VariableName }}.FileName ?? "{{ parameter.Name }}");
 {%                         endif -%}
+
+{%                      elseif parameter.IsArray -%}
+                    foreach (var item_ in {{ parameter.VariableName }})
+                    {
+                        content_.Add(new System.Net.Http.StringContent(item_), "{{ parameter.Name }}");
+                    }
+{%                      elseif parameter.IsObject -%}
+                    content_.Add(new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ parameter.VariableName }})), "{{ parameter.Name }}");
 {%                     else -%}
                     content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
 {%                     endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -249,7 +249,6 @@
                         content_{{ parameter.VariableName }}_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse({{ parameter.VariableName }}.ContentType);
                     content_.Add(content_{{ parameter.VariableName }}_, "{{ parameter.Name }}", {{ parameter.VariableName }}.FileName ?? "{{ parameter.Name }}");
 {%                         endif -%}
-
 {%                      elseif parameter.IsArray -%}
                     foreach (var item_ in {{ parameter.VariableName }})
                     {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -249,12 +249,12 @@
                         content_{{ parameter.VariableName }}_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse({{ parameter.VariableName }}.ContentType);
                     content_.Add(content_{{ parameter.VariableName }}_, "{{ parameter.Name }}", {{ parameter.VariableName }}.FileName ?? "{{ parameter.Name }}");
 {%                         endif -%}
-{%                      elseif parameter.IsArray -%}
+{%                     elseif parameter.IsArray -%}
                     foreach (var item_ in {{ parameter.VariableName }})
                     {
                         content_.Add(new System.Net.Http.StringContent(item_), "{{ parameter.Name }}");
                     }
-{%                      elseif parameter.IsObject -%}
+{%                     elseif parameter.IsObject -%}
                     content_.Add(new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ parameter.VariableName }})), "{{ parameter.Name }}");
 {%                     else -%}
                     content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/ObjectParameterTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/ObjectParameterTests.cs
@@ -1,0 +1,77 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    public class ObjectParameterTests
+    {
+        [Fact]
+        public async Task when_content_is_formdata_with_property_object_then_content_should_be_json_typescript()
+        {
+            var json = @"{
+              ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+              ""openapi"": ""3.0.0"",
+              ""info"": {
+                ""title"": ""My Title"",
+                ""version"": ""1.0.0""
+              },
+              ""paths"": {
+                ""/api/FileUpload/UploadFile"": {
+                  ""post"": {
+                    ""tags"": [
+                      ""FileUpload""
+                    ],
+                    ""operationId"": ""FileUpload_UploadFile"",
+                    ""requestBody"": {
+                      ""content"": {
+                        ""multipart/form-data"": {
+                          ""schema"": {
+                            ""properties"": {
+                              ""file"": {
+                                ""type"": ""string"",
+                                ""format"": ""binary""
+                              },
+                              ""propertyDto"": {
+                                ""type"": ""object"",
+                                ""description"": ""Configurable properties""
+                              },
+                              ""test"": {
+                                ""type"": ""string""
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    ""responses"": {
+                      ""200"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""application/octet-stream"": {
+                            ""schema"": {
+                              ""type"": ""string"",
+                              ""format"": ""binary""
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+    
+              },
+              ""components"": {}
+            }";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings());
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("const content_ = new FormData();", code);
+            Assert.Contains("content_.append(\"propertyDto\", JSON.stringify(propertyDto))", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -59,6 +59,8 @@ else
 {%                 endif -%}
 {%             elseif parameter.IsDateOrDateTime -%}
     content_.append("{{ parameter.Name }}", {{ parameter.VariableName }}.toJSON());
+{%             elseif parameter.IsObject -%}
+    content_.append("{{ parameter.Name }}", JSON.stringify({{ parameter.VariableName }}));
 {%             elseif parameter.IsArray -%}
     {{ parameter.VariableName }}.forEach(item_ => content_.append("{{ parameter.Name }}", item_.toString()));
 {%             else -%}


### PR DESCRIPTION
Adding support to the object parameter for multipart/form-data. 
The object parameter should be added in the content as json stringify.

