### PR TITLE
Fix issue #3312 with Arrays + complex objects

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
@@ -142,7 +142,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             //// Assert
             Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
             Assert.Contains("foreach (var item_ in arrayOfIds)", code);
-            Assert.Contains("content_.Add(new System.Net.Http.StringContent(item_), \"arrayOfIds\");", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(ConvertToString(arrayOfIds, System.Globalization.CultureInfo.InvariantCulture)), \"arrayOfIds\");", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
@@ -142,7 +142,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             //// Assert
             Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
             Assert.Contains("foreach (var item_ in arrayOfIds)", code);
-            Assert.Contains("content_.Add(new System.Net.Http.StringContent(ConvertToString(arrayOfIds, System.Globalization.CultureInfo.InvariantCulture)), \"arrayOfIds\");", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture)), \"arrayOfIds\");", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -252,7 +252,7 @@
 {%                     elseif parameter.IsArray -%}
                     foreach (var item_ in {{ parameter.VariableName }})
                     {
-                        content_.Add(new System.Net.Http.StringContent(item_), "{{ parameter.Name }}");
+                        content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
                     }
 {%                     elseif parameter.IsObject -%}
                     content_.Add(new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ parameter.VariableName }}, {% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value)), "{{ parameter.Name }}");

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -252,7 +252,7 @@
 {%                     elseif parameter.IsArray -%}
                     foreach (var item_ in {{ parameter.VariableName }})
                     {
-                        content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
+                        content_.Add(new System.Net.Http.StringContent(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
                     }
 {%                     elseif parameter.IsObject -%}
                     content_.Add(new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject({{ parameter.VariableName }}, {% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value)), "{{ parameter.Name }}");


### PR DESCRIPTION
Now `ConvertToString` is used instead of simple `ToString()` call (not compilable)

After I took a deep dive into the source code it looks like to me that the `ConvertToString` is missing for arrays with complex objects.

I Adjusted the Test accordingly (validate for new string after creation).

Local test works with manual change (like now provided in the Template)

It should fix #3312 