### PR TITLE
Use latest version of DiagnosticSource in NSwag.Console for .NET 4.

### DIFF
--- a/src/NSwag.Console.x86/NSwag.Console.x86.csproj
+++ b/src/NSwag.Console.x86/NSwag.Console.x86.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="NConsole" Version="3.9.6519.30868" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.18" />

--- a/src/NSwag.Console/NSwag.Console.csproj
+++ b/src/NSwag.Console/NSwag.Console.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="NConsole" Version="3.9.6519.30868" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.18" />


### PR DESCRIPTION
This makes it possible to use it with projects which reference latest version of DiagnosticSource.
Fixes #3292