### PR TITLE
fix C# Client nullable body guard

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/AllowNullableBodyParametersTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/AllowNullableBodyParametersTests.cs
@@ -1,13 +1,60 @@
+using Microsoft.AspNetCore.Mvc;
+using NSwag.CodeGeneration.OperationNameGenerators;
+using NSwag.Generation.WebApi;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using NSwag.Generation.WebApi;
 using Xunit;
 
 namespace NSwag.CodeGeneration.CSharp.Tests
 {
     public class AllowNullableBodyParametersTests
     {
+        [Fact]
+        public async Task TestNoGuardForOptionalBodyParameter()
+        {
+            //// Arrange
+            var swagger =
+@"{
+  ""openapi"": ""3.0.1"",
+  ""paths"": {
+    ""/definitions/{definitionId}/elements"": {
+      ""get"": {
+        ""operationId"": ""elements_LIST_1"",
+        ""requestBody"": {
+          ""content"": {
+            ""*/*"": {
+              ""schema"": {
+                ""type"": ""integer"",
+                ""format"": ""int64""
+              }
+            }
+          }
+        },
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success""
+          }
+        }
+      }
+    }
+  }
+}";
+            var document = await OpenApiDocument.FromJsonAsync(swagger);
+
+            //// Act
+            var codeGen = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings()
+            {
+                UseBaseUrl = false,
+                GenerateClientInterfaces = true,
+                OperationNameGenerator = new SingleClientFromOperationIdOperationNameGenerator()
+            });
+
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain("throw new System.ArgumentNullException(\"body\")", code);
+        }
+
         [Fact]
         public async Task TestNullableBodyWithAllowNullableBodyParameters()
         {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -127,7 +127,7 @@
 
 {%         endif -%}
 {%     endfor -%}
-{%     if operation.HasContent and operation.ContentParameter.IsNullable != true -%}
+{%     if operation.HasContent and operation.ContentParameter.IsRequired -%}
         if ({{ operation.ContentParameter.VariableName }} == null)
             throw new System.ArgumentNullException("{{ operation.ContentParameter.VariableName }}");
 


### PR DESCRIPTION
Due to changes introduced in commit e5d6903edd0b82044dccbdf84d86adeb4ee53829 generatic C# Client from swagger.json below will add `null` guard for optional body parameter. Due to recent changes to `IsRequired` and `IsNullable` evaluation from commit b35310290ed944dc7af40088564197e2f2efbf4a it makes sense to revert change from e5d6903edd0b82044dccbdf84d86adeb4ee53829 and use `IsRequired` instead of `IsNullable` to evaluate whether a guard is needed

```
{
  "openapi": "3.0.1",
  "paths": {
    "testOp": {
      "get": {
        "operationId": "testOp",
        "requestBody": {
          "content": {
            "*/*": {
              "schema": {
                "type": "integer",
                "format": "int64"
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "Success"
          }
        }
      }
    }
  }
}
```


