### PR TITLE
Add option, OutputPath, to allow seting the location where the project output is located

### DIFF
--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
@@ -61,8 +61,8 @@ namespace NSwag.Commands.Generation.AspNetCore
         [Argument(Name = nameof(NoBuild), IsRequired = false, Description = "Don't build the project. Only use this when the build is up-to-date.")]
         public bool NoBuild { get; set; }
 
-        [Argument(Name = nameof(OutputPath), IsRequired = false, Description = "Path to the MSBUILD output directory")]
-        public string OutputPath { get; set; }
+        [Argument(Name = nameof(MSBuildOutputPath), IsRequired = false, Description = "The MSBuild output path")]
+        public string MSBuildOutputPath { get; set; }
 
         [Argument(Name = nameof(Verbose), IsRequired = false, Description = "Print verbose output.")]
         public bool Verbose { get; set; } = true;
@@ -110,7 +110,7 @@ namespace NSwag.Commands.Generation.AspNetCore
                     Configuration,
                     Runtime,
                     NoBuild,
-                    OutputPath,
+                    MSBuildOutputPath,
                     verboseHost).ConfigureAwait(false);
 
                 if (!File.Exists(Path.Combine(projectMetadata.OutputPath, projectMetadata.TargetFileName)))

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
@@ -61,6 +61,9 @@ namespace NSwag.Commands.Generation.AspNetCore
         [Argument(Name = nameof(NoBuild), IsRequired = false, Description = "Don't build the project. Only use this when the build is up-to-date.")]
         public bool NoBuild { get; set; }
 
+        [Argument(Name = nameof(OutputPath), IsRequired = false, Description = "Path to the MSBUILD output directory")]
+        public string OutputPath { get; set; }
+
         [Argument(Name = nameof(Verbose), IsRequired = false, Description = "Print verbose output.")]
         public bool Verbose { get; set; } = true;
 
@@ -107,6 +110,7 @@ namespace NSwag.Commands.Generation.AspNetCore
                     Configuration,
                     Runtime,
                     NoBuild,
+                    OutputPath,
                     verboseHost).ConfigureAwait(false);
 
                 if (!File.Exists(Path.Combine(projectMetadata.OutputPath, projectMetadata.TargetFileName)))

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/ProjectMetadata.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/ProjectMetadata.cs
@@ -78,6 +78,7 @@ namespace NSwag.Commands.Generation.AspNetCore
             string configuration,
             string runtime,
             bool noBuild,
+            string outputPath,
             IConsoleHost console = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(file), "file is null or empty.");
@@ -135,6 +136,11 @@ namespace NSwag.Commands.Generation.AspNetCore
                     args.Add("/p:RuntimeIdentifier=" + runtime);
                 }
 
+                if (!string.IsNullOrEmpty(outputPath))
+                {
+                    args.Add("/p:OutputPath=" + outputPath);
+                }
+
                 if (!string.IsNullOrEmpty(file))
                 {
                     args.Add(file);
@@ -180,7 +186,13 @@ namespace NSwag.Commands.Generation.AspNetCore
             };
 
             projectMetadata.ProjectDir = Path.GetFullPath(projectMetadata.ProjectDir);
-            projectMetadata.OutputPath = Path.GetFullPath(Path.Combine(projectMetadata.ProjectDir, projectMetadata.OutputPath));
+
+            if (string.IsNullOrEmpty(outputPath))
+            {
+                projectMetadata.OutputPath = Path.Combine(projectMetadata.ProjectDir, projectMetadata.OutputPath);
+            }
+
+            projectMetadata.OutputPath = Path.GetFullPath(projectMetadata.OutputPath);
 
             return projectMetadata;
         }

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -51,6 +51,10 @@
                         <TextBox Text="{Binding Command.TargetFramework, Mode=TwoWay}" 
                                  ToolTip="TargetFramework" Margin="0,0,0,12" />
 
+                        <TextBlock Text="MSBuildOutputPath" FontWeight="Bold" Margin="0,0,0,6" />
+                        <TextBox Text="{Binding Command.MSBuildOutputPath, Mode=TwoWay}"
+                                 ToolTip="MSBuildOutputPath" Margin="0,0,0,12" />
+
                         <CheckBox IsChecked="{Binding Command.NoBuild, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="NoBuild">
                             <TextBlock Text="NoBuild" TextWrapping="Wrap" />
                         </CheckBox>


### PR DESCRIPTION
NSwag currently uses the default OutputPath from MSBuild. For normal builds this is sufficient, however if a project is build with a different outputPath (dotnet build -o or msbuild .. /p:OutputPath), it breaks with the following error: _'Project outputs could not be located in ..'_.

This PR fixes the problem, by adding an extra option called OutputPath, which contains the location where the project output is located.

Fixes: at least #2168 