### PR TITLE
Revert breaking changes introduced by PR#3195

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -131,7 +131,7 @@
 
 {%         endif -%}
 {%     endfor -%}
-{%     if operation.HasContent and operation.ContentParameter.IsNullable != true -%}
+{%     if operation.HasContent and operation.ContentParameter.IsRequired -%}
         if ({{ operation.ContentParameter.VariableName }} == null)
             throw new System.ArgumentNullException("{{ operation.ContentParameter.VariableName }}");
 


### PR DESCRIPTION
[Small regression](https://github.com/RicoSuter/NSwag/issues/2736#issuecomment-678384132 ) with 'mvcoptions.AllowEmptyInputInBodyModelBinding = true' was also fixed later by [b7883ef3bd](https://github.com/RicoSuter/NSwag/pull/3117/files#diff-b7883ef3bd60fb5f6833e6f36a24e5f9e12e8498a2959e7d9fb9084e75a811c1R348) within [PR3117](https://github.com/RicoSuter/NSwag/pull/3117). And my fix was definitely done in wrong place.
Now **IsRequired** and **IsNullable** during schema generation are calculated based on AllowEmptyInputInBodyModelBinding as well and that is great.