### PR TITLE
Drop deprecated Microsoft.AspNetCore.*

### DIFF
--- a/src/NSwag.Annotations/NSwag.Annotations.csproj
+++ b/src/NSwag.Annotations/NSwag.Annotations.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../NSwag.snk</AssemblyOriginatorKeyFile>
     <Authors>Rico Suter</Authors>
-    <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</PackageIconUrl>
+    <PackageIcon>NuGetIcon.png</PackageIcon>
     <Company />
     <RepositoryType>git</RepositoryType> 
     <RepositoryUrl>https://github.com/RicoSuter/NSwag.git</RepositoryUrl> 
@@ -22,6 +22,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\NuGetIcon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/NSwag.Annotations/OpenApiExtensionDataAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiExtensionDataAttribute.cs
@@ -14,7 +14,9 @@ namespace NSwag.Annotations
     /// <remarks>Requires the SwaggerExtensionDataOperationProcessor to be used in the Swagger definition generation.</remarks>
     /// <seealso cref="Attribute" />
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = true)]
+#pragma warning disable 618
     public sealed class OpenApiExtensionDataAttribute : SwaggerExtensionDataAttribute
+#pragma warning restore 618
     {
         /// <summary>Initializes a new instance of the <see cref="SwaggerExtensionDataAttribute"/> class.</summary>
         /// <param name="key">The key.</param>

--- a/src/NSwag.Annotations/OpenApiFileAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiFileAttribute.cs
@@ -12,7 +12,9 @@ namespace NSwag.Annotations
 {
     /// <summary>Specifies a parameter or class to be handled as file.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
+#pragma warning disable 618
     public class OpenApiFileAttribute : SwaggerFileAttribute
+#pragma warning restore 618
     {
     }
 

--- a/src/NSwag.Annotations/OpenApiIgnoreAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiIgnoreAttribute.cs
@@ -12,7 +12,9 @@ namespace NSwag.Annotations
 {
     /// <summary>Excludes an action method from the generated Swagger specification.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Parameter)]
+#pragma warning disable 618
     public class OpenApiIgnoreAttribute : SwaggerIgnoreAttribute
+#pragma warning restore 618
     {
     }
 

--- a/src/NSwag.Annotations/OpenApiOperationAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiOperationAttribute.cs
@@ -12,7 +12,9 @@ namespace NSwag.Annotations
 {
     /// <summary>Specifies the operation id, summary and description</summary>
     [AttributeUsage(AttributeTargets.Method)]
+#pragma warning disable 618
     public class OpenApiOperationAttribute : SwaggerOperationAttribute
+#pragma warning restore 618
     {
         /// <summary>Initializes a new instance of the <see cref="OpenApiOperationAttribute"/> class.</summary>
         /// <param name="operationId">The operation ID.</param>

--- a/src/NSwag.Annotations/OpenApiOperationProcessorAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiOperationProcessorAttribute.cs
@@ -13,7 +13,9 @@ namespace NSwag.Annotations
     /// <summary>Registers an operation processor for the given method or class.</summary>
     /// <seealso cref="System.Attribute" />
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+#pragma warning disable 618
     public class OpenApiOperationProcessorAttribute : SwaggerOperationProcessorAttribute
+#pragma warning restore 618
     {
         /// <summary>Initializes a new instance of the <see cref="SwaggerOperationProcessorAttribute"/> class.</summary>
         /// <param name="type">The operation processor type (must implement IOperationProcessor).</param>

--- a/src/NSwag.Annotations/OpenApiTagAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiTagAttribute.cs
@@ -12,7 +12,9 @@ namespace NSwag.Annotations
 {
     /// <summary>Specifies the tags for an operation.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+#pragma warning disable 618
     public class OpenApiTagAttribute : SwaggerTagAttribute
+#pragma warning restore 618
     {
         /// <summary>Initializes a new instance of the <see cref="SwaggerTagAttribute"/> class.</summary>
         public OpenApiTagAttribute(string name) : base(name)

--- a/src/NSwag.Annotations/OpenApiTagsAttribute.cs
+++ b/src/NSwag.Annotations/OpenApiTagsAttribute.cs
@@ -12,7 +12,9 @@ namespace NSwag.Annotations
 {
     /// <summary>Specifies the tags for an operation or a document.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+#pragma warning disable 618
     public class OpenApiTagsAttribute : SwaggerTagsAttribute
+#pragma warning restore 618
     {
         /// <summary>Initializes a new instance of the <see cref="SwaggerTagsAttribute"/> class.</summary>
         /// <param name="tags">The tags.</param>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -68,10 +68,6 @@
     <ProjectReference Include="..\NSwag.Generation\NSwag.Generation.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="obj" />
-  </ItemGroup>
-
   <Target Name="PopulateNuspec">
     <PropertyGroup>
       <NuspecProperties>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.6;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <Version>13.10.8</Version>
     <PackageTags>Swagger Documentation AspNetCore NetCore TypeScript CodeGen</PackageTags>
@@ -11,7 +11,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../NSwag.snk</AssemblyOriginatorKeyFile>
     <Authors>Rico Suter</Authors>
-    <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</PackageIconUrl>
+    <PackageIcon>NuGetIcon.png</PackageIcon>
     <Company />
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
 
@@ -22,7 +22,9 @@
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.6</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.4</MicrosoftAspNetCoreStaticFilesPackageVersion>
     <MicrosoftExtensionsApiDescriptionServerPackageVersion>3.0.0</MicrosoftExtensionsApiDescriptionServerPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>[1.0.1, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>[3.1, 4.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>[5, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
     <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>
@@ -31,36 +33,43 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\..\assets\NuGetIcon.png" Pack="true" PackagePath="" />
     <EmbeddedResource Include="ReDoc\index.html" />
     <EmbeddedResource Include="SwaggerUi\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
     <EmbeddedResource Include="SwaggerUi3\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="$(MicrosoftAspNetCoreMvcFormattersJsonPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
-  </ItemGroup>
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0" />
-  </ItemGroup>-->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.IO.FileSystem" Version="$(SystemIOFileSystemPackageVersion)" />
     <PackageReference Include="System.Xml.XPath.XDocument" Version="$(SystemXmlXPathXDocumentPackageVersion)" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <Compile Remove="Middlewares\WebApiToSwaggerMiddleware.cs" />
-    <Compile Remove="SwaggerExtensions.cs" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NSwag.Annotations\NSwag.Annotations.csproj" />
     <ProjectReference Include="..\NSwag.Core\NSwag.Core.csproj" />
     <ProjectReference Include="..\NSwag.Core.Yaml\NSwag.Core.Yaml.csproj" />
     <ProjectReference Include="..\NSwag.Generation.AspNetCore\NSwag.Generation.AspNetCore.csproj" />
     <ProjectReference Include="..\NSwag.Generation\NSwag.Generation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="obj" />
   </ItemGroup>
 
   <Target Name="PopulateNuspec">
@@ -77,6 +86,8 @@
         microsoftAspNetCoreStaticFilesPackageVersion=$(MicrosoftAspNetCoreStaticFilesPackageVersion);
         microsoftExtensionsApiDescriptionServerPackageVersion=$(MicrosoftExtensionsApiDescriptionServerPackageVersion);
         microsoftExtensionsFileProvidersEmbeddedPackageVersion=$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion);
+        microsoftExtensionsFileProvidersEmbeddedPackageVersionCore31=$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31);
+        microsoftExtensionsFileProvidersEmbeddedPackageVersionNet5=$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5);
         netStandardLibraryPackageVersion=$(NETStandardLibraryPackageVersion);
         systemIOFileSystemPackageVersion=$(SystemIOFileSystemPackageVersion);
         systemXmlXPathXDocumentPackageVersion=$(SystemXmlXPathXDocumentPackageVersion);

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -8,7 +8,7 @@
         <tags>OpenAPI Swagger AspNetCore Documentation CodeGen TypeScript WebApi AspNet</tags>
         <projectUrl>https://github.com/RicoSuter/NSwag</projectUrl>
         <license type="expression">MIT</license>
-        <iconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</iconUrl>
+        <icon>NuGetIcon.png</icon>
         <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
         <dependencies>
             <group targetFramework=".NETFramework4.5.1">
@@ -71,6 +71,7 @@
         </dependencies>
     </metadata>
     <files>
+        <file src="..\..\assets\NuGetIcon.png" target="NuGetIcon.png" />
         <file src="build\*" target="build\" />
         <file src="buildMultiTargeting\*" target="buildMultiTargeting\" />
         <file src="bin\$configuration$\net451\NSwag.AspNetCore.dll" target="lib\net451\" />

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -52,6 +52,22 @@
                 <dependency id="System.IO.FileSystem" version="$systemIOFileSystemPackageVersion$" exclude="Build,Analyzers" />
                 <dependency id="System.Xml.XPath.XDocument" version="$systemXmlXPathXDocumentPackageVersion$" exclude="Build,Analyzers" />
             </group>
+            <group targetFramework="netcoreapp3.1">
+                <dependency id="NSwag.Annotations" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core.Yaml" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation.AspNetCore" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31$" exclude="Build,Analyzers" />
+            </group>
+            <group targetFramework="net5.0">
+                <dependency id="NSwag.Annotations" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core.Yaml" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation.AspNetCore" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5$" exclude="Build,Analyzers" />
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -63,5 +79,9 @@
         <file src="bin\$configuration$\netstandard1.6\NSwag.AspNetCore.xml" target="lib\netstandard1.6\" />
         <file src="bin\$configuration$\netstandard2.0\NSwag.AspNetCore.dll" target="lib\netstandard2.0\" />
         <file src="bin\$configuration$\netstandard2.0\NSwag.AspNetCore.xml" target="lib\netstandard2.0\" />
+        <file src="bin\$configuration$\netcoreapp3.1\NSwag.AspNetCore.dll" target="lib\netcoreapp3.1\" />
+        <file src="bin\$configuration$\netcoreapp3.1\NSwag.AspNetCore.xml" target="lib\netcoreapp3.1\" />
+        <file src="bin\$configuration$\net5.0\NSwag.AspNetCore.dll" target="lib\net5.0\" />
+        <file src="bin\$configuration$\net5.0\NSwag.AspNetCore.xml" target="lib\net5.0\" />
     </files>
 </package>

--- a/src/NSwag.AspNetCore/SwaggerSettings.cs
+++ b/src/NSwag.AspNetCore/SwaggerSettings.cs
@@ -65,7 +65,9 @@ namespace NSwag.AspNetCore
         public TimeSpan ExceptionCacheTime { get; set; } = TimeSpan.FromSeconds(10);
 #endif
 
+#pragma warning disable 618
         internal virtual string ActualSwaggerDocumentPath => DocumentPath.Substring(MiddlewareBasePath?.Length ?? 0);
+#pragma warning restore 618
 
 #if AspNetOwin
         internal T CreateGeneratorSettings(JsonSerializerSettings serializerSettings, object mvcOptions)

--- a/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
@@ -142,7 +142,9 @@ namespace NSwag.AspNetCore
             html = html.Replace("{Urls}", !SwaggerRoutes.Any() ?
                 "undefined" :
                 JsonConvert.SerializeObject(
+#pragma warning disable 618
                     SwaggerRoutes.Select(r => new SwaggerUi3Route(r.Name, TransformToExternalPath(r.Url.Substring(MiddlewareBasePath?.Length ?? 0), request)))
+#pragma warning restore 618
                 ));
 
             html = html.Replace("{ValidatorUrl}", ValidateSpecification ? "undefined" : "null");

--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -42,7 +42,9 @@ namespace NSwag.AspNetCore
         /// <summary>Gets or sets the internal swagger UI route (must start with '/').</summary>
         public string Path { get; set; } = "/swagger";
 
+#pragma warning disable 618
         internal string ActualSwaggerUiPath => Path.Substring(MiddlewareBasePath?.Length ?? 0);
+#pragma warning restore 618
 
         /// <summary>Gets or sets custom inline styling to inject into the index.html</summary>
         public string CustomInlineStyles { get; set; }

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
@@ -68,7 +68,7 @@ namespace NSwag.Commands.Generation.AspNetCore
                         null, createWebHostMethod.GetParameters().Length > 0 ? new object[] { args } : new object[0]);
                     serviceProvider = webHostBuilder.Build().Services;
                 }
-#if NET5_0 || NETCOREAPP3_0
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
                 else
                 {
                     var createHostMethod =

--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -220,7 +220,7 @@ namespace NSwag.Commands.Generation
         public async Task<TSettings> CreateSettingsAsync(AssemblyLoader.AssemblyLoader assemblyLoader, IServiceProvider serviceProvider, string workingDirectory)
         {
             var mvcOptions = serviceProvider?.GetRequiredService<IOptions<MvcOptions>>().Value;
-#if NET5_0 || NETCOREAPP3_0
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
             JsonSerializerSettings serializerSettings;
             try
             {
@@ -302,7 +302,7 @@ namespace NSwag.Commands.Generation
                     }
                     else
                     {
-#if NET5_0 || NETCOREAPP3_0
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
                         method =
                             programType.GetRuntimeMethod("CreateHostBuilder", new[] { typeof(string[]) }) ??
                             programType.GetRuntimeMethod("CreateHostBuilder", new Type[0]);

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <Version>13.10.8</Version>
     <PackageTags>OpenAPI Swagger AspNetCore Documentation CodeGen TypeScript WebApi AspNet</PackageTags>
@@ -47,6 +47,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
+++ b/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
@@ -41,7 +41,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/src/NSwag.Generation.AspNetCore.Tests.Web/NSwag.Generation.AspNetCore.Tests.Web.csproj
+++ b/src/NSwag.Generation.AspNetCore.Tests.Web/NSwag.Generation.AspNetCore.Tests.Web.csproj
@@ -4,10 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="2.2.0" />
   </ItemGroup>

--- a/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
+++ b/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
@@ -6,10 +6,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.142" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -64,7 +64,7 @@ namespace NSwag.Generation.AspNetCore
             dynamic options = null;
             try
             {
-#if NET5_0 || NETCOREAPP3_0
+#if NET5_0 || NETCOREAPP3_1
                 options = new Func<dynamic>(() => serviceProvider?.GetRequiredService(typeof(IOptions<MvcNewtonsoftJsonOptions>)) as dynamic)();
 #else
                 options = new Func<dynamic>(() => serviceProvider?.GetRequiredService(typeof(IOptions<MvcJsonOptions>)) as dynamic)();

--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -64,7 +64,7 @@ namespace NSwag.Generation.AspNetCore
             dynamic options = null;
             try
             {
-#if NET5_0 || NETCOREAPP3_1
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
                 options = new Func<dynamic>(() => serviceProvider?.GetRequiredService(typeof(IOptions<MvcNewtonsoftJsonOptions>)) as dynamic)();
 #else
                 options = new Func<dynamic>(() => serviceProvider?.GetRequiredService(typeof(IOptions<MvcJsonOptions>)) as dynamic)();

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -37,6 +37,18 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  Version="[3.1, 4)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson"  Version="[3.1, 4)" />
+    <PackageReference Include="Microsoft.Extensions.Options"  Version="[3.1, 4)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  Version="[5, 6)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson"  Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Options"  Version="[5, 6)" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NSwag.Generation\NSwag.Generation.csproj" />
   </ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <Version>13.10.8</Version>
     <PackageTags>Swagger Documentation AspNetCore</PackageTags>
@@ -36,6 +36,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  Version="[3.0, 3.1)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson"  Version="[3.0, 3.1)" />
+    <PackageReference Include="Microsoft.Extensions.Options"  Version="[3.0, 3.1)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <Version>13.10.8</Version>
     <PackageTags>Swagger Documentation AspNetCore</PackageTags>
@@ -11,7 +11,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../NSwag.snk</AssemblyOriginatorKeyFile>
     <Authors>Rico Suter</Authors>
-    <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</PackageIconUrl>
+    <PackageIcon>NuGetIcon.png</PackageIcon>
     <Company />
     <RepositoryType>git</RepositoryType> 
     <RepositoryUrl>https://github.com/RicoSuter/NSwag.git</RepositoryUrl> 
@@ -24,14 +24,17 @@
     <DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\..\assets\NuGetIcon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NJsonSchema" Version="10.3.11" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.0.4" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NSwag.Generation/NSwag.Generation.csproj
+++ b/src/NSwag.Generation/NSwag.Generation.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../NSwag.snk</AssemblyOriginatorKeyFile>
     <Authors>Rico Suter</Authors>
-    <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</PackageIconUrl>
+    <PackageIcon>NuGetIcon.png</PackageIcon>
     <Company />
     <RepositoryType>git</RepositoryType> 
     <RepositoryUrl>https://github.com/RicoSuter/NSwag.git</RepositoryUrl> 
@@ -22,6 +22,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\NuGetIcon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NJsonSchema" Version="10.3.11" />


### PR DESCRIPTION
Hi, this PR add new targets `netcoreapp3.1;net5.0` in `NSwag.AspNetCore` so it can remove dependency on obsolete packages (`Microsoft.AspNetCore.Mvc.Core`, `Microsoft.AspNetCore.Mvc.Formatters.Json`, `Microsoft.AspNetCore.StaticFiles`)