### PR TITLE
Add support for free form objects

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
@@ -78,5 +78,225 @@ namespace NSwag.CodeGeneration.CSharp.Tests
                 "urlBuilder_.Append(System.Uri.EscapeDataString(\"limit\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(paging.Limit, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
                 code);
         }
+
+        [Fact]
+        public void When_query_parameter_is_untyped_free_form_object_parameters_are_expanded()
+        {
+            var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""1.0.0"",
+    ""title"": ""Query params tests""
+  },
+  ""servers"": [
+    {
+      ""url"": ""http://localhost:8080""
+    }
+  ],
+  ""paths"": {
+    ""/settings"": {
+      ""get"": {
+        ""summary"": ""List all settings"",
+        ""operationId"": ""listSettings"",
+        ""parameters"": [
+          {
+            ""name"": ""extendedProperties"",
+            ""in"": ""query"",
+            ""description"": ""list setting filter"",
+            ""required"": false,
+            ""style"": ""form"",
+            ""explode"": true,
+            ""schema"": {
+              ""$ref"": ""#/components/schemas/ExtendedProperties""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""An array of settings""
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""ExtendedProperties"": {
+        ""type"": ""object"",
+        ""additionalProperties"": true
+      }
+    }
+  }
+}
+";
+
+            var document = OpenApiDocument.FromJsonAsync(spec).Result;
+
+            //// Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+            Assert.Contains(
+                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                code);
+        }
+
+        [Fact]
+        public void When_query_parameter_is_typed_free_form_object_parameters_are_expanded()
+        {
+            var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""1.0.0"",
+    ""title"": ""Query params tests""
+  },
+  ""servers"": [
+    {
+      ""url"": ""http://localhost:8080""
+    }
+  ],
+  ""paths"": {
+    ""/settings"": {
+      ""get"": {
+        ""summary"": ""List all settings"",
+        ""operationId"": ""listSettings"",
+        ""parameters"": [
+          {
+            ""name"": ""extendedProperties"",
+            ""in"": ""query"",
+            ""description"": ""list setting filter"",
+            ""required"": false,
+            ""style"": ""form"",
+            ""explode"": true,
+            ""schema"": {
+              ""$ref"": ""#/components/schemas/ExtendedProperties""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""An array of settings""
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""ExtendedProperties"": {
+        ""type"": ""object"",
+        ""additionalProperties"": {
+          ""type"": ""string""
+        }
+      }
+    }
+  }
+}
+";
+
+            var document = OpenApiDocument.FromJsonAsync(spec).Result;
+
+            //// Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+            Assert.Contains(
+                "foreach (var item_ in extendedProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                code);
+        }
+
+        [Fact]
+        public void When_query_parameter_is_mixed_free_form_object_parameters_are_expanded()
+        {
+            var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""1.0.0"",
+    ""title"": ""Query params tests""
+  },
+  ""servers"": [
+    {
+      ""url"": ""http://localhost:8080""
+    }
+  ],
+  ""paths"": {
+    ""/settings"": {
+      ""get"": {
+        ""summary"": ""List all settings"",
+        ""operationId"": ""listSettings"",
+        ""parameters"": [
+          {
+            ""name"": ""limit"",
+            ""in"": ""query"",
+            ""description"": ""list setting filter"",
+            ""required"": false,
+            ""schema"": {
+              ""type"": ""integer"",
+              ""format"": ""int32""
+            }
+          },
+          {
+            ""name"": ""extendedProperties"",
+            ""in"": ""query"",
+            ""description"": ""list setting filter"",
+            ""required"": false,
+            ""style"": ""form"",
+            ""explode"": true,
+            ""schema"": {
+              ""$ref"": ""#/components/schemas/ExtendedProperties""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""An array of settings""
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""ExtendedProperties"": {
+        ""type"": ""object"",
+        ""additionalProperties"": {
+          ""type"": ""string""
+        },
+        ""properties"": {
+          ""default"": {
+            ""type"": ""string""
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+            var document = OpenApiDocument.FromJsonAsync(spec).Result;
+
+            //// Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+            Assert.Contains(
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"default\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties.Default, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                code);
+            Assert.Contains(
+                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpParameterModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpParameterModel.cs
@@ -47,5 +47,12 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets a value indicating whether the parameter name is a valid CSharp identifier.</summary>
         public bool IsValidIdentifier => Name.Equals(VariableName, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>Gets a value indicating whether the parameter allows additional properties.</summary>
+        public bool HasAdditionalProperties =>
+            IsObject &&
+            Schema.AllowAdditionalProperties &&
+            !IsDictionary &&
+            Type != "object";
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -8,6 +8,8 @@ urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Ap
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
 {% elseif parameter.IsArray -%}
 foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+{% elseif parameter.IsDictionary -%}
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% elseif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
@@ -34,6 +36,9 @@ if ({{parameter.Name}}.{{property.Name}} != null)
     urlBuilder_.Append(System.Uri.EscapeDataString("{{property.Key}}") + "=").Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
 }
 {%     endfor -%}
-{% else -%}
+{% elseif parameter.HasAdditionalProperties == false -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
+{% endif -%}
+{% if parameter.HasAdditionalProperties -%}
+foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
 {% endif -%}


### PR DESCRIPTION
Fixes #2257

`AdditionalProperties` were supported for the Body but missing for `QueryParameter`.

It seems, that the following `schema` definition will result in `IDictionary<string, string>` until `properties` is explicitly defined. If no `type` is defined (`additionalProperties: true`) or if `properties` are defined, a separate class `ExtendedProperties` is generated.
```json
{
  "ExtendedProperties": {
    "type": "object",
    "additionalProperties": {
      "type": "string"
    }
  }
}
```

Therefore I needed to handle `parameter.IsDictionary` and `parameter.HasAdditionalProperties` seperately. It would be easier if the class is always generated when `parameter.Schema.AllowAdditionalProperties` is `true`. But I'm not too deep into `NJsonSchema` to be able to do this.