### PR TITLE
Typescript named parameters for method invocation

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
@@ -119,5 +119,8 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets a value indicating whether to use the AbortSignal (Fetch template only, default: false).</summary>
         public bool UseAbortSignal => _settings.UseAbortSignal;
+
+        /// <summary>Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException instance.</summary>
+        public bool NamedParameters => _settings.NamedParameters;
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -36,9 +36,9 @@
 
     {% template Client.Method.Documentation %}
     {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}
-    {% if WrapDtoExceptions -%}
+    {% if NamedParameters -%}
     (parameters: {
-            {% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}
+            {% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}; {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}; {% endif %}signal?: AbortSignal | undefined{% endif %}
         })
         const { {% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %} } = parameters;
         {% if UseAbortSignal %}const { signal } = parameters; {% endif %}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -35,7 +35,16 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}): Promise<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}
+    {% if WrapDtoExceptions -%}
+    (parameters: {
+            {% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %}
+        })
+        const { {% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %} } = parameters;
+        {% if UseAbortSignal %}const { signal } = parameters; {% endif %}
+    {% else -%}
+    ({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal | undefined{% endif %})
+    {% endif -%}: Promise<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -111,6 +111,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
 
+        /// <summary>Creates client methods that use position invariant, named parameters as input (default: false).</summary>
+        public bool NamedParameters { get; set; }
+
         internal ITemplate CreateTemplate(object model)
         {
             if (Template == TypeScriptTemplate.Aurelia)

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -394,6 +394,13 @@ namespace NSwag.Commands.CodeGeneration
             return code;
         }
 
+        [Argument(Name = "NamedParameters", IsRequired = false, Description = "Creates client methods that use position invariant, named parameters as input (default: false).")]
+        public bool NamedParameters
+        {
+            get { return Settings.NamedParameters; }
+            set { Settings.NamedParameters = value; }
+        }
+
         public Task<string> RunAsync()
         {
             return Task.Run(async () =>

--- a/src/NSwag.Integration.Tests/VersionMissmatchTest/input/NSwag.CodeGeneration.TypeScript.xml
+++ b/src/NSwag.Integration.Tests/VersionMissmatchTest/input/NSwag.CodeGeneration.TypeScript.xml
@@ -81,6 +81,9 @@
         <member name="P:NSwag.CodeGeneration.TypeScript.Models.TypeScriptClientTemplateModel.WrapDtoExceptions">
             <summary>Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException instance.</summary>
         </member>
+        <member name="P:NSwag.CodeGeneration.TypeScript.Models.TypeScriptClientTemplateModel.NamedParameters">
+            <summary>Creates client methods that use position invariant, named parameters as input (default: false).</summary>
+        </member>
         <member name="T:NSwag.CodeGeneration.TypeScript.Models.TypeScriptFileTemplateModel">
             <summary>The TypeScript file template model.</summary>
         </member>

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
@@ -212,6 +212,13 @@
                         </StackPanel>
                     </GroupBox>
 
+                    <GroupBox Header="Parameter Types" Margin="0,0,0,12">
+                        <StackPanel Margin="4,8,4,-8">
+                            <TextBlock Text="Named Parameters" FontWeight="Bold" Margin="0,0,0,6" />
+                            <TextBox Text="{Binding Command.NamedParameters, Mode=TwoWay}" ToolTip="NamedParameters" Margin="0,0,0,12" />
+                        </StackPanel>
+                    </GroupBox>
+
                     <GroupBox Header="DTO Types" Margin="0,0,0,12">
                         <StackPanel Margin="4,8,4,-8">
                             <CheckBox IsChecked="{Binding Command.GenerateDtoTypes, Mode=TwoWay}" 


### PR DESCRIPTION
Status: proposal

In order to achieve positional independence of the method parameters, this proposal adds a configuration flag that changes the current behavior

```typescript
    test(a: number, b: number | null | undefined): Promise<string | null> {
```

where `const a = 2; const b = 3; test(b,a);` is compiling just fine while not doing what would be expected.
This may in reality become a problem if the OAS changes, e.g. due to some refactoring of the backend code.

By changing to a structure like
```typescript
    test(parameters: {
            a: number; b: number | null | undefined
        }): Promise<string | null> {
        const { a, b } = parameters;
```
the above code will have to change to `test({a,b})`, but is now invariant to changes in the position.

If this is something that you would accept for the code generation, I would love to continue working on this approach.