### PR TITLE
Add x-originalName handling in spec and code generator

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
@@ -362,7 +362,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
                             {
                                 Kind = OpenApiParameterKind.Query,
                                 Name = "foo",
-                                CustomName = "bar",
+                                OriginalName = "bar",
                                 Schema = new JsonSchema
                                 {
                                     Type = JsonObjectType.String

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
@@ -347,7 +347,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
-        public void When_custom_name_is_defined_then_csharp_parameter_is_the_same()
+        public void When_original_name_is_defined_then_csharp_parameter_is_the_same()
         {
             //// Arrange
             var document = new OpenApiDocument();

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
@@ -345,5 +345,41 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Assert.Contains($@"fromQuery.Value.ToString(""{dateFormat}""", code);
             Assert.Contains($@"toQuery.Value.ToString(""{dateTimeFormat}""", code);
         }
+
+        [Fact]
+        public void When_custom_name_is_defined_then_csharp_parameter_is_the_same()
+        {
+            //// Arrange
+            var document = new OpenApiDocument();
+            document.Paths["foo"] = new OpenApiPathItem
+            {
+                {
+                    OpenApiOperationMethod.Get, new OpenApiOperation
+                    {
+                        Parameters =
+                        {
+                            new OpenApiParameter
+                            {
+                                Kind = OpenApiParameterKind.Query,
+                                Name = "foo",
+                                CustomName = "bar",
+                                Schema = new JsonSchema
+                                {
+                                    Type = JsonObjectType.String
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            //// Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("FooAsync(string bar,", code);
+            Assert.Contains("EscapeDataString(\"foo\")", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -21,19 +21,22 @@ namespace NSwag.CodeGeneration
         /// <returns>The parameter name.</returns>
         public string Generate(OpenApiParameter parameter, IEnumerable<OpenApiParameter> allParameters)
         {
-            if (string.IsNullOrEmpty(parameter.Name))
+            var name = !string.IsNullOrEmpty(parameter.CustomName) ? 
+                parameter.CustomName : parameter.Name;
+
+            if (string.IsNullOrEmpty(name))
             {
                 return "unnamed";
             }
 
-            var variableName = ConversionUtilities.ConvertToLowerCamelCase(parameter.Name
+            var variableName = ConversionUtilities.ConvertToLowerCamelCase(name
                 .Replace("-", "_")
                 .Replace(".", "_")
                 .Replace("$", string.Empty)
                 .Replace("[", string.Empty)
                 .Replace("]", string.Empty), true);
 
-            if (allParameters.Count(p => p.Name == parameter.Name) > 1)
+            if (allParameters.Count(p => p.Name == name) > 1)
             {
                 return variableName + parameter.Kind;
             }

--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -21,8 +21,8 @@ namespace NSwag.CodeGeneration
         /// <returns>The parameter name.</returns>
         public string Generate(OpenApiParameter parameter, IEnumerable<OpenApiParameter> allParameters)
         {
-            var name = !string.IsNullOrEmpty(parameter.CustomName) ? 
-                parameter.CustomName : parameter.Name;
+            var name = !string.IsNullOrEmpty(parameter.OriginalName) ? 
+                parameter.OriginalName : parameter.Name;
 
             if (string.IsNullOrEmpty(name))
             {

--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -71,6 +71,13 @@ namespace NSwag.Commands.Generation
             set => Settings.DefaultResponseReferenceTypeNullHandling = value;
         }
 
+        [Argument(Name = nameof(GenerateCustomParameterNames), IsRequired = false, Description = "Generate x-name properties when parameter name is differnt in .NET and HTTP (default: true).")]
+        public bool GenerateCustomParameterNames
+        {
+            get => Settings.GenerateCustomParameterNames;
+            set => Settings.GenerateCustomParameterNames = value;
+        }
+
         [Argument(Name = "DefaultEnumHandling", IsRequired = false, Description = "The default enum handling ('String' or 'Integer'), default: Integer.")]
         public EnumHandling DefaultEnumHandling
         {

--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -71,11 +71,11 @@ namespace NSwag.Commands.Generation
             set => Settings.DefaultResponseReferenceTypeNullHandling = value;
         }
 
-        [Argument(Name = nameof(GenerateCustomParameterNames), IsRequired = false, Description = "Generate x-name properties when parameter name is differnt in .NET and HTTP (default: true).")]
-        public bool GenerateCustomParameterNames
+        [Argument(Name = nameof(GenerateOriginalParameterNames), IsRequired = false, Description = "Generate x-originalName properties when parameter name is differnt in .NET and HTTP (default: true).")]
+        public bool GenerateOriginalParameterNames
         {
-            get => Settings.GenerateCustomParameterNames;
-            set => Settings.GenerateCustomParameterNames = value;
+            get => Settings.GenerateOriginalParameterNames;
+            set => Settings.GenerateOriginalParameterNames = value;
         }
 
         [Argument(Name = "DefaultEnumHandling", IsRequired = false, Description = "The default enum handling ('String' or 'Integer'), default: Integer.")]

--- a/src/NSwag.Core/OpenApiParameter.cs
+++ b/src/NSwag.Core/OpenApiParameter.cs
@@ -44,9 +44,9 @@ namespace NSwag
             }
         }
 
-        /// <summary>Gets or sets a custom name which is often used in code generation (default: null).</summary>
-        [JsonProperty(PropertyName = "x-name", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public string CustomName { get; set; }
+        /// <summary>Gets or sets a original name property x-originalName which is often used in code generation (default: null).</summary>
+        [JsonProperty(PropertyName = "x-originalName", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string OriginalName { get; set; }
 
         /// <summary>Gets or sets the kind of the parameter.</summary>
         [JsonProperty(PropertyName = "in", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/NSwag.Core/OpenApiParameter.cs
+++ b/src/NSwag.Core/OpenApiParameter.cs
@@ -44,6 +44,10 @@ namespace NSwag
             }
         }
 
+        /// <summary>Gets or sets a custom name which is often used in code generation (default: null).</summary>
+        [JsonProperty(PropertyName = "x-name", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string CustomName { get; set; }
+
         /// <summary>Gets or sets the kind of the parameter.</summary>
         [JsonProperty(PropertyName = "in", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public OpenApiParameterKind Kind
@@ -245,7 +249,7 @@ namespace NSwag
                 {
                     var consumes = parent.ActualConsumes;
                     return consumes?.Any() == true &&
-                           (Schema?.IsBinary != false || 
+                           (Schema?.IsBinary != false ||
                             consumes.Contains("multipart/form-data")) &&
                            consumes?.Any(p => p.Contains("*/*")) == false &&
                            consumes.Any(p => AppJsonRegex.IsMatch(p)) == false;

--- a/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Parameters/RenamedQueryParameterController.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Parameters/RenamedQueryParameterController.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace NSwag.Generation.AspNetCore.Tests.Web.Controllers.Parameters
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class RenamedQueryParameterController : Controller
+    {
+        [HttpGet]
+        public ActionResult GetMonths([FromQuery(Name = "month")] string[] months)
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
@@ -63,5 +63,21 @@ namespace NSwag.Generation.AspNetCore.Tests.Parameters
             Assert.False(operation.ActualParameters.Skip(1).First().IsRequired);
             Assert.True(operation.ActualParameters.Skip(2).First().IsRequired);
         }
+
+        [Fact]
+        public async Task When_parameter_is_overwritten_then_custom_name_is_set()
+        {
+            // Arrange
+            var settings = new AspNetCoreOpenApiDocumentGeneratorSettings { RequireParametersWithoutDefault = false };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(RenamedQueryParameterController));
+
+            // Assert
+            var parameter = document.Operations.First().Operation.ActualParameters.First();
+
+            Assert.Equal("month", parameter.Name);
+            Assert.Equal("months", parameter.CustomName);
+        }
     }
 }

--- a/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
@@ -77,7 +77,7 @@ namespace NSwag.Generation.AspNetCore.Tests.Parameters
             var parameter = document.Operations.First().Operation.ActualParameters.First();
 
             Assert.Equal("month", parameter.Name);
-            Assert.Equal("months", parameter.CustomName);
+            Assert.Equal("months", parameter.OriginalName);
         }
     }
 }

--- a/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Parameters/QueryParametersTests.cs
@@ -65,7 +65,7 @@ namespace NSwag.Generation.AspNetCore.Tests.Parameters
         }
 
         [Fact]
-        public async Task When_parameter_is_overwritten_then_custom_name_is_set()
+        public async Task When_parameter_is_overwritten_then_original_name_is_set()
         {
             // Arrange
             var settings = new AspNetCoreOpenApiDocumentGeneratorSettings { RequireParametersWithoutDefault = false };

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -184,8 +184,8 @@ namespace NSwag.Generation.AspNetCore.Processors
 
                 if (operationParameter != null)
                 {
-                    operationParameter.Position = position;
                     position++;
+                    operationParameter.Position = position;
 
                     if (_settings.SchemaType == SchemaType.OpenApi3)
                     {
@@ -194,6 +194,11 @@ namespace NSwag.Generation.AspNetCore.Processors
 
                     if (parameter != null)
                     {
+                        if (_settings.GenerateCustomParameterNames && operationParameter.Name != parameter.Name)
+                        {
+                            operationParameter.CustomName = parameter.Name;
+                        }
+
                         ((Dictionary<ParameterInfo, OpenApiParameter>)operationProcessorContext.Parameters)[parameter] = operationParameter;
                     }
                 }

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -194,9 +194,9 @@ namespace NSwag.Generation.AspNetCore.Processors
 
                     if (parameter != null)
                     {
-                        if (_settings.GenerateCustomParameterNames && operationParameter.Name != parameter.Name)
+                        if (_settings.GenerateOriginalParameterNames && operationParameter.Name != parameter.Name)
                         {
-                            operationParameter.CustomName = parameter.Name;
+                            operationParameter.OriginalName = parameter.Name;
                         }
 
                         ((Dictionary<ParameterInfo, OpenApiParameter>)operationProcessorContext.Parameters)[parameter] = operationParameter;

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -184,8 +184,8 @@ namespace NSwag.Generation.AspNetCore.Processors
 
                 if (operationParameter != null)
                 {
-                    position++;
                     operationParameter.Position = position;
+                    position++;
 
                     if (_settings.SchemaType == SchemaType.OpenApi3)
                     {

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -182,8 +182,18 @@ namespace NSwag.Generation.WebApi.Processors
 
                 if (operationParameter != null)
                 {
-                    operationParameter.Position = position;
                     position++;
+                    operationParameter.Position = position;
+
+                    if (_settings.SchemaType == SchemaType.OpenApi3)
+                    {
+                        operationParameter.IsNullableRaw = null;
+                    }
+
+                    if (operationParameter.Name != contextualParameter.ParameterInfo.Name)
+                    {
+                        operationParameter.CustomName = contextualParameter.ParameterInfo.Name;
+                    }
                     
                     ((Dictionary<ParameterInfo, OpenApiParameter>)context.Parameters)[contextualParameter.ParameterInfo] = operationParameter;
                 }

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -182,8 +182,8 @@ namespace NSwag.Generation.WebApi.Processors
 
                 if (operationParameter != null)
                 {
-                    position++;
                     operationParameter.Position = position;
+                    position++;
 
                     if (_settings.SchemaType == SchemaType.OpenApi3)
                     {

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -192,7 +192,7 @@ namespace NSwag.Generation.WebApi.Processors
 
                     if (operationParameter.Name != contextualParameter.ParameterInfo.Name)
                     {
-                        operationParameter.CustomName = contextualParameter.ParameterInfo.Name;
+                        operationParameter.OriginalName = contextualParameter.ParameterInfo.Name;
                     }
                     
                     ((Dictionary<ParameterInfo, OpenApiParameter>)context.Parameters)[contextualParameter.ParameterInfo] = operationParameter;

--- a/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
@@ -46,8 +46,8 @@ namespace NSwag.Generation
         /// <summary>Gets or sets the default response reference type null handling when no nullability information is available (if NotNullAttribute and CanBeNullAttribute are missing, default: NotNull).</summary>
         public ReferenceTypeNullHandling DefaultResponseReferenceTypeNullHandling { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate x-name properties when parameter name is differnt in .NET and HTTP (default: true).</summary>
-        public bool GenerateCustomParameterNames { get; set; } = true;
+        /// <summary>Gets or sets a value indicating whether to generate x-originalName properties when parameter name is differnt in .NET and HTTP (default: true).</summary>
+        public bool GenerateOriginalParameterNames { get; set; } = true;
 
         /// <summary>Gets the operation processors.</summary>
         [JsonIgnore]

--- a/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
@@ -46,6 +46,9 @@ namespace NSwag.Generation
         /// <summary>Gets or sets the default response reference type null handling when no nullability information is available (if NotNullAttribute and CanBeNullAttribute are missing, default: NotNull).</summary>
         public ReferenceTypeNullHandling DefaultResponseReferenceTypeNullHandling { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether to generate x-name properties when parameter name is differnt in .NET and HTTP (default: true).</summary>
+        public bool GenerateCustomParameterNames { get; set; } = true;
+
         /// <summary>Gets the operation processors.</summary>
         [JsonIgnore]
         public OperationProcessorCollection OperationProcessors { get; } = new OperationProcessorCollection

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -173,8 +173,8 @@
                 <ComboBox SelectedItem="{Binding Command.DefaultResponseReferenceTypeNullHandling, Mode=TwoWay}" 
                           ToolTip="DefaultResponseReferenceTypeNullHandling" ItemsSource="{Binding ReferenceTypeNullHandlings}" Margin="0,0,0,12" />
 
-                <CheckBox IsChecked="{Binding Command.GenerateCustomParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateCustomParameterNames">
-                    <TextBlock Text="Generate x-name properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
+                <CheckBox IsChecked="{Binding Command.GenerateOriginalParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateOriginalParameterNames">
+                    <TextBlock Text="Generate x-originalName properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
                 </CheckBox>
 
                 <CheckBox IsChecked="{Binding Command.GenerateAbstractProperties, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateAbstractProperties">

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -173,6 +173,10 @@
                 <ComboBox SelectedItem="{Binding Command.DefaultResponseReferenceTypeNullHandling, Mode=TwoWay}" 
                           ToolTip="DefaultResponseReferenceTypeNullHandling" ItemsSource="{Binding ReferenceTypeNullHandlings}" Margin="0,0,0,12" />
 
+                <CheckBox IsChecked="{Binding Command.GenerateCustomParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateCustomParameterNames">
+                    <TextBlock Text="Generate x-name properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
+                </CheckBox>
+
                 <CheckBox IsChecked="{Binding Command.GenerateAbstractProperties, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateAbstractProperties">
                     <TextBlock Text="Generate abstract properties (i.e. interface and abstract properties. Properties may defined multiple times in a inheritance hierarchy)" TextWrapping="Wrap" />
                 </CheckBox>

--- a/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
@@ -165,6 +165,10 @@
                 <ComboBox SelectedItem="{Binding Command.DefaultResponseReferenceTypeNullHandling, Mode=TwoWay}" 
                           ToolTip="DefaultResponseReferenceTypeNullHandling" ItemsSource="{Binding ReferenceTypeNullHandlings}" Margin="0,0,0,12" />
 
+                <CheckBox IsChecked="{Binding Command.GenerateCustomParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateCustomParameterNames">
+                    <TextBlock Text="Generate x-name properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
+                </CheckBox>
+
                 <CheckBox IsChecked="{Binding Command.GenerateAbstractProperties, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateAbstractProperties">
                     <TextBlock Text="Generate abstract properties (i.e. interface and abstract properties. Properties may defined multiple times in a inheritance hierarchy)" TextWrapping="Wrap" />
                 </CheckBox>

--- a/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
@@ -165,8 +165,8 @@
                 <ComboBox SelectedItem="{Binding Command.DefaultResponseReferenceTypeNullHandling, Mode=TwoWay}" 
                           ToolTip="DefaultResponseReferenceTypeNullHandling" ItemsSource="{Binding ReferenceTypeNullHandlings}" Margin="0,0,0,12" />
 
-                <CheckBox IsChecked="{Binding Command.GenerateCustomParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateCustomParameterNames">
-                    <TextBlock Text="Generate x-name properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
+                <CheckBox IsChecked="{Binding Command.GenerateOriginalParameterNames, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateOriginalParameterNames">
+                    <TextBlock Text="Generate x-originalName properties when parameter name is differnt in .NET and HTTP." TextWrapping="Wrap" />
                 </CheckBox>
 
                 <CheckBox IsChecked="{Binding Command.GenerateAbstractProperties, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="GenerateAbstractProperties">


### PR DESCRIPTION
If the C# controller parameter name does not match the HTTP parameter name then generate a custom name so that the client gens can generate the same parameter names.