### PR TITLE
Properly generate client code for string and array of string responses

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/PlainResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/PlainResponseTests.cs
@@ -10,6 +10,70 @@ namespace NSwag.CodeGeneration.CSharp.Tests
     public class PlainResponseTests
     {
         [Fact]
+        public async Task When_openapi3_reponse_contains_plain_text_string_array_then_ReadObjectResponseAsync_is_generated()
+        {
+            // Arrange
+            var json = @"{
+  ""openapi"": ""3.0.1"",
+  ""paths"": {
+    ""/api/get-ienumerable"": {
+      ""get"": {
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+              ""text/plain"": {
+                ""schema"": {
+                  ""type"": ""array"",
+                  ""items"": {
+                    ""type"": ""string"",
+                    ""nullable"": true
+                  },
+                  ""nullable"": true
+                }
+              },
+              ""application/json"": {
+                ""schema"": {
+                  ""type"": ""array"",
+                  ""items"": {
+                    ""type"": ""string"",
+                    ""nullable"": true
+                  },
+                  ""nullable"": true
+                }
+              },
+              ""text/json"": {
+                ""schema"": {
+                  ""type"": ""array"",
+                  ""items"": {
+                    ""type"": ""string"",
+                    ""nullable"": true
+                  },
+                  ""nullable"": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            //// Act
+            var codeGenerator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientInterfaces = true
+            });
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<string>> GetIenumerableAsync(", code);
+            Assert.Contains("await ReadObjectResponseAsync<System.Collections.Generic.ICollection<string>>(", code);
+        }
+
+        [Fact]
         public async Task When_openapi3_reponse_contains_plain_text_then_Convert_is_generated()
         {
             // Arrange
@@ -48,6 +112,50 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             //// Assert
             Assert.Contains("public async System.Threading.Tasks.Task<string> PlainAsync(", code);
+            Assert.Contains("(string)System.Convert.ChangeType(responseData_, typeof(string));", code);
+        }
+
+        [Fact]
+        public async Task When_swagger_reponse_contains_plain_text_string_array_then_ReadObjectResponseAsync_is_generated()
+        {
+            // Arrange
+            var swagger = @"{
+  ""swagger"": ""2.0"",
+  ""paths"": {
+    ""/api/get-ienumerable"": {
+      ""get"": {
+        ""produces"": [
+          ""text/plain"",
+          ""application/json"",
+          ""text/json""
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""schema"": {
+              ""type"": ""array"",
+              ""items"": {
+                ""type"": ""string""
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+            var document = await OpenApiDocument.FromJsonAsync(swagger);
+
+            //// Act
+            var codeGenerator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientInterfaces = true
+            });
+            var code = codeGenerator.GenerateFile();
+
+            //// Assert
+            Assert.Contains("public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<string>> GetIenumerableAsync(", code);
+            Assert.Contains("await ReadObjectResponseAsync<System.Collections.Generic.ICollection<string>>(", code);
         }
 
         [Fact]
@@ -85,6 +193,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             //// Assert
             Assert.Contains("public async System.Threading.Tasks.Task<string> PlainAsync(", code);
+            Assert.Contains("(string)System.Convert.ChangeType(responseData_, typeof(string));", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -86,8 +86,10 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets a value indicating whether the response requires a text/plain content.</summary>
         public bool IsPlainText =>
-            !_response.Content.ContainsKey("application/json") &&
-            (_response.Content.ContainsKey("text/plain") || _operationModel.Produces == "text/plain");
+            (_response.Content.ContainsKey("application/json") &&
+            _response.Schema != null && _response.Schema?.Type == JsonObjectType.String) ||
+            (!_response.Content.ContainsKey("application/json") &&
+            (_response.Content.ContainsKey("text/plain") || _operationModel.Produces == "text/plain"));
 
         /// <summary>Gets a value indicating whether this is a file response.</summary>
         public bool IsFile => IsSuccess && _response.IsBinary(_operation);

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -85,11 +85,16 @@ namespace NSwag.CodeGeneration.Models
         }
 
         /// <summary>Gets a value indicating whether the response requires a text/plain content.</summary>
-        public bool IsPlainText =>
-            (_response.Content.ContainsKey("application/json") &&
-            _response.Schema != null && _response.Schema?.Type == JsonObjectType.String) ||
-            (!_response.Content.ContainsKey("application/json") &&
-            (_response.Content.ContainsKey("text/plain") || _operationModel.Produces == "text/plain"));
+        public bool IsPlainText
+        {
+            get
+            {
+                JsonObjectType primitive = JsonObjectType.String | JsonObjectType.Integer | JsonObjectType.Number | JsonObjectType.Boolean;
+                return ActualResponseSchema != null &&
+                    (ActualResponseSchema.Type & primitive) == ActualResponseSchema.Type &&
+                    (ActualResponseSchema.Type | primitive) == primitive;
+            }
+        }
 
         /// <summary>Gets a value indicating whether this is a file response.</summary>
         public bool IsFile => IsSuccess && _response.IsBinary(_operation);


### PR DESCRIPTION
See Github issues #2384 and #2596.

Attempt to resolve both issues handling plain text and JSON lists by
checking for the response's schema type. Treat as plaintext if schema
type is string or marked as produces text/plain content.