### PR TITLE
fix: (Dependencies): Bump dependencies for NSwag.Generation.AspNetCore to work with v5 assemblies.

### DIFF
--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -39,8 +39,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1, 4)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1, 4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1, 6)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1, 6)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
Bump depedencies for aspnetCore to allow Microsoft.Extensions.DependencyInjection.Abstractions and Extensions.Optios v5  (Both of which are compatible with netstandard2.0) #3476

The v5 assemblies have a base requirement of net standard 2.0. 
