### PR TITLE
Improve GenerateOperationIds

### DIFF
--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -274,8 +274,6 @@ namespace NSwag
         /// <summary>Generates missing or non-unique operation IDs.</summary>
         public void GenerateOperationIds()
         {
-            // TODO: Improve this method
-
             // Generate missing IDs
             foreach (var operation in Operations.Where(o => string.IsNullOrEmpty(o.Operation.OperationId)))
             {
@@ -283,29 +281,53 @@ namespace NSwag
             }
 
             // Find non-unique operation IDs
+
+            // 1: Append all to methods returning collections
+            foreach (var group in Operations.GroupBy(o => o.Operation.OperationId))
+            {
+                if (group.Count() > 1)
+                {
+                    var collections = group.Where(o => o.Operation.ActualResponses.Any(r =>
+                              HttpUtilities.IsSuccessStatusCode(r.Key) &&
+                              r.Value.Schema?.ActualSchema.Type == JsonObjectType.Array));
+                    // if we have just collections, adding All will not help in discrimination
+                    if (collections.Count() == group.Count()) continue;
+
+                    foreach (var o in group)
+                    {
+                        var isCollection = o.Operation.ActualResponses.Any(r =>
+                            HttpUtilities.IsSuccessStatusCode(r.Key) &&
+                            r.Value.Schema?.ActualSchema.Type == JsonObjectType.Array);
+
+                        if (isCollection)
+                        {
+                            o.Operation.OperationId += "All";
+                        }
+                    }
+                }
+            }
+
+            // 2: Append the Method type
+            foreach (var group in Operations.GroupBy(o => o.Operation.OperationId))
+            {
+                if (group.Count() > 1)
+                {
+                    var methods = group.Select(o => o.Method.ToUpper()).Distinct();
+                    if (methods.Count() == 1) continue;
+
+                    foreach (var o in group)
+                    {
+                        o.Operation.OperationId += "_" + o.Method.ToUpper();
+                    }
+                }
+            }
+
+            // 3: Append numbers as last resort
             foreach (var group in Operations.GroupBy(o => o.Operation.OperationId))
             {
                 var operations = group.ToList();
                 if (group.Count() > 1)
                 {
-                    // Append "All" if possible
-                    var arrayResponseOperation = operations.FirstOrDefault(
-                        o => o.Operation.ActualResponses.Any(r =>
-                            HttpUtilities.IsSuccessStatusCode(r.Key) &&
-                            r.Value.Schema?.ActualSchema.Type == JsonObjectType.Array));
-
-                    if (arrayResponseOperation != null)
-                    {
-                        var name = arrayResponseOperation.Operation.OperationId + "All";
-                        if (Operations.All(o => o.Operation.OperationId != name))
-                        {
-                            arrayResponseOperation.Operation.OperationId = name;
-                            operations.Remove(arrayResponseOperation);
-                            GenerateOperationIds();
-                            return;
-                        }
-                    }
-
                     // Add numbers
                     var i = 2;
                     foreach (var operation in operations.Skip(1))


### PR DESCRIPTION
The current version of `GenerateOperationIds` handles the case when we overload a method on the Controller, and one method would be returning an collection.

I am running often into the problem that we annotate methods with `[HttpGet]` and `[HttpHead]`.
In this case one of them gets randomly assigned the the "All" suffix, which is prone to error.

This PR tries to add "All" if it makes sense (if all overloads return collections, better not do that at all).
Second, it will try to add the HTTP method in uppercase.
Third, it will fallback to appending numbers.

Instead of
```json
{
    "paths": {
      "/api/Values": {
        "get": {
          "operationId": "Values_GetAll",
        },
        "head": {
          "operationId": "Values_Get",
        },
      "/api/Values/{id}": {
        "get": {
          "operationId": "Values_Get2",
        },
        "head": {
          "operationId": "Values_Get3",

```

we will have
```json
{
    "paths": {
      "/api/Values": {
        "get": {
          "operationId": "Values_GetAll_GET",
        },
        "head": {
          "operationId": "Values_GetAll_HEAD",
        },
      "/api/Values/{id}": {
        "get": {
          "operationId": "Values_Get_GET",
        },
        "head": {
          "operationId": "Values_Get_HEAD",
        },

```

for the example `NSwag/src/NSwag.Sample.NET50/Controllers/ValuesController.cs`

```csharp
        [HttpGet]
        [HttpHead]
        public ActionResult<IEnumerable<Person>> Get()
        {
            return new Person[] { };
        }

        // GET api/values/5
        [HttpGet("{id}")]
        [HttpHead("{id}")]
        public ActionResult<TestEnum> Get(int id)
        {
            return TestEnum.Foo;
        }
```
