### PR TITLE
Support for HttpMethodAttribute Name

### DIFF
--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -224,6 +224,14 @@ namespace NSwag.Commands.Generation
             set => Settings.AllowNullableBodyParameters = value;
         }
 
+
+        [Argument(Name = "UseHttpAttributeNameAsOperationId", IsRequired = false, Description = "Gets or sets a value indicating whether the HttpMethodAttribute Name property shall be used as OperationId.")]
+        public bool UseHttpAttributeNameAsOperationId
+        {
+            get => Settings.UseHttpAttributeNameAsOperationId;
+            set => Settings.UseHttpAttributeNameAsOperationId = value;
+        }
+
         public async Task<TSettings> CreateSettingsAsync(AssemblyLoader.AssemblyLoader assemblyLoader, IServiceProvider serviceProvider, string workingDirectory)
         {
             var mvcOptions = serviceProvider?.GetRequiredService<IOptions<MvcOptions>>().Value;

--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -224,7 +224,6 @@ namespace NSwag.Commands.Generation
             set => Settings.AllowNullableBodyParameters = value;
         }
 
-
         [Argument(Name = "UseHttpAttributeNameAsOperationId", IsRequired = false, Description = "Gets or sets a value indicating whether the HttpMethodAttribute Name property shall be used as OperationId.")]
         public bool UseHttpAttributeNameAsOperationId
         {

--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -317,7 +317,7 @@ namespace NSwag
 
                     foreach (var o in group)
                     {
-                        o.Operation.OperationId += "_" + o.Method.ToUpper();
+                        o.Operation.OperationId += o.Method.ToUpper();
                     }
                 }
             }

--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -426,7 +426,7 @@ namespace NSwag.Generation.AspNetCore
             {
                 operationId = swaggerOperationAttribute.OperationId;
             }
-            else if (httpAttribute != null && !string.IsNullOrWhiteSpace(httpAttribute.Name))
+            else if (Settings.UseHttpAttributeNameAsOperationId && httpAttribute != null && !string.IsNullOrWhiteSpace(httpAttribute.Name))
             {
                 operationId = httpAttribute.Name;
             }

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -312,7 +312,7 @@ namespace NSwag.Generation.WebApi
             {
                 operationId = swaggerOperationAttribute.OperationId;
             }
-            else if (httpAttribute != null && !string.IsNullOrWhiteSpace(httpAttribute.Name))
+            else if (Settings.UseHttpAttributeNameAsOperationId && httpAttribute != null && !string.IsNullOrWhiteSpace(httpAttribute.Name))
             {
                 operationId = httpAttribute.Name;
             }

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -183,7 +183,7 @@ namespace NSwag.Generation.WebApi
                                     Operation = new OpenApiOperation
                                     {
                                         IsDeprecated = method.GetCustomAttribute<ObsoleteAttribute>() != null,
-                                        OperationId = GetOperationId(document, controllerType.Name, method)
+                                        OperationId = GetOperationId(document, controllerType.Name, method, httpMethod)
                                     }
                                 };
 
@@ -240,7 +240,7 @@ namespace NSwag.Generation.WebApi
             // 1. Run from settings
             foreach (var operationProcessor in Settings.OperationProcessors)
             {
-                if (operationProcessor.Process(context)== false)
+                if (operationProcessor.Process(context) == false)
                 {
                     return false;
                 }
@@ -290,7 +290,7 @@ namespace NSwag.Generation.WebApi
                 });
         }
 
-        private string GetOperationId(OpenApiDocument document, string controllerName, MethodInfo method)
+        private string GetOperationId(OpenApiDocument document, string controllerName, MethodInfo method, string httpMethod)
         {
             string operationId;
 
@@ -298,9 +298,23 @@ namespace NSwag.Generation.WebApi
                 .GetCustomAttributes()
                 .FirstAssignableToTypeNameOrDefault("SwaggerOperationAttribute", TypeNameStyle.Name);
 
+            dynamic httpAttribute = null;
+            if (!string.IsNullOrWhiteSpace(httpMethod))
+            {
+                var attributeName = Char.ToUpperInvariant(httpMethod[0]) + httpMethod.Substring(1).ToLowerInvariant();
+                var typeName = string.Format("Microsoft.AspNetCore.Mvc.Http{0}Attribute", attributeName);
+                httpAttribute = method
+                    .GetCustomAttributes()
+                    .FirstAssignableToTypeNameOrDefault(typeName);
+            }
+
             if (swaggerOperationAttribute != null && !string.IsNullOrEmpty(swaggerOperationAttribute.OperationId))
             {
                 operationId = swaggerOperationAttribute.OperationId;
+            }
+            else if (httpAttribute != null && !string.IsNullOrWhiteSpace(httpAttribute.Name))
+            {
+                operationId = httpAttribute.Name;
             }
             else
             {

--- a/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
@@ -74,6 +74,9 @@ namespace NSwag.Generation
         /// </summary>
         public bool UseControllerSummaryAsTagDescription { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether the HttpMethodAttribute Name property shall be used as OperationId.</summary>
+        public bool UseHttpAttributeNameAsOperationId { get; set; } = false;
+
         /// <summary>Inserts a function based operation processor at the beginning of the pipeline to be used to filter operations.</summary>
         /// <param name="filter">The processor filter.</param>
         public void AddOperationFilter(Func<OperationProcessorContext, bool> filter)

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -290,7 +290,11 @@
 
                         <TextBlock Text="Custom JsonSerializerSettings implementation (deprecated, automatically resolved via DI)" FontWeight="Bold" Margin="0,0,0,6" />
                         <TextBox Text="{Binding Command.SerializerSettingsType, Mode=TwoWay}" 
-                                 ToolTip="SerializerSettingsType" Margin="0,0,0,12" />
+                                ToolTip="SerializerSettingsType" Margin="0,0,0,12" />
+
+                        <TextBlock Text="Use the HttpMethodAttribute Name property as OperationId (if available)." FontWeight="Bold" Margin="0,0,0,6" />
+                        <TextBox Text="{Binding Command.UseHttpAttributeNameAsOperationId, Mode=TwoWay}" 
+                                ToolTip="UseHttpAttributeNameAsOperationId" Margin="0,0,0,12" />
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -209,6 +209,10 @@
                     <TextBlock Text="Generate xmlObject representation for definitions" TextWrapping="Wrap" />
                 </CheckBox>
 
+                <CheckBox IsChecked="{Binding Command.UseHttpAttributeNameAsOperationId, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="UseHttpAttributeNameAsOperationId">
+                    <TextBlock Text="Use the HttpMethodAttribute Name property as OperationId (if available)." TextWrapping="Wrap" />
+                </CheckBox>
+
                 <TextBlock Text="The excluded type names (same as JsonSchemaIgnoreAttribute, comma separated)." FontWeight="Bold" Margin="0,0,0,6" />
                 <TextBox Text="{Binding Command.ExcludedTypeNames, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
                          ToolTip="ExcludedTypeNames" Margin="0,0,0,12" />
@@ -291,10 +295,6 @@
                         <TextBlock Text="Custom JsonSerializerSettings implementation (deprecated, automatically resolved via DI)" FontWeight="Bold" Margin="0,0,0,6" />
                         <TextBox Text="{Binding Command.SerializerSettingsType, Mode=TwoWay}" 
                                 ToolTip="SerializerSettingsType" Margin="0,0,0,12" />
-
-                        <TextBlock Text="Use the HttpMethodAttribute Name property as OperationId (if available)." FontWeight="Bold" Margin="0,0,0,6" />
-                        <TextBox Text="{Binding Command.UseHttpAttributeNameAsOperationId, Mode=TwoWay}" 
-                                ToolTip="UseHttpAttributeNameAsOperationId" Margin="0,0,0,12" />
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
@@ -287,6 +287,10 @@
                         <TextBlock Text="Custom JsonSerializerSettings implementation" FontWeight="Bold" Margin="0,0,0,6" />
                         <TextBox Text="{Binding Command.SerializerSettingsType, Mode=TwoWay}" 
                                  ToolTip="SerializerSettingsType" Margin="0,0,0,12" />
+
+                        <TextBlock Text="Use the HttpMethodAttribute Name property as OperationId (if available)." FontWeight="Bold" Margin="0,0,0,6" />
+                        <TextBox Text="{Binding Command.UseHttpAttributeNameAsOperationId, Mode=TwoWay}" 
+                                ToolTip="UseHttpAttributeNameAsOperationId" Margin="0,0,0,12" />
                     </StackPanel>
                 </GroupBox>
             </StackPanel>


### PR DESCRIPTION
This PR adds support for HttpAttribute names, e.g.

```csharp
        // GET api/values/5
        [HttpGet("{id}/foo", Name = "GET_AttributeName_TEST")]
        [HttpHead("{id}/foo", Name = "HEAD_AttributeName_TEST")]
        public ActionResult<string> GetFooBar(int id)
        {
            return "value";
        }
```

will create 
```json
    "/api/Values/{id}/foo": {
      "get": {
        "operationId": "GET_AttributeName_TEST",
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int32"
            },
            "x-position": 1
          }
        ],
        "responses": {        }
      },
      "head": {
        "operationId": "HEAD_AttributeName_TEST",
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int32"
            },
            "x-position": 1
          }
        ],
        "responses": {
        }
```

In addition it improves the behavior when no name is present and there are name collisions:
The current version of `GenerateOperationIds` handles the case when we overload a method on the Controller, and one method would be returning an collection.

I am running often into the problem that we annotate methods with `[HttpGet]` and `[HttpHead]`.
In this case one of them gets randomly assigned the the "All" suffix, which is prone to error.

This PR tries to add "All" if it makes sense (if all overloads return collections, better not do that at all).
Second, it will try to add the HTTP method in uppercase.
Third, it will fallback to appending numbers.

Instead of
```json
{
    "paths": {
      "/api/Values": {
        "get": {
          "operationId": "Values_GetAll",
        },
        "head": {
          "operationId": "Values_Get",
        },
      "/api/Values/{id}": {
        "get": {
          "operationId": "Values_Get2",
        },
        "head": {
          "operationId": "Values_Get3",

```

we will have
```json
{
    "paths": {
      "/api/Values": {
        "get": {
          "operationId": "Values_GetAll_GET",
        },
        "head": {
          "operationId": "Values_GetAll_HEAD",
        },
      "/api/Values/{id}": {
        "get": {
          "operationId": "Values_Get_GET",
        },
        "head": {
          "operationId": "Values_Get_HEAD",
        },

```

for the example `NSwag/src/NSwag.Sample.NET50/Controllers/ValuesController.cs`

```csharp
        [HttpGet]
        [HttpHead]
        public ActionResult<IEnumerable<Person>> Get()
        {
            return new Person[] { };
        }

        // GET api/values/5
        [HttpGet("{id}")]
        [HttpHead("{id}")]
        public ActionResult<TestEnum> Get(int id)
        {
            return TestEnum.Foo;
        }
```
