### PR TITLE
Automatically generate httpmethod, when action for controller does no…

### DIFF
--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -214,7 +214,10 @@ namespace NSwag.Generation.AspNetCore
                         }
 
                         var controllerActionDescriptor = (ControllerActionDescriptor)apiDescription.ActionDescriptor;
-                        var httpMethod = apiDescription.HttpMethod?.ToLowerInvariant() ?? OpenApiOperationMethod.Get;
+                        var httpMethod = apiDescription.HttpMethod?.ToLowerInvariant() ?? (apiDescription.ParameterDescriptions.Where(p =>
+                        {
+                            return p.Source == Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource.Body;
+                        }).Count() > 0 ? OpenApiOperationMethod.Post : OpenApiOperationMethod.Get);
 
                         var operationDescription = new OpenApiOperationDescription
                         {


### PR DESCRIPTION
Automatically generate httpmethod, when active does not specify httpmethod.
When the parameter source of action is body, httmethod is set to POST, otherwise it is GET.
sorry,my bad english.