### PR TITLE
Replace . for _ in operation name

### DIFF
--- a/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
@@ -225,7 +225,8 @@ namespace NSwag.CodeGeneration
                 .Select(tuple =>
                 {
                     var operationName = BaseSettings.OperationNameGenerator.GetOperationName(document, tuple.Path, tuple.HttpMethod, tuple.Operation);
-                    if(operationName.Contains("."))
+
+                    if (operationName.Contains("."))
                     {
                         operationName = operationName.Replace(".", "_");
                     }

--- a/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
@@ -225,13 +225,14 @@ namespace NSwag.CodeGeneration
                 .Select(tuple =>
                 {
                     var operationName = BaseSettings.OperationNameGenerator.GetOperationName(document, tuple.Path, tuple.HttpMethod, tuple.Operation);
+                    if(operationName.Contains("."))
+                    {
+                        operationName = operationName.Replace(".", "_");
+                    }
+
                     if (operationName.EndsWith("Async"))
                     {
                         operationName = operationName.Substring(0, operationName.Length - "Async".Length);
-                    }
-                    if(operationName.Contains("."))
-                    {   
-                        operationName = operationName.Replace(".", "_");    
                     }
 
                     var operationModel = CreateOperationModel(tuple.Operation, BaseSettings);

--- a/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
@@ -229,6 +229,10 @@ namespace NSwag.CodeGeneration
                     {
                         operationName = operationName.Substring(0, operationName.Length - "Async".Length);
                     }
+                    if(operationName.Contains("."))
+                    {   
+                        operationName = operationName.Replace(".", "_");    
+                    }
 
                     var operationModel = CreateOperationModel(tuple.Operation, BaseSettings);
                     operationModel.ControllerName = BaseSettings.OperationNameGenerator.GetClientName(document, tuple.Path, tuple.HttpMethod, tuple.Operation);


### PR DESCRIPTION
I created a fix for issue #3531. It replaces dot for underscores in operation names
