### PR TITLE
update generated typescript to work with rxjs 7

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
@@ -14,7 +14,7 @@ return Promise.resolve<{{ operation.ResultType }}>(<any>null);
 {%     if operation.WrapResponse -%}
 return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
 {%     else -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(<any>null);
+return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(<any[]>null);
 {%     endif -%}
 {% elseif Framework.IsAngularJS -%}
 {%     if operation.WrapResponse -%}


### PR DESCRIPTION
@wratho has tested to confirm that this new generated code works with both the new rxjs 7 and with rxjs 6.

see #3506