### PR TITLE
update generated typescript to work with rxjs 6 and 7

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
@@ -14,7 +14,7 @@ return Promise.resolve<{{ operation.ResultType }}>(<any>null);
 {%     if operation.WrapResponse -%}
 return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
 {%     else -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(<any[]>null);
+return {{ Framework.RxJs.ObservableOfMethod }}(null);
 {%     endif -%}
 {% elseif Framework.IsAngularJS -%}
 {%     if operation.WrapResponse -%}


### PR DESCRIPTION
RxJs 6 and 7 have very different d.ts type definitions for the `of` function, and this is the best option I found that works with both.

This fixes #3566 which I broke with my prior PR (#3544).