### PR TITLE
Add support for HttpContext parameter in angular generation

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
@@ -153,5 +153,53 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             Assert.DoesNotContain("signal?: AbortSignal | undefined", code);
             Assert.DoesNotContain("signal", code);;
         }
+
+        [Fact]
+        public async Task When_includeHttpContext()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Angular,
+                IncludeHttpContext = true,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.7m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.Contains("httpContext?: HttpContext", code);
+            Assert.Contains("context: httpContext", code);
+        }
+
+        [Fact]
+        public async Task When_no_includeHttpContext()
+        {
+            //// Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+            var json = document.ToJson();
+
+            //// Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Angular,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.7m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.DoesNotContain("httpContext?: HttpContext", code);
+            Assert.DoesNotContain("context: httpContext", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptClientTemplateModel.cs
@@ -119,5 +119,8 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets a value indicating whether to use the AbortSignal (Fetch/Aurelia template only, default: false).</summary>
         public bool UseAbortSignal => _settings.UseAbortSignal;
+
+        /// <summary>Gets a value indicating whether to include the httpContext (Angular template only, default: false).</summary>
+        public bool IncludeHttpContext => _settings.IncludeHttpContext;
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -39,7 +39,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false%}, {% endif %}{% endfor %}): Observable<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false or IncludeHttpContext == true%}, {% endif %}{% endfor %}{% if IncludeHttpContext%}httpContext?: HttpContext{% endif %}) : Observable<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}
@@ -61,6 +61,9 @@
 {%     endif -%}
 {%     if operation.IsFile and Framework.Angular.UseHttpClient == false -%}
             responseType: ResponseContentType.Blob,
+{%     endif -%}
+{%     if IncludeHttpContext -%}
+            context: httpContext,
 {%     endif -%}
             headers: new {% if Framework.Angular.UseHttpClient %}HttpHeaders{% else %}Headers{% endif %}({
 {%     for parameter in operation.HeaderParameters -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -31,7 +31,7 @@ import { Observable, {% if UseTransformOptionsMethod %}from as {{ Framework.RxJs
 {%             endif -%}
 import { Injectable, Inject, Optional, {{ Framework.Angular.InjectionTokenType }} } from '@angular/core';
 {%             if Framework.Angular.UseHttpClient -%}
-import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase{% if IncludeHttpContext %}, HttpContext{% endif %} } from '@angular/common/http';
 {%             else -%}
 import { Http, Headers, ResponseContentType, Response{% if UseTransformOptionsMethod %}, RequestOptionsArgs{% endif %} } from '@angular/http';
 {%             endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -111,6 +111,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
 
+        /// <summary>Gets a value indicating whether to include the httpContext parameter (Angular template only, default: false).</summary>
+        public bool IncludeHttpContext { get; set; } = false;
+
         internal ITemplate CreateTemplate(object model)
         {
             if (Template == TypeScriptTemplate.Aurelia)


### PR DESCRIPTION
Angular 12 provides HttpContext  that offer the ability to store and retrieve custom metadata for requests, especially in interceptors.

- Adds the httpContext parameter as the last optional parameter in the typescript generation for angular.
