### PR TITLE
Create request body as x-www-form-urlencoded per #1338

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -74,6 +74,10 @@ else
 const content_ = {{ operation.ContentParameter.VariableName }};
 {%         elseif operation.HasXmlBodyParameter -%}
 const content_ = {{ operation.ContentParameter.VariableName }};
+{%         elseif operation.Consumes == "application/x-www-form-urlencoded" -%}
+const content_ = Object.keys({{ operation.ContentParameter.VariableName }} as any).map((key) => {
+    return encodeURIComponent(key) + '=' + encodeURIComponent(({{ operation.ContentParameter.VariableName }} as any)[key]);
+}).join('&')
 {%         else -%}
 const content_ = JSON.stringify({{ operation.ContentParameter.VariableName }});
 {%         endif -%}


### PR DESCRIPTION
#1338 describes a problem with  typescript generator for x-www-form-urlencoded request, with a solution for a partial Client.RequestBody.liquid template. 
#1963 is similar but for OpenApi 3.0.0

This patch has the fix from #1338 modified to work with OpenApi 3.0.0. I don't know if it works properly with OpenApi 2 but hopefully someone with more detailed knowledge of nswag can check. Meanwhile, this Client.RequestBody.liquid is working for me as a template override.