### PR TITLE
Fix parameters comparison

### DIFF
--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NJsonSchema;
@@ -36,7 +37,7 @@ namespace NSwag.CodeGeneration
                 .Replace("[", string.Empty)
                 .Replace("]", string.Empty), true);
 
-            if (allParameters.Count(p => p.Name == name) > 1)
+            if (allParameters.Count(p => string.Equals(p.Name, name, StringComparison.CurrentCultureIgnoreCase)) > 1)
             {
                 return variableName + parameter.Kind;
             }


### PR DESCRIPTION
In the case of the path, parameters have the name argument with the same name in query param, it generated duplicate parameters. This PR is fixing that.