### PR TITLE
Enable support for generating DTOs as C# 9.0 records

### DIFF
--- a/src/NSwag.Commands/Commands/CodeGeneration/JsonSchemaToCSharpCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/JsonSchemaToCSharpCommand.cs
@@ -169,6 +169,13 @@ namespace NSwag.Commands.CodeGeneration
             set => Settings.GenerateDataAnnotations = value;
         }
 
+        [Argument(Name = "UseNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
+        public bool UseNativeRecords
+        {
+            get { return Settings.GenerateNativeRecords; }
+            set { Settings.GenerateNativeRecords = value; }
+        }
+
         [Argument(Name = "ExcludedTypeNames", IsRequired = false, Description = "The excluded DTO type names (must be defined in an import or other namespace).")]
         public string[] ExcludedTypeNames
         {

--- a/src/NSwag.Commands/Commands/CodeGeneration/JsonSchemaToCSharpCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/JsonSchemaToCSharpCommand.cs
@@ -169,8 +169,8 @@ namespace NSwag.Commands.CodeGeneration
             set => Settings.GenerateDataAnnotations = value;
         }
 
-        [Argument(Name = "UseNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
-        public bool UseNativeRecords
+        [Argument(Name = "GenerateNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
+        public bool GenerateNativeRecords
         {
             get { return Settings.GenerateNativeRecords; }
             set { Settings.GenerateNativeRecords = value; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -266,8 +266,8 @@ namespace NSwag.Commands.CodeGeneration
             set => Settings.CSharpGeneratorSettings.GenerateDataAnnotations = value;
         }
 
-        [Argument(Name = "UseNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
-        public bool UseNativeRecords
+        [Argument(Name = "GenerateNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
+        public bool GenerateNativeRecords
         {
             get { return Settings.CSharpGeneratorSettings.GenerateNativeRecords; }
             set { Settings.CSharpGeneratorSettings.GenerateNativeRecords = value; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -266,6 +266,13 @@ namespace NSwag.Commands.CodeGeneration
             set => Settings.CSharpGeneratorSettings.GenerateDataAnnotations = value;
         }
 
+        [Argument(Name = "UseNativeRecords", IsRequired = false, Description = "Generate C# 9.0 record types instead of record-like classes.")]
+        public bool UseNativeRecords
+        {
+            get { return Settings.CSharpGeneratorSettings.GenerateNativeRecords; }
+            set { Settings.CSharpGeneratorSettings.GenerateNativeRecords = value; }
+        }
+
         [Argument(Name = "ExcludedTypeNames", IsRequired = false, Description = "The excluded DTO type names (must be defined in an import or other namespace).")]
         public string[] ExcludedTypeNames
         {

--- a/src/NSwagStudio/Views/CodeGenerators/Views/CSharpSettingsView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/Views/CSharpSettingsView.xaml
@@ -63,6 +63,11 @@
                     <TextBlock Text="Generate data annotation attributes" TextWrapping="Wrap" />
                 </CheckBox>
 
+                <CheckBox IsChecked="{Binding Command.GenerateNativeRecords, Mode=TwoWay}" 
+                          ToolTip="GenerateNativeRecords" Margin="0,0,0,12">
+                    <TextBlock Text="Generate native C# 9 records" TextWrapping="Wrap" />
+                </CheckBox>
+
                 <CheckBox IsChecked="{Binding Command.GenerateJsonMethods, Mode=TwoWay}" 
                           ToolTip="GenerateJsonMethods" Margin="0,0,0,12">
                     <TextBlock Text="Generate ToJson() and FromJson() methods" TextWrapping="Wrap" />


### PR DESCRIPTION
[Apologies in advance if I should have submitted an issue or something instead of just a PR out of the blue.]

This PR, in conjunction with a separate PR to NJsonSchema, adds an option to change how ClassStyle="Record" generates DTOs. If you set **"classStyle": "Record"** and also **"UseNativeRecords": true**, nswag will generate DTOs as records instead of classes.

This allows you to use C# 9.0 "with" statements for usability, while still maintaining null safety.




