### PR TITLE
Add logic for date and datetimes from the body to the request url #1613

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -7,9 +7,9 @@ if ({{ parameter.VariableName }} === undefined || {{ parameter.VariableName }} =
 if ({{ parameter.VariableName }} !== null && {{ parameter.VariableName }} !== undefined)
 {%     endif -%}
 {%     if parameter.IsDateOrDateTimeArray -%}
-url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }}.map(s_ => s_ ? s_.toJSON() : "null").join()));
+url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }}.map(s_ => s_ ? s_.{{ parameter.GetDateTimeToString }} : "null").join()));
 {%     elseif parameter.IsDateOrDateTime -%}
-url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.toJSON() : "null"));
+url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.{{ parameter.GetDateTimeToString }} : "null"));
 {%     elseif parameter.IsArray -%}
 url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent({{ parameter.VariableName }}.join()));
 {%     else -%}
@@ -50,7 +50,7 @@ else if ({{ parameter.VariableName }} !== undefined)
 			}
     });
 {%     elseif parameter.IsDateOrDateTime -%}
-    url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.toJSON() : "{{ QueryNullValue }}") + "&";
+    url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.{{ parameter.GetDateTimeToString }} : "{{ QueryNullValue }}") + "&";
 {%     elseif parameter.IsArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "&"; });
 {%     else -%}


### PR DESCRIPTION
This PR resolves an issue where the dates and dateTimes in the request url are not formatted to the correct string value (e.g. when OffsetMomentJS is chosen in the settings, the offset was lost due to the .toJSON()) (https://github.com/RicoSuter/NSwag/issues/1613)

This logic was copied from NJS, where this was already implemented for dateTimes that live inside the body of a request