### PR TITLE
Parameter of type DateTime should only be nullable when it is not required

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
@@ -1,7 +1,7 @@
 {% if parameter.IsStringArray -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
 {% elseif parameter.IsDateTime -%}
-request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}{{ if parameter.IsNullable }}?{{ endif }}.ToString("{{ ParameterDateTimeFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
+request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}{% unless parameter.IsRequired %}{% if parameter.IsNullable %}?{% endif %}{% endunless %}.ToString("{{ ParameterDateTimeFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
 {% else -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
 {% endif -%}


### PR DESCRIPTION
Since #3346 parameters of type Datetime which are required are rendered as nullable in the header section while the parameter itself in the method isn't nullable. Because of this the generated client does not compile.

