### PR TITLE
Make typings for `axios` more explicit on `AxiosResponse`

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -74,16 +74,16 @@
             } else {
                 throw _error;
             }
-        }).then((_response: AxiosResponse) => {
+        }).then((_response: AxiosResponse<string>) => {
 {%     if UseTransformResultMethod -%}
-            return this.transformResult(url_, _response, (_response: AxiosResponse) => this.process{{ operation.ActualOperationNameUpper }}(_response));
+            return this.transformResult(url_, _response, (_response: AxiosResponse<string>) => this.process{{ operation.ActualOperationNameUpper }}(_response));
 {%     else -%}
             return this.process{{ operation.ActualOperationNameUpper }}(_response);
 {%     endif -%}
         });
     }
 
-    protected process{{ operation.ActualOperationNameUpper }}(response: AxiosResponse): Promise<{{ operation.ResultType }}> {
+    protected process{{ operation.ActualOperationNameUpper }}(response: AxiosResponse<string>): Promise<{{ operation.ResultType }}> {
         const status = response.status;
         {% template Client.ProcessResponse %}
     }


### PR DESCRIPTION
Hello,

Following recent versions bumps of axios, the `AxiosResponse` moved from a default being `any` to one being `unknown`. When bumping to `0.23.0`, the code built by nswag breaks as `response.data` being an `unknown` instead of an `any` becomes incompatible with part of the generated code.

I had two solutions in mind but there are probably others and maybe some better ones:
- Option 1: Transform `AxiosResponse` (defaults to `any`) into `AxiosResponse<string>` (the one if this commit)
- Option 2: Adapt code downstream to do the `as string` whenever required

Here is the code I get with my current setup of nswag:

```ts
    addAccessRightMetric(applicationId: string, body: CreateApplicationArmRequest | undefined , cancelToken?: CancelToken | undefined): Promise<AccessRightMetric> {
        let url_ = this.baseUrl + "/api/workspace/accessrights/AddAccessRightMetric/{applicationId}";
        if (applicationId === undefined || applicationId === null)
            throw new Error("The parameter 'applicationId' must be defined.");
        url_ = url_.replace("{applicationId}", encodeURIComponent("" + applicationId));
        url_ = url_.replace(/[?&]$/, "");

        const content_ = JSON.stringify(body);

        let options_ = <AxiosRequestConfig>{
            data: content_,
            method: "POST",
            url: url_,
            headers: {
                "Content-Type": "application/json-patch+json",
                "Accept": "text/plain"
            },
            cancelToken
        };

        return this.instance.request(options_).catch((_error: any) => {
            if (isAxiosError(_error) && _error.response) {
                return _error.response;
            } else {
                throw _error;
            }
        }).then((_response: AxiosResponse) => {
            return this.processAddAccessRightMetric(_response);
        });
    }

    protected processAddAccessRightMetric(response: AxiosResponse): Promise<AccessRightMetric> {
        const status = response.status;
        let _headers: any = {};
        if (response.headers && typeof response.headers === "object") {
            for (let k in response.headers) {
                if (response.headers.hasOwnProperty(k)) {
                    _headers[k] = response.headers[k];
                }
            }
        }
        if (status === 200) {
            const _responseText = response.data;
            let result200: any = null;
            let resultData200  = _responseText;
            result200 = JSON.parse(resultData200); // Does not compile anymore with 0.23.0
            return result200;
        } else if (status !== 200 && status !== 204) {
            const _responseText = response.data;
            return throwException("An unexpected server error occurred.", status, _responseText, _headers); // Does not compile anymore with 0.23.0
        }
        return Promise.resolve<AccessRightMetric>(<any>null);
    }
```

The signature of `AxiosResponse` in axios 0.23.0:
```ts
export interface AxiosResponse<T = unknown, D = any>  {
  data: T;
  status: number;
  statusText: string;
  headers: AxiosResponseHeaders;
  config: AxiosRequestConfig<D>;
  request?: any;
}
```

In previous releases:
```ts
export interface AxiosResponse<T = any>  {
  data: T;
  status: number;
  statusText: string;
  headers: any;
  config: AxiosRequestConfig;
  request?: any;
}
```

In the current PR, I implemented Option 1, but it is maybe not the one you planned to use. Please feel free to discard the PR if it does not make sense or if you have other options.