### PR TITLE
Add 7.0 to RxJsVersions in NSwag Studio

### DIFF
--- a/src/NSwagStudio/ViewModels/CodeGenerators/SwaggerToTypeScriptClientGeneratorViewModel.cs
+++ b/src/NSwagStudio/ViewModels/CodeGenerators/SwaggerToTypeScriptClientGeneratorViewModel.cs
@@ -35,7 +35,7 @@ namespace NSwagStudio.ViewModels.CodeGenerators
         public decimal[] TypeScriptVersions => new[] { 1.8m, 2.0m, 2.4m, 2.7m };
 
         /// <summary>Gets the supported RxJs versions.</summary>
-        public decimal[] RxJsVersions => new[] { 5.0m, 6.0m };
+        public decimal[] RxJsVersions => new[] { 5.0m, 6.0m, 7.0m };
 
         /// <summary>Gets the output templates.</summary>
         public TypeScriptTemplate[] Templates { get; } = Enum.GetNames(typeof(TypeScriptTemplate))


### PR DESCRIPTION
NSwag added support for RxJs 7 via PR #3482 as mentioned in #3463. NSwag Studio does not allow selection though.
