### PR TITLE
Fix Swagger variable replacement for Owin integration

### DIFF
--- a/src/NSwag.AspNet.Owin/SwaggerUi3/index.html
+++ b/src/NSwag.AspNet.Owin/SwaggerUi3/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Swagger UI</title>
+    <title>{DocumentTitle}</title>
     <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
@@ -29,6 +29,7 @@
       }
     </style>
     {CustomStyle}
+    {CustomHeadContent}
   </head>
 
   <body>


### PR DESCRIPTION
The SwaggerUi3 template is currently missing two replacements in the owin integration.

This is specifically unexpected, as the properties for those replacements are actually available in the SwaggerUi settings object.