### PR TITLE
Fix 00_Install.bat to call restore target

### DIFF
--- a/build/00_Install.bat
+++ b/build/00_Install.bat
@@ -1,3 +1,3 @@
 pushd "%~dp0\.."
-cmd /c call build.cmd install --configuration Release
+cmd /c call build.cmd restore --configuration Release
 popd


### PR DESCRIPTION
https://ci.appveyor.com/project/rsuter/nswag-25x6o/builds/41404480 failed because the naming was changed in the process