### PR TITLE
Fix NSwag.ApiDescription.Client path in Build.cs

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -144,7 +144,7 @@ partial class Build : NukeBuild
             );
 
             NuGetPack(x => x
-                .SetTargetPath(SourceDirectory / "NSwag.ApiDescription" / "NSwag.ApiDescription.Client.nuspec")
+                .SetTargetPath(SourceDirectory / "NSwag.ApiDescription.Client" / "NSwag.ApiDescription.Client.nuspec")
             );
 
             NuGetPack(x => x


### PR DESCRIPTION
This is should fix the packaging error in https://github.com/RicoSuter/NSwag/runs/4104320971?check_suite_focus=true