### PR TITLE
Add support for GitHub artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj', 'src/**/package.json') }}
       - name: Run './build.cmd InstallDependencies Compile Test Pack'
         run: ./build.cmd InstallDependencies Compile Test Pack
+      - uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ _ReSharper.Caches/
 # NUKE build temp files
 .nuke/temp
 
+/artifacts

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -20,7 +20,7 @@ using Nuke.Common.CI.GitHubActions;
     OnPushBranches = new [] { "master" },
     // OnPushBranchesIgnore = new[] { MasterBranch, ReleaseBranchPrefix + "/*" },
     //OnPullRequestBranches = new[] { DevelopBranch },
-    PublishArtifacts = false,
+    PublishArtifacts = true,
     InvokedTargets = new[] { nameof(InstallDependencies), nameof(Compile), nameof(Test), nameof(Pack) },
     CacheKeyFiles = new[] { "global.json", "src/**/*.csproj", "src/**/package.json" })
 ]


### PR DESCRIPTION
@RicoSuter here's a version that shows how artifacts are handled (only gathers for `master` builds/non-prs).  `build.yml` was automatically generated when running NUKE as it detects the c# has changed. 

Didn't see how `NSwag.zip` is generated so just created it by zipping the studio's bin folder.

As you can see ideally everything is written inside the `Build.cs` and can then generate minimal triggering logic and rules for providers, like Appveyor. Appveyor configuration doesn't seem to be part of version control so not sure what to expect there (NUKE can also generate to config if you can export a sanitized version from Appveyor for me to see and diff).