### PR TITLE
NSwag.AspNetCore: Fixed dependencies for Net6.0.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ steps:
   displayName: 'Install .NET Core SDK'
   inputs:
     packageType: 'sdk'
-    version: '5.0.100'
+    version: '6.0.100'
 
 - task: CmdLine@2
   displayName: 'Install DNT'

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.6;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <Version>13.13.2</Version>
     <PackageTags>Swagger Documentation AspNetCore NetCore TypeScript CodeGen</PackageTags>
@@ -25,6 +25,7 @@
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>[1.0.1, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>[3.1, 4.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>[5, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>
+	<MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>[6.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
     <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>
@@ -58,6 +59,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -25,7 +25,7 @@
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>[1.0.1, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>[3.1, 4.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>[5, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>
-	<MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>[6.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>
+	<MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>[6.0, 7.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
     <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -77,7 +77,7 @@
                 <dependency id="NSwag.Generation.AspNetCore" version="$version$" exclude="Build,Analyzers" />
                 <dependency id="NSwag.Generation" version="$version$" exclude="Build,Analyzers" />
                 <dependency id="Microsoft.Extensions.ApiDescription.Server" version="$microsoftExtensionsApiDescriptionServerPackageVersion$" />
-                <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5$" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6$" exclude="Build,Analyzers" />
             </group>
         </dependencies>
     </metadata>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -70,6 +70,15 @@
                 <dependency id="Microsoft.Extensions.ApiDescription.Server" version="$microsoftExtensionsApiDescriptionServerPackageVersion$" />
                 <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5$" exclude="Build,Analyzers" />
             </group>
+			<group targetFramework="net6.0">
+                <dependency id="NSwag.Annotations" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Core.Yaml" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation.AspNetCore" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="NSwag.Generation" version="$version$" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.ApiDescription.Server" version="$microsoftExtensionsApiDescriptionServerPackageVersion$" />
+                <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5$" exclude="Build,Analyzers" />
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -86,5 +95,7 @@
         <file src="bin\$configuration$\netcoreapp3.1\NSwag.AspNetCore.xml" target="lib\netcoreapp3.1\" />
         <file src="bin\$configuration$\net5.0\NSwag.AspNetCore.dll" target="lib\net5.0\" />
         <file src="bin\$configuration$\net5.0\NSwag.AspNetCore.xml" target="lib\net5.0\" />
+        <file src="bin\$configuration$\net6.0\NSwag.AspNetCore.dll" target="lib\net6.0\" />
+        <file src="bin\$configuration$\net6.0\NSwag.AspNetCore.xml" target="lib\net6.0\" />
     </files>
 </package>


### PR DESCRIPTION
Fixes https://github.com/RicoSuter/NSwag/issues/3699 (Hopefully, I couldn't check it properly as NetFramework 4.5 and 4.5.1 is no longer installed on my machine --> End of life).