### PR TITLE
Add missing variable for includeHttpContext in the file.template

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -97,6 +97,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether to call 'transformOptions' on the base class or extension class.</summary>
         public bool UseTransformOptionsMethod => _settings.UseTransformOptionsMethod;
 
+        /// <summary>Gets a value indicating whether to include the httpContext parameter (Angular template only, default: false).</summary>
+        public bool IncludeHttpContext => _settings.IncludeHttpContext;
+
         /// <summary>Gets the clients code.</summary>
         public string Clients => _settings.GenerateClientClasses ? _clientCode : string.Empty;
 


### PR DESCRIPTION
A support for HttpContext has been added on this PR https://github.com/RicoSuter/NSwag/pull/3573/.
This PR provides a fix when the includeHttpContext is set to true.

The HttpContext wasn't imported because a variable was missing in the  model TypeScriptFileTemplateModel.cs.

