### PR TITLE
Trim whitespace from operation summaries

### DIFF
--- a/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
+++ b/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+using NSwag.Annotations;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+using Xunit;
+
+namespace NSwag.Generation.Tests.Processors
+{
+    public class OperationSummaryAndDescriptionProcessorTests
+    {
+        public class DocumentedController
+        {
+            [OpenApiOperation("\r\n\t This method is documented. \r\n\t", "")]
+            public void DocumentedMethodWithOpenApiOperationAttribute()
+            {
+            }
+            
+            [Description("\r\n\t This method is documented. \r\n\t")]
+            public void DocumentedMethodWithDescriptionAttribute()
+            {
+            }
+
+            /// <summary>
+            ///     This method is documented.
+            /// </summary>
+            public void DocumentedMethodWithSummary()
+            {
+            }
+        }
+        
+        [Fact]
+        public void Process_TrimsWhitespaceFromOpenApiOperationSummary()
+        {
+            //// Arrange
+            var controllerType = typeof(DocumentedController);
+            var methodInfo = controllerType.GetMethod(nameof(DocumentedController.DocumentedMethodWithOpenApiOperationAttribute));
+
+            var context = GetContext(controllerType, methodInfo);
+            var processor = new OperationSummaryAndDescriptionProcessor();
+
+            //// Act
+            processor.Process(context);
+
+            //// Assert
+            var summary = context.OperationDescription.Operation.Summary;
+            Assert.Equal("This method is documented.", summary);
+        }
+        
+        [Fact]
+        public void Process_TrimsWhitespaceFromDescription()
+        {
+            //// Arrange
+            var controllerType = typeof(DocumentedController);
+            var methodInfo = controllerType.GetMethod(nameof(DocumentedController.DocumentedMethodWithDescriptionAttribute));
+
+            var context = GetContext(controllerType, methodInfo);
+            var processor = new OperationSummaryAndDescriptionProcessor();
+
+            //// Act
+            processor.Process(context);
+
+            //// Assert
+            var summary = context.OperationDescription.Operation.Summary;
+            Assert.Equal("This method is documented.", summary);
+        }
+        
+        [Fact]
+        public void Process_TrimsWhitespaceFromSummary()
+        {
+            //// Arrange
+            var controllerType = typeof(DocumentedController);
+            var methodInfo = controllerType.GetMethod(nameof(DocumentedController.DocumentedMethodWithSummary));
+
+            var context = GetContext(controllerType, methodInfo);
+            var processor = new OperationSummaryAndDescriptionProcessor();
+
+            //// Act
+            processor.Process(context);
+
+            //// Assert
+            var summary = context.OperationDescription.Operation.Summary;
+            Assert.Equal("This method is documented.", summary);
+        }
+        
+        
+        private OperationProcessorContext GetContext(Type controllerType, MethodInfo methodInfo)
+        {
+            var document = new OpenApiDocument();
+            var operationDescription = new OpenApiOperationDescription { Operation = new OpenApiOperation() };
+            var settings = new OpenApiDocumentGeneratorSettings();
+            return new OperationProcessorContext(document, operationDescription, controllerType, methodInfo, null, null, null, settings, null);
+        }
+    }
+}

--- a/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
+++ b/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
@@ -84,7 +84,6 @@ namespace NSwag.Generation.Tests.Processors
             Assert.Equal("This method is documented.", summary);
         }
         
-        
         private OperationProcessorContext GetContext(Type controllerType, MethodInfo methodInfo)
         {
             var document = new OpenApiDocument();

--- a/src/NSwag.Generation/Processors/OperationSummaryAndDescriptionProcessor.cs
+++ b/src/NSwag.Generation/Processors/OperationSummaryAndDescriptionProcessor.cs
@@ -53,7 +53,7 @@ namespace NSwag.Generation.Processors
 
             if (!string.IsNullOrEmpty(summary))
             {
-                context.OperationDescription.Operation.Summary = summary;
+                context.OperationDescription.Operation.Summary = summary.Trim();
             }
         }
 


### PR DESCRIPTION
Adds a `string.Trim()` call to operation summaries to remove leading and trailing whitespace.

I encountered this behaviour when adding XML documentation to some controller methods with a format like the [following](https://github.com/RicoSuter/NSwag/compare/master...esond:esond/trim-whitespace-from-summaries?expand=1#diff-d8e7dde10714933137a5f7426213c84428b2004fac57a0d15c5bcbbb081f30faR25) [^1]:

```csharp
/// <summary>
///     This method is documented.
/// </summary>
public void DocumentedMethodWithSummary()
{
}
```

This resulted in schema output with trailing whitespace at the end of the summary like this:

```jsonc
"/someController/documentedMethodWithSummary": {
  "get": {
    "summary": "This method is documented.\n            ",
    // ...
}
```

I figured if the beginning of the summary is going to be trimmed, the end probably should be trimmed as well. This is just a simple call to `string.Trim()`, so whitespace inside the summary itself will be maintained.

I also included the trimming behaviour on summaries set with `OpenApiOperationAttribute` and `DescriptionAttribute` as no downsides to this were immediately apparent to me.

Thank you for considering my contribution and for the great tool. NSwag has been perennially useful to me and teams I have been on.

[^1]: For what it's worth, this is the default way JetBrains tools (ReSharper, Rider) format XML doc.

