### PR TITLE
Allowing Microsoft.Extensions.Options and Microsoft.Extensions.DependencyInjection.Abstractions up to and including version 6

### DIFF
--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -22,14 +22,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1, 6)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1, 6]" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1, 6]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5, 6)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[5, 6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5, 6]" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[5, 6]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
👋 Hi Guys, 

I have a `netcoreapp3.1` project I'm still maintaining and planning to upgrade to dotnet 6, but we aren't quite there yet. 
We do try to hold all packages up-to-date as far as goes. With the release of dotnet 6, all Microsoft.Extensions.* packages got bumped to version 6, and still available on 3.1 and 5. 
We ran into problem with `NSWag.Generation.AspNetCore` becouse of the limit the package sets of `[3.1, 6)`.
To be able to build the project I have referenced 
```
 Microsoft.Extensions.Options 6.0.0
 Microsoft.Extensions.DependencyInjection.Abstractions 6.0.0
```
Directly in the project. This results in a warning: 
```
 warning NU1608: Detected package version outside of dependency constraint: NSwag.Generation.AspNetCore 13.14.7 requires Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1.0 && < 6.0.0) but version Microsoft.Extensions.DependencyInjection.Abstractions 6.0.0 was resolved.
 
 warning NU1608: Detected package version outside of dependency constraint: NSwag.Generation.AspNetCore 13.14.7 requires Microsoft.Extensions.Options (>= 3.1.0 && < 6.0.0) but version Microsoft.Extensions.Options 6.0.0 was resolved.
```
but everything works just fine runtime. 

This PR allows version 6 of these packages in `NSwag.Generation.AspNetCore`.

Please feel free to close the PR if there is a special corner-case with version 6.0.0 I'm not aware of.