### PR TITLE
Add file and information version to MSBuild call

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -61,6 +61,7 @@ public partial class Build
                     .SetConfiguration(Configuration)
                     .SetOutputDirectory(ArtifactsDirectory)
                     .SetDeterministic(IsServerBuild)
+                    .SetContinuousIntegrationBuild(IsServerBuild)
                 );
             }
 


### PR DESCRIPTION
Putting explicit version info to every call that builds code to ensure we don't get missing information.