### PR TITLE
Use async processing in NSwagCommandProcessor

### DIFF
--- a/src/NSwag.Commands/NSwagCommandProcessor.cs
+++ b/src/NSwag.Commands/NSwagCommandProcessor.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Tasks;
 using NConsole;
 using NJsonSchema;
 using NJsonSchema.Infrastructure;
@@ -31,7 +32,12 @@ namespace NSwag.Commands
         /// <summary>Processes the command line arguments.</summary>
         /// <param name="args">The arguments.</param>
         /// <returns>The result.</returns>
-        public int Process(string[] args)
+        public int Process(string[] args) => ProcessAsync(args).GetAwaiter().GetResult();
+
+        /// <summary>Processes the command line arguments.</summary>
+        /// <param name="args">The arguments.</param>
+        /// <returns>The result.</returns>
+        public async Task<int> ProcessAsync(string[] args)
         {
             _host.WriteMessage("toolchain v" + OpenApiDocument.ToolchainVersion +
                 " (NJsonSchema v" + JsonSchema.ToolchainVersion + ")\n");
@@ -52,7 +58,7 @@ namespace NSwag.Commands
 
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
-                processor.Process(args);
+                await processor.ProcessAsync(args).ConfigureAwait(false);
                 stopwatch.Stop();
 
                 _host.WriteMessage("\nDuration: " + stopwatch.Elapsed + "\n");

--- a/src/NSwag.Console/Program.cs
+++ b/src/NSwag.Console/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NConsole;
 using NSwag.Commands;
 
@@ -6,11 +7,11 @@ namespace NSwag
 {
     public class Program
     {
-        static int Main(string[] args)
+        private static Task<int> Main(string[] args)
         {
             Console.Write("NSwag command line tool for .NET 4.6.1+ " + RuntimeUtilities.CurrentRuntime + ", ");
             var processor = new NSwagCommandProcessor(new ConsoleHost());
-            return processor.Process(args);
+            return processor.ProcessAsync(args);
         }
     }
 }

--- a/src/NSwag.ConsoleCore/Program.cs
+++ b/src/NSwag.ConsoleCore/Program.cs
@@ -1,15 +1,16 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NSwag.Commands;
 
 namespace NSwag
 {
     public class Program
     {
-        static int Main(string[] args)
+        private static Task<int> Main(string[] args)
         {
             Console.Write("NSwag command line tool for .NET Core " + RuntimeUtilities.CurrentRuntime + ", ");
             var processor = new NSwagCommandProcessor(new CoreConsoleHost());
-            return processor.Process(args);
+            return processor.ProcessAsync(args);
         }
     }
 }


### PR DESCRIPTION
`CommandLineProcessor` has async Process overload , `ProcessAsync` , that should be used to prevent from going to sync path. Changed existing method to be async and with `Async` suffix, added method to wrap its result for possible backwards compatibility.