### PR TITLE
Include SymbolPackageFormat in Directory.Build.props

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -175,6 +175,7 @@ partial class Build : NukeBuild
                     .SetMaxCpuCount(Environment.ProcessorCount)
                     .SetNodeReuse(IsLocalBuild)
                     .SetVerbosity(MSBuildVerbosity.Minimal)
+                    .SetProperty("Deterministic", IsServerBuild)
                     .SetProperty("ContinuousIntegrationBuild", IsServerBuild)
             );
         });

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugSymbols>true</DebugSymbols>
 
     <!-- reduce package size by only including english resources -->

--- a/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
+++ b/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
@@ -35,7 +35,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.StaticFiles" Version="3.0.1" />
-    <PackageReference Include="NJsonSchema" Version="10.6.2" />
     <PackageReference Include="Owin" Version="1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net461;netstandard1.6;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageTags>Swagger Documentation AspNetCore NetCore TypeScript CodeGen</PackageTags>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
 
     <!-- Execute PopulateNuspec fairly late. -->
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);PopulateNuspec</GenerateNuspecDependsOn>

--- a/src/NSwag.Demo.Web/NSwag.Demo.Web.csproj
+++ b/src/NSwag.Demo.Web/NSwag.Demo.Web.csproj
@@ -142,8 +142,6 @@
     <PackageReference Include="Microsoft.Owin.FileSystems" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="3.0.1" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
-    <PackageReference Include="Namotion.Reflection" Version="2.0.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NJsonSchema" Version="10.6.2" />
     <PackageReference Include="Owin" Version="1.0.0" />
   </ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -6,10 +6,6 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.6.2" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.4" />

--- a/src/NSwag.Generation.WebApi.Tests/NSwag.Generation.WebApi.Tests.csproj
+++ b/src/NSwag.Generation.WebApi.Tests/NSwag.Generation.WebApi.Tests.csproj
@@ -42,9 +42,7 @@
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="Namotion.Reflection" Version="2.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.6.2" />
     <PackageReference Include="Swashbuckle" Version="5.5.3" />
     <PackageReference Include="Swashbuckle.Core" Version="5.5.3" />
     <PackageReference Include="WebActivatorEx" Version="2.0.0" />

--- a/src/NSwag.Generation.WebApi/NSwag.Generation.WebApi.csproj
+++ b/src/NSwag.Generation.WebApi/NSwag.Generation.WebApi.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NJsonSchema" Version="10.6.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/src/NSwag.Sample.NetGlobalAsax/NSwag.Sample.NetGlobalAsax.csproj
+++ b/src/NSwag.Sample.NetGlobalAsax/NSwag.Sample.NetGlobalAsax.csproj
@@ -199,7 +199,6 @@
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="3.1.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Modernizr" Version="2.6.2" />
-    <PackageReference Include="Namotion.Reflection" Version="2.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Owin" Version="1.0.0" />
     <PackageReference Include="Respond" Version="1.2.0" />


### PR DESCRIPTION
* globally snupkg, but for AspNetCore the old format as seems to cause trouble with custom nuspec
* removed some redundant package references