### PR TITLE
Reduce enumerator and list allocations

### DIFF
--- a/src/NSwag.Core/Collections/ObservableDictionary.cs
+++ b/src/NSwag.Core/Collections/ObservableDictionary.cs
@@ -22,31 +22,33 @@ namespace NSwag.Collections
         IDictionary<TKey, TValue>, INotifyCollectionChanged,
         INotifyPropertyChanged, IDictionary, IReadOnlyDictionary<TKey, TValue>
     {
+        private Dictionary<TKey, TValue> _dictionary;
+
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
         public ObservableDictionary()
         {
-            Dictionary = new Dictionary<TKey, TValue>();
+            _dictionary = new Dictionary<TKey, TValue>();
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
         /// <param name="dictionary">The dictionary to initialize this dictionary. </param>
         public ObservableDictionary(IDictionary<TKey, TValue> dictionary)
         {
-            Dictionary = new Dictionary<TKey, TValue>(dictionary);
+            _dictionary = new Dictionary<TKey, TValue>(dictionary);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
         /// <param name="comparer">The comparer. </param>
         public ObservableDictionary(IEqualityComparer<TKey> comparer)
         {
-            Dictionary = new Dictionary<TKey, TValue>(comparer);
+            _dictionary = new Dictionary<TKey, TValue>(comparer);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
         /// <param name="capacity">The capacity. </param>
         public ObservableDictionary(int capacity)
         {
-            Dictionary = new Dictionary<TKey, TValue>(capacity);
+            _dictionary = new Dictionary<TKey, TValue>(capacity);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
@@ -54,7 +56,7 @@ namespace NSwag.Collections
         /// <param name="comparer">The comparer. </param>
         public ObservableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
         {
-            Dictionary = new Dictionary<TKey, TValue>(dictionary, comparer);
+            _dictionary = new Dictionary<TKey, TValue>(dictionary, comparer);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
@@ -62,11 +64,11 @@ namespace NSwag.Collections
         /// <param name="comparer">The comparer. </param>
         public ObservableDictionary(int capacity, IEqualityComparer<TKey> comparer)
         {
-            Dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
+            _dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
         }
 
         /// <summary>Gets the underlying dictonary. </summary>
-        protected IDictionary<TKey, TValue> Dictionary { get; private set; }
+        protected Dictionary<TKey, TValue> Dictionary => _dictionary;
 
         /// <summary>Adds multiple key-value pairs the the dictionary. </summary>
         /// <param name="items">The key-value pairs. </param>
@@ -79,21 +81,21 @@ namespace NSwag.Collections
 
             if (items.Count > 0)
             {
-                if (Dictionary.Count > 0)
+                if (_dictionary.Count > 0)
                 {
-                    if (items.Keys.Any(k => Dictionary.ContainsKey(k)))
+                    if (items.Keys.Any(k => _dictionary.ContainsKey(k)))
                     {
                         throw new ArgumentException("An item with the same key has already been added.");
                     }
 
-                    foreach (var item in items)
+                    foreach (var pair in items)
                     {
-                        Dictionary.Add(item);
+                        _dictionary.Add(pair.Key, pair.Value);
                     }
                 }
                 else
                 {
-                    Dictionary = new Dictionary<TKey, TValue>(items);
+                    _dictionary = new Dictionary<TKey, TValue>(items);
                 }
 
                 OnCollectionChanged(NotifyCollectionChangedAction.Add, items.ToArray());
@@ -107,7 +109,7 @@ namespace NSwag.Collections
         protected virtual void Insert(TKey key, TValue value, bool add)
         {
             TValue item;
-            if (Dictionary.TryGetValue(key, out item))
+            if (_dictionary.TryGetValue(key, out item))
             {
                 if (add)
                 {
@@ -119,12 +121,12 @@ namespace NSwag.Collections
                     return;
                 }
 
-                Dictionary[key] = value;
+                _dictionary[key] = value;
                 OnCollectionChanged(NotifyCollectionChangedAction.Replace, new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, item));
             }
             else
             {
-                Dictionary[key] = value;
+                _dictionary[key] = value;
                 OnCollectionChanged(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value));
             }
         }
@@ -214,23 +216,20 @@ namespace NSwag.Collections
         /// <returns></returns>
         public bool ContainsKey(TKey key)
         {
-            return Dictionary.ContainsKey(key);
+            return _dictionary.ContainsKey(key);
         }
 
         /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1" /> containing the keys of the <see cref="T:System.Collections.Generic.IDictionary`2" />.</summary>
         public ICollection<TKey> Keys
         {
-            get { return Dictionary.Keys; }
+            get { return _dictionary.Keys; }
         }
 
-        ICollection IDictionary.Values { get { return ((IDictionary)Dictionary).Values; } }
+        ICollection IDictionary.Values => _dictionary.Values;
 
-        ICollection IDictionary.Keys { get { return ((IDictionary)Dictionary).Keys; } }
+        ICollection IDictionary.Keys => _dictionary.Keys;
 
-        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
-        {
-            get { return Values; }
-        }
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
 
         /// <summary>Removes the specified key.</summary>
         /// <param name="key">The key.</param>
@@ -243,10 +242,7 @@ namespace NSwag.Collections
                 throw new ArgumentNullException("key");
             }
 
-            TValue value;
-            Dictionary.TryGetValue(key, out value);
-
-            var removed = Dictionary.Remove(key);
+            var removed = _dictionary.Remove(key);
             if (removed)
             {
                 OnCollectionChanged();
@@ -261,7 +257,7 @@ namespace NSwag.Collections
         /// <returns></returns>
         public bool TryGetValue(TKey key, out TValue value)
         {
-            return Dictionary.TryGetValue(key, out value);
+            return _dictionary.TryGetValue(key, out value);
         }
 
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
@@ -270,10 +266,7 @@ namespace NSwag.Collections
         }
 
         /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1" /> containing the values in the <see cref="T:System.Collections.Generic.IDictionary`2" />.</summary>
-        public ICollection<TValue> Values
-        {
-            get { return Dictionary.Values; }
-        }
+        public ICollection<TValue> Values => _dictionary.Values;
 
         /// <summary>Gets or sets the TValue with the specified key.</summary>
         /// <value>The TValue.</value>
@@ -281,8 +274,8 @@ namespace NSwag.Collections
         /// <returns></returns>
         public TValue this[TKey key]
         {
-            get { return Dictionary[key]; }
-            set { Insert(key, value, false); }
+            get => _dictionary[key];
+            set => Insert(key, value, false);
         }
 
         #endregion
@@ -304,9 +297,9 @@ namespace NSwag.Collections
         /// <summary>Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
         public void Clear()
         {
-            if (Dictionary.Count > 0)
+            if (_dictionary.Count > 0)
             {
-                Dictionary.Clear();
+                _dictionary.Clear();
                 OnCollectionChanged();
             }
         }
@@ -318,12 +311,12 @@ namespace NSwag.Collections
             var pairs = keyValuePairs.ToList();
             foreach (var pair in pairs)
             {
-                Dictionary[pair.Key] = pair.Value;
+                _dictionary[pair.Key] = pair.Value;
             }
 
-            foreach (var key in Dictionary.Keys.Where(k => !pairs.Any(p => Equals(p.Key, k))).ToArray())
+            foreach (var key in _dictionary.Keys.Where(k => !pairs.Any(p => Equals(p.Key, k))).ToArray())
             {
-                Dictionary.Remove(key);
+                _dictionary.Remove(key);
             }
 
             OnCollectionChanged();
@@ -346,7 +339,7 @@ namespace NSwag.Collections
 
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
-            return ((IDictionary)Dictionary).GetEnumerator();
+            return ((IDictionary) _dictionary).GetEnumerator();
         }
 
         /// <summary>Removes the specified key.</summary>
@@ -364,7 +357,7 @@ namespace NSwag.Collections
         /// <returns></returns>
         public bool Contains(KeyValuePair<TKey, TValue> item)
         {
-            return Dictionary.Contains(item);
+            return _dictionary.Contains(item);
         }
 
         /// <summary>Copies to.</summary>
@@ -372,7 +365,7 @@ namespace NSwag.Collections
         /// <param name="arrayIndex">Index of the array.</param>
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            Dictionary.CopyTo(array, arrayIndex);
+            ((IDictionary) _dictionary).CopyTo(array, arrayIndex);
         }
 
         /// <summary>Copies to.</summary>
@@ -380,14 +373,11 @@ namespace NSwag.Collections
         /// <param name="index">The index.</param>
         public void CopyTo(Array array, int index)
         {
-            ((IDictionary)Dictionary).CopyTo(array, index);
+            ((IDictionary)_dictionary).CopyTo(array, index);
         }
 
         /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
-        public int Count
-        {
-            get { return Dictionary.Count; }
-        }
+        public int Count => _dictionary.Count;
 
         /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection" /> is synchronized (thread safe).</summary>
         public bool IsSynchronized { get; private set; }
@@ -396,10 +386,7 @@ namespace NSwag.Collections
         public object SyncRoot { get; private set; }
 
         /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</summary>
-        public bool IsReadOnly
-        {
-            get { return Dictionary.IsReadOnly; }
-        }
+        public bool IsReadOnly => ((IDictionary) _dictionary).IsReadOnly;
 
         object IDictionary.this[object key]
         {
@@ -421,9 +408,16 @@ namespace NSwag.Collections
 
         /// <summary>Returns an enumerator that iterates through the collection.</summary>
         /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
-        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
         {
-            return Dictionary.GetEnumerator();
+            return _dictionary.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
         }
 
         #endregion
@@ -432,7 +426,7 @@ namespace NSwag.Collections
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable)Dictionary).GetEnumerator();
+            return ((IDictionary) _dictionary).GetEnumerator();
         }
 
         #endregion

--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -241,7 +241,7 @@ namespace NSwag
         {
             get
             {
-                foreach (var p in Paths)
+                foreach (var p in _paths)
                 {
                     foreach (var o in p.Value.ActualPathItem)
                     {

--- a/src/NSwag.Core/OpenApiHeaders.cs
+++ b/src/NSwag.Core/OpenApiHeaders.cs
@@ -11,7 +11,7 @@ using NSwag.Collections;
 namespace NSwag
 {
     /// <summary>A collection of headers.</summary>
-    public class OpenApiHeaders : ObservableDictionary<string, OpenApiHeader>
+    public sealed class OpenApiHeaders : ObservableDictionary<string, OpenApiHeader>
     {
     }
 }


### PR DESCRIPTION
* when possible, enumerate concrete `ObservableCollection` type to avoid enumerator boxing and slower enumeration
* tweaked `ObservableCollection` the same way as in NJS that it uses concrete type to access inner dictionary
* don't materialize grouping when not needed
* don't use LINQ in `GetOperations`, it was creating unnecessary intermediate anonymous class too