### PR TITLE
Move installer project pre-build event handling to NUKE

### DIFF
--- a/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
+++ b/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
@@ -55,28 +55,4 @@
             ComponentGroupName="SourceComponentGroup"
             ToolPath="$(WixToolPath)" />
   </Target>
-  <PropertyGroup>
-    <PreBuildEvent>
-      rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /Q /S nonemptydir
-      rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore21" /Q /S nonemptydir
-      rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore31" /Q /S nonemptydir
-      rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Net50" /Q /S nonemptydir
-      rmdir "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Net60" /Q /S nonemptydir
-
-      dotnet restore "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" --no-cache
-
-      dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp2.1" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.1/Publish" /property:Platform=AnyCPU
-      dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "netcoreapp3.1" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp3.1/Publish" /property:Platform=AnyCPU
-      dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "net5.0" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/net5.0/Publish" /property:Platform=AnyCPU
-      dotnet publish "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/NSwag.ConsoleCore.csproj" -c $(ConfigurationName) -f "net6.0" -o "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/net6.0/Publish" /property:Platform=AnyCPU
-
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.Console.x86/bin/$(ConfigurationName)/net461" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.Console/bin/$(ConfigurationName)/net461" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Win" /E /I /y
-
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp2.1/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore21" /E /I /y
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/netcoreapp3.1/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/NetCore31" /E /I /y
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/net5.0/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Net50" /E /I /y
-      xcopy "$(MSBuildProjectDirectory)/../NSwag.ConsoleCore/bin/$(ConfigurationName)/net6.0/publish" "$(MSBuildProjectDirectory)/../NSwagStudio/bin/$(ConfigurationName)/Net60" /E /I /y
-    </PreBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
* moved logic to NUKE side
* using helper local functions to unify logic
* output still seems to be the same for artifacts, studio installer succeeds and studio runs, won't mind some QA testing here