### PR TITLE
Add support to specify persistAuthorization for Swagger UI 3

### DIFF
--- a/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
@@ -104,6 +104,13 @@ namespace NSwag.AspNetCore
             set => AdditionalSettings["tagsSorter"] = value;
         }
 
+        /// <summary>Specifies whether to persist authorization data in Swagger UI 3.</summary>
+        public bool PersistAuthorization
+        {
+            get => (bool)AdditionalSettings["persistAuthorization"];
+            set => AdditionalSettings["persistAuthorization"] = value;
+        }
+
         /// <summary>Gets a value indicating whether to send credentials from the Swagger UI 3 to the backend.</summary>
         public bool WithCredentials
         {


### PR DESCRIPTION
Persist authorization data with the [Swagger parameter](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#authorization) and it would not be lost on browser close/refresh or [.NET Hot Reload](https://devblogs.microsoft.com/dotnet/introducing-net-hot-reload/).

```csharp
app.UseSwaggerUi3(config =>
{
    config.PersistAuthorization = true;
    // config.AdditionalSettings.Add("persistAuthorization", true);
});
```