### PR TITLE
Add @ts-nocheck to the generated code file

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -6,6 +6,7 @@
 // </auto-generated>
 //----------------------
 // ReSharper disable InconsistentNaming
+// @ts-nocheck
 
 {{ ExtensionCodeImport -}}
 {% if ImportRequiredTypes -%}


### PR DESCRIPTION
In new version of Angular (and Typescript) the [noImplicitOverride](https://www.typescriptlang.org/tsconfig#noImplicitOverride) rule is activated by default and this causes issues when trying to get NSwag generated code to compile.

Because I think in the future or even on purpose in some projects other rules can be activated there should be a way to always compile the generated code, even if it doesn't follow the Typescript compiler options.