### PR TITLE
FileResponse: support for special characters in fileName  (+ suppress warning when nullable is enabled in C# clients) 

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -19,6 +19,7 @@ using {{ usage }};
 #pragma warning disable 1591 // Disable "CS1591 Missing XML comment for publicly visible type or member ..."
 #pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
+#pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 
 namespace {{ Namespace }}
 {
@@ -215,3 +216,4 @@ namespace {{ Namespace }}
 #pragma warning restore  114
 #pragma warning restore  108
 #pragma warning restore 3016
+#pragma warning restore 8603

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -6,8 +6,8 @@ const contentDisposition = response.headers ? response.headers["content-disposit
 {%     else -%}
 const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
 {%     endif -%}
-const fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
-const fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+const fileNameMatch = contentDisposition ? /filename[^;=\n]*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+const fileName = fileNameMatch && fileNameMatch.length > 1 ? decodeURIComponent(fileNameMatch[fileNameMatch.length - 1]) : undefined;
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}
 return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}<any>responseBlob{% else %}<any>response.blob(){% endif %}, status: status, headers: _headers }));


### PR DESCRIPTION
**Warning suppressed**
When the Nullable feature is enabled and Warning are treated as errors, the generated C# client will not compile due to the fact, that deserialization might fail and newtonsoft will the return null. Therefore, this pull request will suppress the corresponding warning. 


Example code snippet that might cause an error depending on the C# projec settings: 
`      
  public static Path FromJson(string data)
        {
            return Newtonsoft.Json.JsonConvert.DeserializeObject<Path>(data, new Newtonsoft.Json.JsonSerializerSettings());
        }`

Remark: adding the ? to mark the return value as nullable would have been possible as well. However, this might not be compatible with older C# versions, so i guess its safer to just suppress the error. 