### PR TITLE
Add ability to add a custom exception handler

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
@@ -150,5 +150,25 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             // Assert
             Assert.Contains("public partial interface IFooClient : IClientBase", code);
         }
+
+        [Fact]
+        public async Task When_exception_factory_is_specified_then_exceptions_are_sent_to_it()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<FooController>();
+
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                ExceptionClass = "MyCustomException",
+                ExceptionFactory = "ConvertExceptionToCustomException"
+            });
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("throw ConvertExceptionToCustomException(new MyCustomException(", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -8,16 +8,21 @@
 
 namespace NSwag.CodeGeneration.CSharp
 {
-    /// <summary>Settings for the <see cref="CSharpClientGenerator"/>.</summary>
+    /// <summary>
+    /// Settings for the <see cref="CSharpClientGenerator"/>.
+    /// </summary>
     public class CSharpClientGeneratorSettings : CSharpGeneratorBaseSettings
     {
-        /// <summary>Initializes a new instance of the <see cref="CSharpClientGeneratorSettings"/> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CSharpClientGeneratorSettings"/> class.
+        /// </summary>
         public CSharpClientGeneratorSettings()
         {
             ClassName = "{controller}Client";
 
             GenerateExceptionClasses = true;
             ExceptionClass = "ApiException";
+            ExceptionFactory = "DefaultExceptionFactory";
             ClientClassAccessModifier = "public";
             UseBaseUrl = true;
             HttpClientType = "System.Net.Http.HttpClient";
@@ -34,83 +39,150 @@ namespace NSwag.CodeGeneration.CSharp
             ProtectedMethods = new string[0];
         }
 
-        /// <summary>Gets or sets the full name of the base class.</summary>
+        /// <summary>
+        /// Gets or sets the full name of the base class.
+        /// </summary>
         public string ClientBaseClass { get; set; }
 
-        /// <summary>Gets or sets the full name of the base interface.</summary>
+        /// <summary>
+        /// Gets or sets the full name of the base interface.
+        /// </summary>
         public string ClientBaseInterface { get; set; }
 
-        /// <summary>Gets or sets the full name of the configuration class (<see cref="ClientBaseClass"/> must be set).</summary>
+        /// <summary>
+        /// Gets or sets the full name of the configuration class ( <see cref="ClientBaseClass"/>
+        /// must be set).
+        /// </summary>
         public string ConfigurationClass { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate exception classes (default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate exception classes (default: true).
+        /// </summary>
         public bool GenerateExceptionClasses { get; set; }
 
-        /// <summary>Gets or sets the name of the exception class (supports the '{controller}' placeholder, default 'ApiException').</summary>
+        /// <summary>
+        /// Gets or sets the name of the exception class (supports the '{controller}' placeholder,
+        /// default 'ApiException').
+        /// </summary>
         public string ExceptionClass { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether an HttpClient instance is injected into the client (default: true).</summary>
+        /// <summary>
+        /// Gets or sets the name of the ExceptionFactory to call when an exception occurs. Default null
+        /// </summary>
+        public string ExceptionFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an HttpClient instance is injected into the
+        /// client (default: true).
+        /// </summary>
         public bool InjectHttpClient { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to dispose the HttpClient (injected HttpClient is never disposed, default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to dispose the HttpClient (injected HttpClient
+        /// is never disposed, default: true).
+        /// </summary>
         public bool DisposeHttpClient { get; set; }
 
-        /// <summary>Gets or sets the list of methods with a protected access modifier ("classname.methodname").</summary>
+        /// <summary>
+        /// Gets or sets the list of methods with a protected access modifier ("classname.methodname").
+        /// </summary>
         public string[] ProtectedMethods { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to call CreateHttpClientAsync on the base class to create a new HttpClient instance (cannot be used when the HttpClient is injected).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to call CreateHttpClientAsync on the base class
+        /// to create a new HttpClient instance (cannot be used when the HttpClient is injected).
+        /// </summary>
         public bool UseHttpClientCreationMethod { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to call CreateHttpRequestMessageAsync on the base class to create a new HttpRequestMethod.</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to call CreateHttpRequestMessageAsync on the
+        /// base class to create a new HttpRequestMethod.
+        /// </summary>
         public bool UseHttpRequestMessageCreationMethod { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException instance (default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether DTO exceptions are wrapped in a SwaggerException
+        /// instance (default: true).
+        /// </summary>
         public bool WrapDtoExceptions { get; set; }
 
-        /// <summary>Gets or sets the client class access modifier (default: public).</summary>
+        /// <summary>
+        /// Gets or sets the client class access modifier (default: public).
+        /// </summary>
         public string ClientClassAccessModifier { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to use and expose the base URL (default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to use and expose the base URL (default: true).
+        /// </summary>
         public bool UseBaseUrl { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate the BaseUrl property, must be defined on the base class otherwise (default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate the BaseUrl property, must be
+        /// defined on the base class otherwise (default: true).
+        /// </summary>
         public bool GenerateBaseUrlProperty { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate synchronous methods (not recommended, default: false).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate synchronous methods (not
+        /// recommended, default: false).
+        /// </summary>
         public bool GenerateSyncMethods { get; set; }
 
         /// <summary>
-        /// Gets or sets the HttpClient type which will be used in the generation of the client code. By default the System.Net.Http.HttpClient
-        /// will be used, but this can be overridden. Just keep in mind that the type you specify has the same default HttpClient method signatures.
+        /// Gets or sets the HttpClient type which will be used in the generation of the client
+        /// code. By default the System.Net.Http.HttpClient will be used, but this can be
+        /// overridden. Just keep in mind that the type you specify has the same default HttpClient
+        /// method signatures.
         /// </summary>
         public string HttpClientType { get; set; }
 
-        /// <summary>Gets or sets the format for DateTime type method parameters (default: "s").</summary>
+        /// <summary>
+        /// Gets or sets the format for DateTime type method parameters (default: "s").
+        /// </summary>
         public string ParameterDateTimeFormat { get; set; }
 
-        /// <summary>Gets or sets the format for Date type method parameters (default: "yyyy-MM-dd").</summary>
+        /// <summary>
+        /// Gets or sets the format for Date type method parameters (default: "yyyy-MM-dd").
+        /// </summary>
         public string ParameterDateFormat { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings method (must be implemented in the base class otherwise, default: true).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate the UpdateJsonSerializerSettings
+        /// method (must be implemented in the base class otherwise, default: true).
+        /// </summary>
         public bool GenerateUpdateJsonSerializerSettingsMethod { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to create PrepareRequest and ProcessResponse as async methods, or as partial synchronous methods.
-        /// If value is set to true, PrepareRequestAsync and ProcessResponseAsync methods must be implemented as part of the client base class (if it has one) or as part of the partial client class.
-        /// If value is set to false, PrepareRequest and ProcessResponse methods will be partial methods, and implement them is optional.
+        /// Gets or sets a value indicating whether to create PrepareRequest and ProcessResponse as
+        /// async methods, or as partial synchronous methods. If value is set to true,
+        /// PrepareRequestAsync and ProcessResponseAsync methods must be implemented as part of the
+        /// client base class (if it has one) or as part of the partial client class. If value is
+        /// set to false, PrepareRequest and ProcessResponse methods will be partial methods, and
+        /// implement them is optional.
         /// </summary>
         public bool GeneratePrepareRequestAndProcessResponseAsAsyncMethods { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to generate different request and response serialization settings (default: false).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate different request and response
+        /// serialization settings (default: false).
+        /// </summary>
         public bool UseRequestAndResponseSerializationSettings { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to serialize the type information in a $type property (not recommended, also sets TypeNameHandling = Auto).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to serialize the type information in a $type
+        /// property (not recommended, also sets TypeNameHandling = Auto).
+        /// </summary>
         public bool SerializeTypeInformation { get; set; }
 
-        /// <summary>Gets or sets the null value used for query parameters which are null (default: '').</summary>
+        /// <summary>
+        /// Gets or sets the null value used for query parameters which are null (default: '').
+        /// </summary>
         public string QueryNullValue { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether to expose the JsonSerializerSettings property (default: false).</summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether to expose the JsonSerializerSettings property
+        /// (default: false).
+        /// </summary>
         public bool ExposeJsonSerializerSettings { get; set; }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -45,6 +45,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
             BaseClass = _settings.ClientBaseClass?.Replace("{controller}", controllerName);
             ExceptionClass = _settings.ExceptionClass.Replace("{controller}", controllerName);
+            ExceptionFactory = _settings.ExceptionFactory;
         }
 
         /// <summary>Gets the class name.</summary>
@@ -100,6 +101,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets the exception class name.</summary>
         public string ExceptionClass { get; }
+
+        /// <summary>Gets the exception factory method name.</summary>
+        public string ExceptionFactory { get; }
 
         /// <summary>Gets a value indicating whether to generate optional parameters.</summary>
         public bool GenerateOptionalParameters => _settings.GenerateOptionalParameters;

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -7,7 +7,7 @@ disposeClient_ = false; disposeResponse_ = false; // response and client are dis
 return fileResponse_;
 {%         else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_, cancellationToken).ConfigureAwait(false);
-throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+throw {{ ExceptionFactory }}(new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null));
 {%         endif -%}
 {%     elsif response.IsPlainText -%}
 var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -19,14 +19,14 @@ return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, hea
 return result_;
 {%             endif -%}
 {%         else -%}
-throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, responseData_, headers_, result_, null);
+throw {{ ExceptionFactory }}(new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, responseData_, headers_, result_, null));
 {%         endif -%}
 {%     else -%}
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_, cancellationToken).ConfigureAwait(false);
 {%         if response.IsNullable == false -%}
 if (objectResponse_.Object == null)
 {
-    throw new {{ ExceptionClass }}("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+    throw {{ ExceptionFactory }}(new {{ ExceptionClass }}("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null));
 }
 {%         endif -%}
 {%         if response.IsSuccess -%}
@@ -43,12 +43,12 @@ responseObject_.Data.Add("HttpStatus", status_.ToString());
 responseObject_.Data.Add("HttpHeaders", headers_);
 responseObject_.Data.Add("HttpResponse", objectResponse_.Text);
 {%                 if WrapDtoExceptions -%}
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, responseObject_);
+throw {{ ExceptionFactory }}(new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, responseObject_));
 {%                 else -%}
 throw responseObject_;
 {%                 endif -%}
 {%             else -%}
-throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+throw {{ ExceptionFactory }}(new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null));
 {%             endif -%}
 {%         endif -%}
 {%     endif -%}
@@ -68,5 +68,5 @@ return;
 {%     endif -%}
 {% else -%}{% comment %} implied: `if !response.HasType` so just read it as text {% endcomment %}
 string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, responseText_, headers_, null);
+throw {{ ExceptionFactory }}(new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, responseText_, headers_, null));
 {% endif %}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -26,7 +26,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
         {
             var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
-            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, responseText, headers, exception);
+            throw {{ ExceptionFactory }}(new {{ ExceptionClass }}(message, (int)response.StatusCode, responseText, headers, exception));
         }
     }
     else
@@ -54,7 +54,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
         {
             var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
-            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, string.Empty, headers, exception);
+            throw {{ ExceptionFactory }}(new {{ ExceptionClass }}(message, (int)response.StatusCode, string.Empty, headers, exception));
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -332,7 +332,7 @@
 {%         elsif operation.HasSuccessResponse -%}
                     {
                         var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", status_, responseData_, headers_, null);
+                        throw {{ ExceptionFactory }}(new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", status_, responseData_, headers_, null));
                     }
 {%        elsif operation.HasResultType -%}
 {%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" %}
@@ -368,7 +368,7 @@
 {%         endif -%}
                     {
                         var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        throw {{ ExceptionFactory }}(new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null));
                     }
 {%     endif -%}
                 }
@@ -404,4 +404,9 @@
 
     {% template Client.Class.ConvertToString %}
     {% template Client.Class.Body %}
+
+    private static Exception DefaultExceptionFactory({{ExceptionClass}} ex)
+    {
+        return ex;
+    }
 }


### PR DESCRIPTION
In our solutions we already have existing exceptions that are handled in our front-ends.
These exceptions are custom and are now used when communicating with our legacy WCF services. 
When generating a WebAPI client with NSwag there is the option to re-use a single exception, if it has the correct constructor.

With this PR, I have added the option to specify an ExceptionFactory. If you do not specify a custom factory, the default is used:
```
    private static Exception DefaultExceptionFactory({{ExceptionClass}} ex)
    {
        return ex;
    }
```

But now we can specify a custom ExceptionFactory, for example: "My.Custom.NameSpace.MyCustomExceptionFactory":
```
public static Exception MyCustomExceptionFactory(ApiException ex)
{
  return ex.StatusCode switch
  {
    400 => ex.Result is ValidationProblemDetails ? new ValidationException(ex.Result.Errors) : new FunctionalException(ex.Result.Message)
    401 => new UnauthorizedException();
    403 => new ForbiddenException();
    _ => ex;
  };
}
```

Without the ExceptionFactory, we would need to catch the ApiException everywhere the client is used and convert it afterwards.