### PR TITLE
Improve processing performance

### DIFF
--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -169,7 +169,7 @@ namespace NSwag.Commands.CodeGeneration
             get { return Settings.ExposeJsonSerializerSettings; }
             set { Settings.ExposeJsonSerializerSettings = value; }
         }
-        
+
         [Argument(Name = "ClientClassAccessModifier", IsRequired = false, Description = "The client class access modifier (default: public).")]
         public string ClientClassAccessModifier
         {
@@ -254,28 +254,23 @@ namespace NSwag.Commands.CodeGeneration
             return result;
         }
 
-        public Task<Dictionary<string, string>> RunAsync()
+        public async Task<Dictionary<string, string>> RunAsync()
         {
-            return Task.Run(async () =>
-            {
-                var document = await GetInputSwaggerDocument().ConfigureAwait(false);
-                var clientGenerator = new CSharpClientGenerator(document, Settings);
+            var document = await GetInputSwaggerDocument().ConfigureAwait(false);
+            var clientGenerator = new CSharpClientGenerator(document, Settings);
 
-                if (GenerateContractsOutput)
-                {
-                    var result = new Dictionary<string, string>();
-                    GenerateContracts(result, clientGenerator);
-                    GenerateImplementation(result, clientGenerator);
-                    return result;
-                }
-                else
-                {
-                    return new Dictionary<string, string>
-                    {
-                        { OutputFilePath ?? "Full", clientGenerator.GenerateFile(ClientGeneratorOutputType.Full) }
-                    };
-                }
-            });
+            if (GenerateContractsOutput)
+            {
+                var result = new Dictionary<string, string>();
+                GenerateContracts(result, clientGenerator);
+                GenerateImplementation(result, clientGenerator);
+                return result;
+            }
+
+            return new Dictionary<string, string>
+            {
+                { OutputFilePath ?? "Full", clientGenerator.GenerateFile(ClientGeneratorOutputType.Full) }
+            };
         }
 
         private void GenerateImplementation(Dictionary<string, string> result, CSharpClientGenerator clientGenerator)

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpControllerCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpControllerCommand.cs
@@ -94,12 +94,9 @@ namespace NSwag.Commands.CodeGeneration
 
         public async Task<string> RunAsync()
         {
-            return await Task.Run(async () =>
-            {
-                var document = await GetInputSwaggerDocument().ConfigureAwait(false);
-                var clientGenerator = new CSharpControllerGenerator(document, Settings);
-                return clientGenerator.GenerateFile();
-            });
+            var document = await GetInputSwaggerDocument().ConfigureAwait(false);
+            var clientGenerator = new CSharpControllerGenerator(document, Settings);
+            return clientGenerator.GenerateFile();
         }
     }
 }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -401,22 +401,19 @@ namespace NSwag.Commands.CodeGeneration
             return code;
         }
 
-        public Task<string> RunAsync()
+        public async Task<string> RunAsync()
         {
-            return Task.Run(async () =>
+            var additionalCode = ExtensionCode ?? string.Empty;
+            if (DynamicApis.FileExists(additionalCode))
             {
-                var additionalCode = ExtensionCode ?? string.Empty;
-                if (DynamicApis.FileExists(additionalCode))
-                {
-                    additionalCode = DynamicApis.FileReadAllText(additionalCode);
-                }
+                additionalCode = DynamicApis.FileReadAllText(additionalCode);
+            }
 
-                Settings.TypeScriptGeneratorSettings.ExtensionCode = additionalCode;
+            Settings.TypeScriptGeneratorSettings.ExtensionCode = additionalCode;
 
-                var document = await GetInputSwaggerDocument().ConfigureAwait(false);
-                var clientGenerator = new TypeScriptClientGenerator(document, Settings);
-                return clientGenerator.GenerateFile();
-            });
+            var document = await GetInputSwaggerDocument().ConfigureAwait(false);
+            var clientGenerator = new TypeScriptClientGenerator(document, Settings);
+            return clientGenerator.GenerateFile();
         }
     }
 }

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
@@ -8,7 +8,6 @@
 
 using System.IO;
 using System.Reflection;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 #pragma warning disable CS0618
@@ -28,8 +27,7 @@ namespace NSwag.Commands.Generation.AspNetCore
             var serviceProvider = ServiceProviderResolver.GetServiceProvider(assembly);
 
             var assemblyLoader = new AssemblyLoader.AssemblyLoader();
-            var document = Task.Run(async () =>
-                await command.GenerateDocumentAsync(assemblyLoader, serviceProvider, previousWorkingDirectory)).GetAwaiter().GetResult();
+            var document = command.GenerateDocumentAsync(assemblyLoader, serviceProvider, previousWorkingDirectory).GetAwaiter().GetResult();
 
             var json = command.UseDocumentProvider ? document.ToJson() : document.ToJson(command.OutputType);
 

--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -44,7 +44,7 @@ namespace NSwag.Commands
 
         public abstract Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host);
 
-        protected async Task<TResult> RunIsolatedAsync(string configurationFile)
+        protected Task<TResult> RunIsolatedAsync(string configurationFile)
         {
             var assemblyDirectory = AssemblyPaths.Any() ? Path.GetDirectoryName(Path.GetFullPath(PathUtilities.ExpandFileWildcards(AssemblyPaths).First())) : configurationFile;
             var bindingRedirects = GetBindingRedirects();
@@ -58,7 +58,7 @@ namespace NSwag.Commands
 
             using (var isolated = new AppDomainIsolation<IsolatedCommandAssemblyLoader>(assemblyDirectory, AssemblyConfig, bindingRedirects, assemblies))
             {
-                return await Task.Run(() => isolated.Object.Run(GetType().FullName, JsonConvert.SerializeObject(this), AssemblyPaths, ReferencePaths)).ConfigureAwait(false);
+                return Task.FromResult(isolated.Object.Run(GetType().FullName, JsonConvert.SerializeObject(this), AssemblyPaths, ReferencePaths));
             }
         }
 

--- a/src/NSwag.Core/IsExternalInit.cs
+++ b/src/NSwag.Core/IsExternalInit.cs
@@ -1,0 +1,4 @@
+namespace System.Runtime.CompilerServices;
+
+// for older frameworks
+internal static class IsExternalInit { }


### PR DESCRIPTION
* optimize couple hot paths where LINQ was allocating and making things slow
* only spawn Task.Run where forking makes sense (multiple generators), spawning of Task didn't produce performance benefit and only made profiling harder due the unnecessary extra thread, now spawning for generator handling.


Running against our code base and generating TS and C# clients from Swagger2.0 specification

master:        `Duration: 00:00:06.2780536`
this branch: `Duration: 00:00:05.6278623`