### PR TITLE
Map blob type from response content type

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -14,7 +14,7 @@ return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}
 {%         elsif Framework.IsAngularJS -%}
 return this.q.resolve(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers }));
 {%         elsif Framework.IsAxios -%}
-return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers }));
+return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, status: status, data: new Blob([response.data], { type: response.headers["content-type"] }), headers: _headers }));
 {%         else -%}
 return response.blob().then(blob => { return new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: blob, status: status, headers: _headers }); });
 {%         endif -%}
@@ -24,7 +24,7 @@ return {{ Framework.RxJs.ObservableOfMethod }}({ fileName: fileName, data: {% if
 {%         elsif Framework.IsAngularJS -%}
 return this.q.resolve({ fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers });
 {%         elsif Framework.IsAxios -%}
-return Promise.resolve({ fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers });
+return Promise.resolve({ fileName: fileName, status: status, data: new Blob([response.data], { type: response.headers["content-type"] }), headers: _headers });
 {%         else -%}
 return response.blob().then(blob => { return { fileName: fileName, data: blob, status: status, headers: _headers }; });
 {%         endif -%}


### PR DESCRIPTION
This is my first PR, so please help me out if I am not following your process.

#3740 actually turned out to be a breaking change for me.

Before this change, the blob would have the correct `type` set according to the `Content-Type` on the response. By initializing a new `Blob` without specifying the type, the `type` property is empty, resulting in potential bugs when processing the blob later.

I just made changes to the code where the `Framework.IsAxios` condition is met. This is because I am using `Axios` with the Typescript client, and I do not know if this could be handled in the same way for Angular JS.  