### PR TITLE
Remove TypeScript bracket type casting syntax

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -86,7 +86,7 @@
         return this.http.request({% if Framework.Angular.UseHttpClient %}"{{ operation.HttpMethodLower }}", {% endif %}url_, options_).{% if Framework.UseRxJs6 %}pipe({% endif %}{{ Framework.RxJs.ObservableMergeMapMethod }}((response_ : any) => {
 {%-    endif -%}
 {%-    if UseTransformResultMethod -%}
-            return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(<any>r));
+            return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(r as any));
 {%-    else -%}
             return this.process{{ operation.ActualOperationNameUpper }}(response_);
 {%-    endif -%}
@@ -94,15 +94,15 @@
             if (response_ instanceof {% if Framework.Angular.UseHttpClient %}HttpResponseBase{% else %}Response{% endif %}) {
                 try {
 {%-    if UseTransformResultMethod -%}
-                    return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(<any>r));
+                    return this.transformResult(url_, response_, (r) => this.process{{ operation.ActualOperationNameUpper }}(r as any));
 {%-    else -%}
-                    return this.process{{ operation.ActualOperationNameUpper }}(<any>response_);
+                    return this.process{{ operation.ActualOperationNameUpper }}(response_ as any);
 {%-    endif -%}
                 } catch (e) {
-                    return <Observable<{{ operation.ResultType }}>><any>{{ Framework.RxJs.ObservableThrowMethod }}(e);
+                    return {{ Framework.RxJs.ObservableThrowMethod }}(e) as any as Observable<{{ operation.ResultType }}>;
                 }
             } else
-                return <Observable<{{ operation.ResultType }}>><any>{{ Framework.RxJs.ObservableThrowMethod }}(response_);
+                return {{ Framework.RxJs.ObservableThrowMethod }}(response_) as any as Observable<{{ operation.ResultType }}>;
         }){% if Framework.UseRxJs6 %}){% endif %};
     }
 
@@ -111,7 +111,7 @@
 {%- if Framework.Angular.UseHttpClient -%}
         const responseBlob =
             response instanceof HttpResponse ? response.body :
-            (<any>response).error instanceof Blob ? (<any>response).error : undefined;
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
 {%- endif -%}
 
         {% template Client.ProcessResponse %}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularJSClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularJSClient.liquid
@@ -41,7 +41,7 @@
         {% template Client.RequestBody %}
 {%     endif -%}
 
-        var options_ = <ng.IRequestConfig>{
+        var options_: ng.IRequestConfig = {
             url: url_,
             method: "{{ operation.HttpMethodUpper | upcase }}",
 {%     if operation.IsFile -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -39,7 +39,7 @@
         {% template Client.RequestBody %}
 
 {%     endif -%}
-        let options_ = <AxiosRequestConfig>{
+        let options_: AxiosRequestConfig = {
 {%     if operation.HasBody -%}
             data: content_,
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -10,7 +10,7 @@ const fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(co
 const fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}
-return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}<any>responseBlob{% else %}<any>response.blob(){% endif %}, status: status, headers: _headers }));
+return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}responseBlob as any{% else %}response.blob() as any{% endif %}, status: status, headers: _headers }));
 {%         elsif Framework.IsAngularJS -%}
 return this.q.resolve(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers }));
 {%         elsif Framework.IsAxios -%}
@@ -20,7 +20,7 @@ return response.blob().then(blob => { return new {{ operation.ResponseClass }}(s
 {%         endif -%}
 {%     else -%}
 {%         if Framework.IsAngular -%}
-return {{ Framework.RxJs.ObservableOfMethod }}({ fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}<any>responseBlob{% else %}<any>response.blob(){% endif %}, status: status, headers: _headers });
+return {{ Framework.RxJs.ObservableOfMethod }}({ fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}responseBlob as any{% else %}response.blob() as any{% endif %}, status: status, headers: _headers });
 {%         elsif Framework.IsAngularJS -%}
 return this.q.resolve({ fileName: fileName, status: status, data: new Blob([response.data]), headers: _headers });
 {%         elsif Framework.IsAxios -%}
@@ -45,7 +45,7 @@ result{{ response.StatusCode }} = {% unless response.IsPlainText %}JSON.parse({%
 let resultData{{ response.StatusCode }} = _responseText === "" ? null : {% if response.IsPlainText %}_responseText{% else %}{% if operation.HandleReferences %}jsonParse{% else %}JSON.parse{% endif %}(_responseText, this.jsonParseReviver){% endif %};
 {{ response.DataConversionCode }}
 {%              else -%}
-result{{ response.StatusCode }} = _responseText === "" ? null : <{{ response.Type }}>{% if response.IsPlainText %}_responseText{% else %}{% if operation.HandleReferences %}jsonParse{% else %}JSON.parse{% endif %}(_responseText, this.jsonParseReviver){% endif %};
+result{{ response.StatusCode }} = _responseText === "" ? null : {% if response.IsPlainText %}_responseText{% else %}{% if operation.HandleReferences %}jsonParse{% else %}JSON.parse{% endif %}(_responseText, this.jsonParseReviver){% endif %} as {{ response.Type }};
 {%              endif -%}
 {%         endif -%}
 {%         if response.IsSuccess -%}
@@ -76,25 +76,25 @@ return throwException({% if Framework.IsAngularJS %}this.q, {% endif %}"{{ respo
 {%     elsif response.IsSuccess -%}
 {%         if operation.WrapResponse -%}
 {%             if Framework.IsAngular -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%             elsif Framework.IsAngularJS -%}
-return this.q.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return this.q.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%             elsif Framework.IsAxios -%}
-return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResultType }}(status, _headers, <any>null));
+return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResultType }}(status, _headers, null as any));
 {%             else -%}
-return new {{ operation.ResponseClass }}(status, _headers, <any>null);
+return new {{ operation.ResponseClass }}(status, _headers, null as any);
 {%             endif -%}
 {%         else -%}
 {%             if Framework.IsAngular -%}
 {%                 if Framework.UseRxJs7 -%}
-return {{ Framework.RxJs.ObservableOfMethod }}(<any>null);
+return {{ Framework.RxJs.ObservableOfMethod }}(null as any);
 {%                 else -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{operation.ResultType}}>(<any>null);
+return {{ Framework.RxJs.ObservableOfMethod }}<{{operation.ResultType}}>(null as any);
 {%                 endif -%}
 {%             elsif Framework.IsAngularJS -%}
-return this.q.resolve<{{ operation.ResultType }}>(<any>null);
+return this.q.resolve<{{ operation.ResultType }}>(null as any);
 {%             elsif Framework.IsAxios -%}
-return Promise.resolve<{{ operation.ResultType }}>(<any>null);
+return Promise.resolve<{{ operation.ResultType }}>(null as any);
 {%             else -%}
 return{% if operation.HasResultType %} null{% endif %};
 {%             endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.Return.liquid
@@ -1,34 +1,34 @@
 {% if Framework.IsFetchOrAurelia -%}
 {%     if operation.WrapResponse -%}
-return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%     else -%}
-return Promise.resolve<{{ operation.ResultType }}>(<any>null);
+return Promise.resolve<{{ operation.ResultType }}>(null as any);
 {%     endif -%}
 {% elsif Framework.IsAxios -%}
 {%     if operation.WrapResponse -%}
-return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return Promise.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%     else -%}
-return Promise.resolve<{{ operation.ResultType }}>(<any>null);
+return Promise.resolve<{{ operation.ResultType }}>(null as any);
 {%     endif -%}
 {% elsif Framework.IsAngular -%}
 {%     if operation.WrapResponse -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%     else -%}
 {%         if Framework.UseRxJs7 -%}
-return {{ Framework.RxJs.ObservableOfMethod }}(<any>null);
+return {{ Framework.RxJs.ObservableOfMethod }}(null as any);
 {%         else -%}
-return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(<any>null);
+return {{ Framework.RxJs.ObservableOfMethod }}<{{ operation.ResultType }}>(null as any);
 {%         endif -%}
 {%     endif -%}
 {% elsif Framework.IsAngularJS -%}
 {%     if operation.WrapResponse -%}
-return this.q.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, <any>null));
+return this.q.resolve<{{ operation.ResultType }}>(new {{ operation.ResponseClass }}(status, _headers, null as any));
 {%     else -%}
-return this.q.resolve<{{ operation.ResultType }}>(<any>null);
+return this.q.resolve<{{ operation.ResultType }}>(null as any);
 {%     endif -%}
 {% else -%}
 {%     if operation.WrapResponse -%}
-return new {{ operation.ResponseClass }}(status, _headers, <any>null);
+return new {{ operation.ResponseClass }}(status, _headers, null as any);
 {%     else -%}
 return{% if operation.HasResultType %} null{% endif %};
 {%     endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestBody.liquid
@@ -27,7 +27,7 @@ else if ({{ parameter.VariableName }} !== undefined)
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach((item_, index_) => {
         for (let attr_ in item_) {
            if (item_.hasOwnProperty(attr_)) {
-                content_ += encodeURIComponent("{{ parameter.Name }}[" + index_ + "]." + attr_) + "=" + encodeURIComponent("" + (<any>item_)[attr_]) + "&";
+                content_ += encodeURIComponent("{{ parameter.Name }}[" + index_ + "]." + attr_) + "=" + encodeURIComponent("" + (item_ as any)[attr_]) + "&";
            }
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -46,7 +46,7 @@ else if ({{ parameter.VariableName }} !== undefined)
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach((item, index) => {
         for (let attr in item)
 			if (item.hasOwnProperty(attr)) {
-				url_ += "{{ parameter.Name }}[" + index + "]." + attr + "=" + encodeURIComponent("" + (<any>item)[attr]) + "&";
+				url_ += "{{ parameter.Name }}[" + index + "]." + attr + "=" + encodeURIComponent("" + (item as any)[attr]) + "&";
 			}
     });
 {%    elsif parameter.IsDateOrDateTime -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -21,7 +21,7 @@
 {%-    if HasBaseClass -%}
         super({% if HasConfigurationClass %}configuration{% endif %});
 {%-    endif -%}
-        this.http = http ? http : <any>window;
+        this.http = http ? http : window as any;
 {%-    if UseGetBaseUrlMethod -%}
         this.baseUrl = this.getBaseUrl("{{ BaseUrl }}", baseUrl);
 {%-    else -%}
@@ -43,7 +43,7 @@
         {% template Client.RequestBody %}
 
 {%-    endif -%}
-        let options_ = <RequestInit>{
+        let options_: RequestInit = {
 {%-    if operation.HasBody -%}
             body: content_,
 {%-    endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -45,7 +45,7 @@ function blobToText(blob: any): Observable<string> {
         } else {
             let reader = new FileReader();
             reader.onload = event => {
-                observer.next((<any>event.target).result);
+                observer.next((event.target as any).result);
                 observer.complete();
             };
             reader.readAsText(blob);
@@ -57,7 +57,7 @@ function blobToText(blob: any): Observable<string> {
 function blobToText(blob: Blob, q: ng.IQService): ng.IPromise<string> {
     return new q((resolve) => {
         let reader = new FileReader();
-        reader.onload = event => resolve((<any>event.target).result);
+        reader.onload = event => resolve((event.target as any).result);
         reader.readAsText(blob);
     });
 }


### PR DESCRIPTION
Remove obsolete bracket syntax from TypeScript templates which causing problems with React setups
Fix for #https://github.com/RicoSuter/NSwag/issues/1590