### PR TITLE
Simplify `#if`'s

### DIFF
--- a/src/NSwag.AspNetCore.Launcher/Program.cs
+++ b/src/NSwag.AspNetCore.Launcher/Program.cs
@@ -89,42 +89,6 @@ namespace NSwag.AspNetCore.Launcher
 
             Console.WriteLine("Launcher directory: " + codeBaseDirectory);
 
-#if NETCOREAPP1_0
-            var loadContext = System.Runtime.Loader.AssemblyLoadContext.Default;
-            loadContext.Resolving += (context, assemblyName) =>
-            {
-                var name = assemblyName.Name;
-
-                if (!NSwagReferencedAssemblies.TryGetValue(name, out var assemblyInfo))
-                {
-                    return null;
-                }
-
-                // If we've loaded a higher version from the app's closure, return it.
-                if (assemblyInfo.LoadedAssembly != null)
-                {
-                    return assemblyInfo.LoadedAssembly;
-                }
-
-                var assemblyLocation = Path.Combine(toolsDirectory, name + ".dll");
-                if (!File.Exists(assemblyLocation))
-                {
-                    assemblyLocation = Path.Combine(codeBaseDirectory, name + ".dll");
-                    if (!File.Exists(assemblyLocation))
-                    {
-                        assemblyLocation = Path.Combine(codeBaseDirectory, "Publish", name + ".dll");
-                        if (!File.Exists(assemblyLocation))
-                        {
-                            Console.WriteLine($"Referenced assembly '{assemblyName}' was not found in {toolsDirectory} and {codeBaseDirectory}.");
-                            throw new InvalidOperationException($"Referenced assembly '{assemblyName}' was not found in {toolsDirectory} and {codeBaseDirectory}.");
-                        }
-                    }
-                }
-
-                return context.LoadFromAssemblyPath(assemblyLocation);
-            };
-            var assembly = loadContext.LoadFromAssemblyName(CommandsAssemblyName);
-#else
             AppDomain.CurrentDomain.AssemblyResolve += (source, eventArgs) =>
             {
                 var assemblyName = new AssemblyName(eventArgs.Name);
@@ -160,8 +124,6 @@ namespace NSwag.AspNetCore.Launcher
             };
 
             var assembly = Assembly.Load(CommandsAssemblyName);
-#endif
-
             var type = assembly.GetType(EntryPointType, throwOnError: true);
             var method = type.GetMethod("Process", BindingFlags.Public | BindingFlags.Static);
 

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
@@ -25,7 +25,7 @@ using NSwag.Generation;
 using NJsonSchema.Generation;
 using Namotion.Reflection;
 
-#if NET5_0_OR_GREATER || NETCOREAPP || NETSTANDARD
+#if NETCOREAPP || NETSTANDARD
 using System.Runtime.Loader;
 #endif
 
@@ -172,7 +172,7 @@ namespace NSwag.Commands.Generation.AspNetCore
                         cleanupFiles.Add(copiedAppConfig);
                     }
                 }
-#elif NET5_0_OR_GREATER || NETCOREAPP || NETSTANDARD
+#elif NETCOREAPP || NETSTANDARD
                 var toolDirectory = AppContext.BaseDirectory;
                 if (!Directory.Exists(toolDirectory))
                 {

--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -247,7 +247,7 @@ namespace NSwag.Commands.Generation
         public async Task<TSettings> CreateSettingsAsync(AssemblyLoader.AssemblyLoader assemblyLoader, IServiceProvider serviceProvider, string workingDirectory)
         {
             var mvcOptions = serviceProvider?.GetRequiredService<IOptions<MvcOptions>>().Value;
-#if NET5_0_OR_GREATER || NETCOREAPP3_1 || NETCOREAPP3_0 
+#if NETCOREAPP3_0_OR_GREATER 
             JsonSerializerSettings serializerSettings;
             try
             {

--- a/src/NSwag.Commands/HostApplication.cs
+++ b/src/NSwag.Commands/HostApplication.cs
@@ -47,7 +47,7 @@ namespace NSwag.Commands
                             null, createWebHostMethod.GetParameters().Length > 0 ? new object[] { args } : Array.Empty<object>());
                         serviceProvider = webHostBuilder.Build().Services;
                     }
-#if NET5_0_OR_GREATER || NETCOREAPP3_1 || NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
                     else
                     {
                         var createHostMethod =

--- a/src/NSwag.Commands/RuntimeUtilities.cs
+++ b/src/NSwag.Commands/RuntimeUtilities.cs
@@ -19,7 +19,7 @@ namespace NSwag.Commands
         {
             get
             {
-#if !NETCOREAPP && !NETSTANDARD && !NET5_0_OR_GREATER
+#if NETFRAMEWORK
                 return IntPtr.Size == 4 ? Runtime.WinX86 : Runtime.WinX64;
 #else
                 var framework = PlatformServices.Default.Application.RuntimeFramework;

--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -83,7 +83,7 @@ namespace NSwag.Generation.AspNetCore
                 }
             }
 
-#if NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             dynamic options = GetJsonOptionsWithReflection(serviceProvider);
 #else
             object options = null;


### PR DESCRIPTION
Here's list of conditional compilation symbols defined for each TFM: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation

- `NETCOREAPP` is also defined for `NET5` and `NET6`
- From what I see `!NETCOREAPP && !NETSTANDARD` is the same as `NETFRAMEWORK`
- Also `#if NET5_0_OR_GREATER` is the same as `#if NET`, but I didn't apply that here

Testing:
- Checked in Visual Studio, new conditions work as expected

Questions:
- There's a `#if NETCOREAPP1_0` here: https://github.com/RicoSuter/NSwag/blob/master/src/NSwag.AspNetCore.Launcher/Program.cs#L92, and looks like it will never be compiled. Should this code be removed?