### PR TITLE
Fix npm resolving net5/6 incorrectly, change default version to net6

### DIFF
--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -2,7 +2,14 @@
 "use strict";
 
 var defaultCoreVersion = "Core21";
-var supportedCoreVersions = ["Core21", "Core22", "Core30", "Core31", "50", "60"];
+var supportedCoreVersions = [
+    { ver: '2.1', dir: "NetCore21", },
+    { ver: '2.2', dir: "NetCore22", },
+    { ver: '3.0', dir: "NetCore30", },
+    { ver: '3.1', dir: "NetCore31", },
+    { ver: '5.0', dir: "Net50", },
+    { ver: '6.0', dir: "Net60", },
+];
 
 // Initialize
 process.title = 'nswag';
@@ -44,19 +51,20 @@ if (hasFullDotNet && args.toLowerCase().indexOf("/runtime:win") != -1) {
     }
 } else {
     // Run .NET Core version
-    var defaultCmd = 'dotnet "' + __dirname + '/binaries/Net' + defaultCoreVersion + '/dotnet-nswag.dll" ' + args;
+    var defaultCmd = 'dotnet "' + __dirname + '/binaries/' + defaultCoreVersion + '/dotnet-nswag.dll" ' + args;
     var infoCmd = "dotnet --version";
-    c.exec(infoCmd, (error, stdout, stderr) => {
+    c.exec(infoCmd, (error, stdout, _stderr) => {
         for (let version of supportedCoreVersions) {
-            var coreCmd = 'dotnet "' + __dirname + '/binaries/Net' + version + '/dotnet-nswag.dll" ' + args;
+            var coreCmd = 'dotnet "' + __dirname + '/binaries/' + version.dir + '/dotnet-nswag.dll" ' + args;
 
-            if (args.toLowerCase().indexOf("/runtime:net" + version.toLocaleLowerCase()) != -1) {
+            if (args.toLowerCase().indexOf("/runtime:" + version.dir.toLocaleLowerCase()) != -1) {
                 c.execSync(coreCmd, { stdio: [0, 1, 2] });
                 return;
             } else {
                 if (!error) {
                     var coreVersion = stdout;
-                    if (coreVersion.indexOf(version.replace('Core', '') + ".0") !== -1) {
+
+                    if (coreVersion.startsWith(version.ver)) {
                         c.execSync(coreCmd, { stdio: [0, 1, 2] });
                         return;
                     }

--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 "use strict";
 
-var defaultCoreVersion = "Core21";
+var defaultCoreVersion = "Net60";
 var supportedCoreVersions = [
-    { ver: '2.1', dir: "NetCore21", },
-    { ver: '2.2', dir: "NetCore22", },
-    { ver: '3.0', dir: "NetCore30", },
-    { ver: '3.1', dir: "NetCore31", },
-    { ver: '5.0', dir: "Net50", },
     { ver: '6.0', dir: "Net60", },
+    { ver: '5.0', dir: "Net50", },
+    { ver: '3.1', dir: "NetCore31", },
+    { ver: '3.0', dir: "NetCore30", },
+    { ver: '2.2', dir: "NetCore22", },
+    { ver: '2.1', dir: "NetCore21", },
 ];
 
 // Initialize
@@ -23,7 +23,7 @@ args = args.replace("--core 2.1", "/runtime:NetCore21");
 args = args.replace("--core 3.1", "/runtime:NetCore31");
 args = args.replace("--core 5.0", "/runtime:Net50");
 args = args.replace("--core 6.0", "/runtime:Net60");
-args = args.replace("--core", "/runtime:Net" + defaultCoreVersion);
+args = args.replace("--core", "/runtime:" + defaultCoreVersion);
 
 // Search for full .NET installation
 var hasFullDotNet = false;


### PR DESCRIPTION
Currently the npm package doesn't resolve NET6 version if `dotnet --version` returns `6.0.*`, most likely same is for NET5. User is met with an error for missing framework versions if core 2.1 is not also installed.

Core 2.1 is [out of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), replaced with NET6 (LTS release).