### PR TITLE
Fix for issue: 3865 content-disposition fileName parsing regex got broken recently

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -19,6 +19,7 @@ using {{ usage }};
 #pragma warning disable 1591 // Disable "CS1591 Missing XML comment for publicly visible type or member ..."
 #pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
+#pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 
 namespace {{ Namespace }}
 {
@@ -215,3 +216,4 @@ namespace {{ Namespace }}
 #pragma warning restore  114
 #pragma warning restore  108
 #pragma warning restore 3016
+#pragma warning restore 8603

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -6,8 +6,8 @@ const contentDisposition = response.headers ? response.headers["content-disposit
 {%     else -%}
 const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
 {%     endif -%}
-const fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
-const fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+const fileNameMatch = contentDisposition ? /filename[^;=\n]*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+const fileName = fileNameMatch && fileNameMatch.length > 1 ? decodeURIComponent(fileNameMatch[fileNameMatch.length - 1]) : undefined;
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}
 return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}<any>responseBlob{% else %}<any>response.blob(){% endif %}, status: status, headers: _headers }));

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -6,8 +6,12 @@ const contentDisposition = response.headers ? response.headers["content-disposit
 {%     else -%}
 const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
 {%     endif -%}
-const fileNameMatch = contentDisposition ? /filename[^;=\n]*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
-const fileName = fileNameMatch && fileNameMatch.length > 1 ? decodeURIComponent(fileNameMatch[fileNameMatch.length - 1]) : undefined;
+let fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+if(!fileName){
+	fileNameMatch = contentDisposition ? /filename[^;=\n]*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+	fileName = fileNameMatch && fileNameMatch.length > 1 ? decodeURIComponent(fileNameMatch[fileNameMatch.length - 1]) : undefined;
+}
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}
 return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}<any>responseBlob{% else %}<any>response.blob(){% endif %}, status: status, headers: _headers }));


### PR DESCRIPTION
Changes to how filename is retrieved from the response header: 

- Going back to the old regex (which we know works in the field). 
- if not successfull, try with the new Regex (which supports special characters, but was the cause for issue 3865)

Probably not to be the final solution (but in my opinion a better state then before)
