### PR TITLE
IsDateTime should return true when using Moment (see NjsonSchema) #1613

### DIFF
--- a/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
@@ -156,7 +156,8 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets a value indicating whether the parameter is of type date-time</summary>
         public bool IsDateTime =>
-            Schema.Format == JsonFormatStrings.DateTime && _generator.GetTypeName(Schema, IsNullable, null) != "string";
+            Schema.Format is JsonFormatStrings.DateTime or JsonFormatStrings.TimeSpan &&
+            _generator.GetTypeName(Schema, IsNullable, null) != "string";
 
         /// <summary>Gets a value indicating whether the parameter is of type date-time or date</summary>
         public bool IsDateOrDateTime => IsDate || IsDateTime;
@@ -182,7 +183,7 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether the parameter is of type date-time array.</summary>
         public bool IsDateTimeArray =>
             IsArray &&
-            Schema.Item?.ActualSchema.Format == JsonFormatStrings.DateTime &&
+            Schema.Item?.ActualSchema.Format is JsonFormatStrings.DateTime or JsonFormatStrings.TimeSpan &&
             _generator.GetTypeName(Schema.Item.ActualSchema, IsNullable, null) != "string";
 
         /// <summary>Gets a value indicating whether the parameter is of type date-time or date array.</summary>


### PR DESCRIPTION
This is a follow-up for PR #3660.

When using Moment, the TimeSpan class is not converted to the correct format when it is part of the url parameters.
Nswag doesn't append the .format('d.hh:mm:ss.SS', { trim: false }) method on TimeSpans, while in NjsonSchema, this is done correctly. This causes TimeSpans to be converted to Moments differently when used in the url parameter or in the body.

The source of this issue lies in the fact that in NjsonSchema, the IsDateTime function returns true when a TimeSpan is used ([NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs](https://github.com/RicoSuter/NJsonSchema/blob/e2a60bcd593479e3f8a7b64e87b02c9b4b7bb5d6/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs#L230)).
In Nswag this was not yet the case, so this was added in this PR.

Kind regards,
Bjarne

