### PR TITLE
Feature/allow 2xx untyped response

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/AllowUntyped2xxResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/AllowUntyped2xxResponseTests.cs
@@ -1,0 +1,146 @@
+using NSwag.CodeGeneration.OperationNameGenerators;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NSwag.CodeGeneration.CSharp.Tests
+{
+    public class AllowUntyped2xxResponseTests
+    {
+        [Fact]
+        public async Task TestAllowUntyped2xxResponseNotSet()
+        {
+            // Arrange
+            var swagger =
+@"{
+  ""openapi"": ""3.0.1"",
+  ""paths"": {
+    ""/definitions/{definitionId}/elements"": {
+      ""get"": {
+        ""operationId"": ""elements_LIST_1"",
+        ""requestBody"": {
+          ""content"": {
+            ""*/*"": {
+              ""schema"": {
+                ""type"": ""integer"",
+                ""format"": ""int64""
+              }
+            }
+          }
+        },
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+                ""text/plain"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                },
+              ""application/json"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                },
+              ""text/json"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                }
+            }
+          },
+          ""204"": {
+            ""description"": ""Success 204"",
+        }
+    }
+      }
+    }
+  }
+}";
+            var document = await OpenApiDocument.FromJsonAsync(swagger);
+            //untyped
+            // Act
+            var codeGen = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings()
+            {
+                GenerateClientInterfaces = true,
+                AllowUntyped2xxResponse = false,
+                OperationNameGenerator = new SingleClientFromOperationIdOperationNameGenerator()
+            });
+
+            var code = codeGen.GenerateFile();
+
+            // Assert
+            Assert.DoesNotContain("return default(string)", code);
+            Assert.Contains(@"throw new ApiException(""Success 204"", status_, responseText_, headers_, null);", code);
+        }
+
+        [Theory]
+        [InlineData(true, "return new SwaggerResponse<string>(status_, headers_, default(string));")]
+        [InlineData(false, "return default(string);")]
+        public async Task TestAllowUntyped2xxResponseIsTrueWrappedOrNot(bool wrapResponse, string expectedResult)
+        {
+            // Arrange
+            var swagger =
+@"{
+  ""openapi"": ""3.0.1"",
+  ""paths"": {
+    ""/definitions/{definitionId}/elements"": {
+      ""get"": {
+        ""operationId"": ""elements_LIST_1"",
+        ""requestBody"": {
+          ""content"": {
+            ""*/*"": {
+              ""schema"": {
+                ""type"": ""integer"",
+                ""format"": ""int64""
+              }
+            }
+          }
+        },
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+                ""text/plain"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                },
+              ""application/json"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                },
+              ""text/json"": {
+                    ""schema"": {
+                        ""type"": ""string""
+                    }
+                }
+            }
+          },
+          ""204"": {
+            ""description"": ""Success 204"",
+        }
+    }
+      }
+    }
+  }
+}";
+            var document = await OpenApiDocument.FromJsonAsync(swagger);
+            //untyped
+            // Act
+            var codeGen = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings()
+            {
+                GenerateClientInterfaces = true,
+                AllowUntyped2xxResponse = true,
+                WrapResponses = wrapResponse,
+                OperationNameGenerator = new SingleClientFromOperationIdOperationNameGenerator()
+            });
+
+            var code = codeGen.GenerateFile();
+
+            // Assert
+            Assert.Contains(expectedResult, code);
+            Assert.DoesNotContain(@"throw new ApiException(""Success 204"", status_, responseText_, headers_, null);", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -112,5 +112,8 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether to expose the JsonSerializerSettings property (default: false).</summary>
         public bool ExposeJsonSerializerSettings { get; set; }
+
+        /// <summary>Accept not typed 2xx messages that return empty data.</summary>
+        public bool AllowUntyped2xxResponse { get; set; }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -146,6 +146,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the null value used for query parameters which are null.</summary>
         public string QueryNullValue => _settings.QueryNullValue;
 
+        /// <summary>Accept not typed 2xx messages that return empty data.</summary>
+        public bool AllowUntyped2xxResponse => _settings.AllowUntyped2xxResponse;
+
         /// <summary>
         /// Gets or sets a value indicating whether to create PrepareRequest and ProcessResponse as async methods, or as partial synchronous methods.
         /// If value is set to true, PrepareRequestAsync and ProcessResponseAsync methods must be implemented as part of the client base class (if it has one) or as part of the partial client class.

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -67,6 +67,14 @@ return;
 {%         endif -%}
 {%     endif -%}
 {% else -%}{% comment %} implied: `if !response.HasType` so just read it as text {% endcomment %}
+{%      if response.IsSuccessStatusCode and AllowUntyped2xxResponse -%}
+{%          if operation.WrapResponse -%}
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
+{%          else -%}
+return {{ operation.UnwrappedResultDefaultValue }};
+{%          endif -%}
+{%      else -%}
 string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
 throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, responseText_, headers_, null);
+{%      endif -%}
 {% endif %}

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -140,5 +140,8 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets the produced mime type of this response if available.</summary>
         public string Produces => _response.Content.Keys.FirstOrDefault();
+
+        /// <summary>If status code is Success</summary>
+        public bool IsSuccessStatusCode => HttpUtilities.IsSuccessStatusCode(StatusCode);
     }
 }


### PR DESCRIPTION
Allow to have multiple 2xx responses for the same request method.

.NET returns 204(no content) for methods that have null responses.
nswag throws exception in these cases.

So in this fix if the Attribute is set
[ProducesResponseType(StatusCodes.Status204NoContent)]
and the config have AllowUntyped2xxResponse = true

Will just return the default value.