### PR TITLE
Implement GenerateTopLevelArrayResponsesAsIAsyncEnumerables

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
@@ -177,8 +177,9 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile();
 
             // Assert
+            Assert.Contains("protected virtual async System.Collections.Generic.IAsyncEnumerable<T> StreamResponseAsync<T>(System.Net.Http.HttpResponseMessage response, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken)", code);
             Assert.Contains("public virtual async System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<object>> GetPeopleAsync", code);
-            Assert.Contains("var result_ = System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable<object>(responseStream_, JsonSerializerSettings, cancellationToken);", code);
+            Assert.Contains("var result_ = StreamResponseAsync<object>(response_, cancellationToken);", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NSwag.Generation.WebApi;
@@ -10,6 +11,14 @@ namespace NSwag.CodeGeneration.CSharp.Tests
         public class FooController : Controller
         {
             public object GetPerson(bool @override = false)
+            {
+                return null;
+            }
+        }
+
+        public class BarController : Controller
+        {
+            public IEnumerable<object> GetPeople(bool @override = false)
             {
                 return null;
             }
@@ -149,6 +158,27 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.Contains("public partial interface IFooClient : IClientBase", code);
+        }
+
+        [Fact]
+        public async Task When_GenerateResponseAsIAsyncEnumerable_is_set_then_IAsyncEnumerable_response_is_generated()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings());
+            var document = await swaggerGenerator.GenerateForControllerAsync<BarController>();
+
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateTopLevelArrayResponsesAsIAsyncEnumerables = true,
+            });
+            generator.Settings.CSharpGeneratorSettings.JsonLibrary = NJsonSchema.CodeGeneration.CSharp.CSharpJsonLibrary.SystemTextJson;
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("public virtual async System.Threading.Tasks.Task<System.Collections.Generic.IAsyncEnumerable<object>> GetPeopleAsync", code);
+            Assert.Contains("var result_ = System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable<object>(responseStream_, JsonSerializerSettings, cancellationToken);", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -32,6 +32,7 @@ namespace NSwag.CodeGeneration.CSharp
             ExposeJsonSerializerSettings = false;
             InjectHttpClient = true;
             ProtectedMethods = new string[0];
+            GenerateTopLevelArrayResponsesAsIAsyncEnumerables = false;
         }
 
         /// <summary>Gets or sets the full name of the base class.</summary>

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -112,5 +112,12 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether to expose the JsonSerializerSettings property (default: false).</summary>
         public bool ExposeJsonSerializerSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate top level array response types as IAsyncEnumerable instead of as <see cref="CSharpGeneratorBaseSettings.ResponseArrayType"/>.
+        /// IAsyncEnumerable will be deserialized in a streaming fashion.
+        /// If value is set to true, <see cref="NJsonSchema.CodeGeneration.CSharp.CSharpGeneratorSettings.JsonLibrary"/> must be set to <see cref="NJsonSchema.CodeGeneration.CSharp.CSharpJsonLibrary.SystemTextJson"/>.
+        /// </summary>
+        public bool GenerateTopLevelArrayResponsesAsIAsyncEnumerables { get; set; }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -116,6 +116,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets a value indicating whether to generate the response class (only applied when WrapResponses == true, default: true).</summary>
         public bool GenerateResponseClasses => _settings.GenerateResponseClasses;
 
+        /// <summary>Gets or sets a value indicating whether to generate top level array response types as IAsyncEnumerable instead of as <see cref="CSharpGeneratorBaseSettings.ResponseArrayType"/>.</summary>
+        public bool GenerateTopLevelArrayResponsesAsIAsyncEnumerables => (_settings as CSharpClientGeneratorSettings)?.GenerateTopLevelArrayResponsesAsIAsyncEnumerables == true;
+
         /// <summary>Gets the response class names.</summary>
         public IEnumerable<string> ResponseClassNames
         {

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpTemplateModelBase.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpTemplateModelBase.cs
@@ -37,6 +37,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether to use System.Text.Json</summary>
         public bool UseSystemTextJson => _settings.CSharpGeneratorSettings.JsonLibrary == CSharpJsonLibrary.SystemTextJson;
 
+        /// <summary>Gets or sets a value indicating whether to generate top level array response types as IAsyncEnumerable instead of as <see cref="CSharpGeneratorBaseSettings.ResponseArrayType"/>.</summary>
+        public bool GenerateTopLevelArrayResponsesAsIAsyncEnumerables => (_settings as CSharpClientGeneratorSettings)?.GenerateTopLevelArrayResponsesAsIAsyncEnumerables == true;
+
         /// <summary>Gets the JSON serializer settings type.</summary>
         public string JsonSerializerSettingsType => _settings.CSharpGeneratorSettings.JsonLibrary == CSharpJsonLibrary.SystemTextJson ? 
             "System.Text.Json.JsonSerializerOptions" :

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -10,9 +10,8 @@ var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(respons
 throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
 {%         endif -%}
 {%     elsif operation.GenerateResponseAsIAsyncEnumerable and response.IsSuccess -%}
-var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
-var result_ = System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable<{{operation.InnerIAsyncEnumerableType}}>(responseStream_, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings, cancellationToken);
-disposeResponse_ = false; // response is disposed by IAsyncEnumerable PROBABLY???
+var result_ = StreamResponseAsync<{{operation.InnerIAsyncEnumerableType}}>(response_, cancellationToken);
+disposeResponse_ = false; // response is disposed by StreamResponseAsync
 {%         if operation.WrapResponse -%}
 return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_);
 {%         else -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -9,6 +9,15 @@ return fileResponse_;
 var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_, cancellationToken).ConfigureAwait(false);
 throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
 {%         endif -%}
+{%     elsif operation.GenerateResponseAsIAsyncEnumerable and response.IsSuccess -%}
+var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
+var result_ = System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable<{{operation.InnerIAsyncEnumerableType}}>(responseStream_, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings, cancellationToken);
+disposeResponse_ = false; // response is disposed by IAsyncEnumerable PROBABLY???
+{%         if operation.WrapResponse -%}
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_);
+{%         else -%}
+return result_;
+{%         endif -%}
 {%     elsif response.IsPlainText -%}
 var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
 var result_ = ({{ response.Type }})System.Convert.ChangeType(responseData_, typeof({{ response.Type }}));

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -58,3 +58,26 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         }
     }
 }
+
+{%- if GenerateTopLevelArrayResponsesAsIAsyncEnumerables -%}
+protected virtual async System.Collections.Generic.IAsyncEnumerable<T> StreamResponseAsync<T>(System.Net.Http.HttpResponseMessage response, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken)
+{
+    try
+    {
+        using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+        {
+            var stream = System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable<T>(responseStream, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings, cancellationToken);
+            await foreach (var item in stream)
+            {
+                yield return item;
+            }
+        }
+    }
+    finally
+    {
+        response.Dispose();
+    }
+}
+{%- else -%}
+FIXME
+{%- endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ReadObjectResponse.liquid
@@ -78,6 +78,4 @@ protected virtual async System.Collections.Generic.IAsyncEnumerable<T> StreamRes
         response.Dispose();
     }
 }
-{%- else -%}
-FIXME
 {%- endif -%}

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -101,7 +101,7 @@ namespace NSwag.CodeGeneration.Models
         public abstract string ResultType { get; }
 
         /// <summary>Gets the type of the unwrapped result type (without Task).</summary>
-        public string UnwrappedResultType
+        public virtual string UnwrappedResultType
         {
             get
             {


### PR DESCRIPTION
With the recent update to .Net 6 that allows IAsyncEnumerable to be streamed from a controller without buffering, it would be nice to be able to consume the stream on the receiving side. Microsoft also recently added a nice way to produce an IAsyncEnumerable with JsonSerializer.DeserializeAsyncEnumerable.

Adds a new C# client generation option that enables any top level Array type to be converted to an IAsyncEnumerable. Note that inner arrays on objects, should still maintain their original array type.

This is a quick and dirty implementation, but I think it would be a really nice feature to have!