### PR TITLE
Discarding fragment from operation path, before query parameters are appended (#3812)

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
@@ -381,5 +381,40 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Assert.Contains("FooAsync(string bar,", code);
             Assert.Contains("EscapeDataString(\"foo\")", code);
         }
+
+        [Fact]
+        public void When_operation_path_contains_fragment_then_fragment_is_discarded()
+        {
+            // Arrange
+            var document = new OpenApiDocument();
+            document.Paths["foo#v=1"] = new OpenApiPathItem
+            {
+                {
+                    OpenApiOperationMethod.Get, new OpenApiOperation
+                    {
+                        Parameters =
+                        {
+                            new OpenApiParameter
+                            {
+                                Kind = OpenApiParameterKind.Query,
+                                Name = "foo",
+                                OriginalName = "bar",
+                                Schema = new JsonSchema
+                                {
+                                    Type = JsonObjectType.String
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("urlBuilder_.Append(\"foo?\")", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -138,7 +138,7 @@
 
 {%     endif -%}
         var urlBuilder_ = new System.Text.StringBuilder();
-        urlBuilder_.Append({% if UseBaseUrl %}BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/{% else %}"{% endif %}{{ operation.Path }}{% if operation.HasQueryParameters %}?{% endif %}");
+        urlBuilder_.Append({% if UseBaseUrl %}BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/{% else %}"{% endif %}{{ operation.Path.Split('#')[0] }}{% if operation.HasQueryParameters %}?{% endif %}");
 {%     for parameter in operation.PathParameters -%}
 {%         if parameter.IsOptional -%}
         if ({{ parameter.VariableName }} != null)


### PR DESCRIPTION
Fixes the bug where query parameters might be appended to a described operation path containing fragment information, resulting in any query parameters' values being stripped away along with the fragment, once the client sends a request to the server.