### PR TITLE
Used TryAddConsumes method to avoid duplicates in 'Consumes'

### DIFF
--- a/src/NSwag.Generation.WebApi/Processors/OperationConsumesProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationConsumesProcessor.cs
@@ -40,7 +40,9 @@ namespace NSwag.Generation.WebApi.Processors
             if (consumesAttribute != null && consumesAttribute.ContentTypes != null)
             {
                 foreach (var contentType in consumesAttribute.ContentTypes)
+                {
                     context.OperationDescription.Operation.TryAddConsumes(contentType);
+                }
             }
 
             return true;

--- a/src/NSwag.Generation.WebApi/Processors/OperationConsumesProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationConsumesProcessor.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="OperationConsumesProcessor.cs" company="NSwag">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
@@ -39,14 +39,8 @@ namespace NSwag.Generation.WebApi.Processors
 
             if (consumesAttribute != null && consumesAttribute.ContentTypes != null)
             {
-                if (context.OperationDescription.Operation.Consumes == null)
-                {
-                    context.OperationDescription.Operation.Consumes = new List<string>(consumesAttribute.ContentTypes);
-                }
-                else
-                {
-                    context.OperationDescription.Operation.Consumes.AddRange(consumesAttribute.ContentTypes);
-                }
+                foreach (var contentType in consumesAttribute.ContentTypes)
+                    context.OperationDescription.Operation.TryAddConsumes(contentType);
             }
 
             return true;


### PR DESCRIPTION
Previous implementation either re-created a list of 'content types or blindly appended a value from ConsumesAttribute attribute.
That blind adding caused content types duplication (in case if other preceding processes have already added a similar content type).
The fix uses a built-in TryAddConsumes method which makes sure that the content type is unique.