### PR TITLE
Update OpenApiServerVariable.cs

### DIFF
--- a/src/NSwag.Core/OpenApiServerVariable.cs
+++ b/src/NSwag.Core/OpenApiServerVariable.cs
@@ -17,7 +17,7 @@ namespace NSwag
     {
         /// <summary>Gets or sets the enum of the server.</summary>
         [JsonProperty(PropertyName = "enum", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public ICollection<string> Enum { get; } = new Collection<string>();
+        public ICollection<string> Enum { get; set; } = new Collection<string>();
 
         /// <summary>Gets or sets the variables of the server.</summary>
         [JsonProperty(PropertyName = "default", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]


### PR DESCRIPTION
This will allow to populate the Enum from an external source, when the external source list can be dynamic in length.

```c#
    private static OpenApiServerVariable GetOpenApiServerVariable()
    {
        var environmentList = InformationHelper.GetEnvironmentList();
        
        var valid = new OpenApiServerVariable
        {
            Default = InformationHelper.GetEnvironmentDefault(),
            Enum = { "dev", "uat", "stage", "api" }
        };
        
        var invalid = new OpenApiServerVariable
        {
            Default = InformationHelper.GetEnvironmentDefault(),
            Enum = environmentList
        };

        return valid;
    }
```