### PR TITLE
WIP: Array parameters in URL (#3529)

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -40,21 +40,51 @@ if ({{ parameter.VariableName }} === null)
 else if ({{ parameter.VariableName }} !== undefined)
 {%        endif -%}
 {%    endif -%}
-{%    if parameter.IsDateOrDateTimeArray -%}
-    {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item_ => { url_ += "{{ parameter.Name }}=" + encodeURIComponent(item_ ? "" + item_.{{ parameter.GetDateTimeToString }} : "null") + "&"; });
-{%    elsif parameter.IsObjectArray -%}
-    {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach((item, index) => {
-        for (let attr in item)
-			if (item.hasOwnProperty(attr)) {
-				url_ += "{{ parameter.Name }}[" + index + "]." + attr + "=" + encodeURIComponent("" + (item as any)[attr]) + "&";
-			}
-    });
-{%    elsif parameter.IsDateOrDateTime -%}
-    url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.{{ parameter.GetDateTimeToString }} : "{{ QueryNullValue }}") + "&";
-{%    elsif parameter.IsArray -%}
-    {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "&"; });
+{%    if parameter.IsArray -%}
+{%      if parameter.IsForm or parameter.IsSimple -%}
+    if ({{ parameter.VariableName }}.length)
+    {
+        url_ += "{{ parameter.Name }}=";
+        {{ parameter.VariableName }}.forEach(item => { url_ += encodeURIComponent("" + item) + ","; });
+        url_ = url_.replace(/,$/, "");
+    }
+{%      elsif parameter.IsLabel -%}
+    if ({{ parameter.VariableName }}.length)
+    {
+        url_ += "{{ parameter.Name }}=";
+        {{ parameter.VariableName }}.forEach(item => { url_ += "." encodeURIComponent("" + item); });
+    }
+{%      elsif parameter.IsMatrix -%}
+{
+    {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + ";"; });
+    url_ = url_.replace(/;$/, "");
+}
+{%      elsif parameter.IsSpaceDelimeted -%}
+{
+    {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + " "; });
+    url_ = url_.replace(/ $/, "");
+}
+{%      elsif parameter.IsPipeDelimited -%}
+{
+    {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "|"; });
+    url_ = url_.replace(/|$/, "");
+}
+{%      elsif parameter.IsDeepObject -%}
+{{ parameter.VariableName }}.forEach((item, index) => {
+    for (let attr in item)
+        if (item.hasOwnProperty(attr)) {
+            url_ += "{{ parameter.Name }}[" + index + "]." + attr + "=" + encodeURIComponent("" + (item as any)[attr]) + "&";
+        }
+});
+{%      else -%}
+{{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "&"; });
+{%      endif -%}
 {%    else -%}
+{%      if parameter.IsDateOrDateTime -%}
+    url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.{{ parameter.GetDateTimeToString }} : "{{ QueryNullValue }}") + "&";
+{%      else -%}
     url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + {{ parameter.VariableName }}) + "&";
+{%      endif -%}
 {%    endif -%}
 {% endfor -%}
 url_ = url_.replace(/[?&]$/, "");

--- a/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ParameterModelBase.cs
@@ -98,8 +98,23 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether the parameter is a deep object (OpenAPI 3).</summary>
         public bool IsDeepObject => _parameter.Style == OpenApiParameterStyle.DeepObject;
 
-        /// <summary>Gets a value indicating whether the parameter has form style.</summary>
+        /// <summary>Gets a value indicating whether the parameter has 'form' style.</summary>
         public bool IsForm => _parameter.Style == OpenApiParameterStyle.Form;
+
+        /// <summary>Gets a value indicating whether the parameter has 'simple' style.</summary>
+        public bool IsSimple => _parameter.Style == OpenApiParameterStyle.Simple;
+
+        /// <summary>Gets a value indicating whether the parameter has 'label' style.</summary>
+        public bool IsLabel => _parameter.Style == OpenApiParameterStyle.Label;
+
+        /// <summary>Gets a value indicating whether the parameter has 'matrix' style.</summary>
+        public bool IsMatrix => _parameter.Style == OpenApiParameterStyle.Matrix;
+
+        /// <summary>Gets a value indicating whether the parameter has 'spaceDelimited' style.</summary>
+        public bool IsSpaceDelimited => _parameter.Style == OpenApiParameterStyle.SpaceDelimeted;
+
+        /// <summary>Gets a value indicating whether the parameter has 'pipeDelimited' style.</summary>
+        public bool IsPipeDelimited => _parameter.Style == OpenApiParameterStyle.PipeDelimited;
 
         /// <summary>Gets the contained value property names (OpenAPI 3).</summary>
         public IEnumerable<PropertyModel> PropertyNames


### PR DESCRIPTION
Hi!

We faced with the issue described in #3529 when the TypeScript client ignores the `style` attribute of a parameter passed in URL. For example, we have a schema defining input argument like this: 

```
  "parameters": [
  {
    "name": "eventTypes",
    "in": "query",
    "style": "form",
    "explode": false,
    "schema": {
        "type": "array",
        "items": {
        "$ref": "#/components/schemas/EventTypes"
        },
        "nullable": true
    }
  },
  ...
```

and Swagger UI does build the URL as `xxx?eventTypes=EventA,EventB` which is exactly what we are expecting. But NSwag - both TypeScript and C# version - serializes parameters differently: `xxx?eventTypes=EventA&eventTypes=EventB` and so on.

I would like to contribute to the library and make necessary changes, and here is the first draft. It is not a completed work, for example, there should be additional checks for `IsDateOrDateTimeArray`. Additionally, I am going to make similar changes to C# generators and write tests. But before I spent too much time on this I wanted to get a confirmation of you that this is the right way to go.

With these changes, I was able to produce such code for my TypeScript client:
1. When `style=matrix`
```
    republishEvents(eventTypes: EventTypes[] | null | undefined): Promise<number> {
        let url_ = this.baseUrl + "/api/v1/data/republishevents?";
        if (eventTypes !== undefined && eventTypes !== null)
        {
            eventTypes.forEach(item => { url_ += "eventTypes=" + encodeURIComponent("" + item) + ";"; });
            url_ = url_.replace(/;$/, "");
        }
        url_ = url_.replace(/[?&]$/, "");

```
2. When `style=form`
```
    republishEvents(eventTypes: RepublishEventTypes[] | null | undefined): Promise<number> {
        let url_ = this.baseUrl + "/api/v1/data/republishevents?";
        if (eventTypes !== undefined && eventTypes !== null)
            if (eventTypes.length)
            {
                url_ += "eventTypes=";
                eventTypes.forEach(item => { url_ += encodeURIComponent("" + item) + ","; });
                url_ = url_.replace(/,$/, "");
            }
        url_ = url_.replace(/[?&]$/, "");
```
Maybe not the best JS code I ever saw, but it seems to do what we need.

Looking forward to hearing back from you, @RicoSuter!