### PR TITLE
Update NSwag.ApiDescription.Client.nuspec

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
@@ -15,8 +15,8 @@
     <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="6.0.3" />
-      <dependency id="NSwag.MSBuild" version="13.14.5" />
+      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="6.0.4" />
+      <dependency id="NSwag.MSBuild" version="13.15.10" />
     </dependencies>
     <references />
   </metadata>


### PR DESCRIPTION
To fix the issue mentioned https://github.com/RicoSuter/NSwag/issues/3987 . We want to use the latest tool chain version which has the supported bug fixes needed.