### PR TITLE
Rename Date to DateDto for TypeScript Clients (#3992)

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptTypeNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptTypeNameGenerator.cs
@@ -24,6 +24,11 @@ namespace NSwag.CodeGeneration.TypeScript
                 typeNameHint = "ErrorDto";
             }
 
+            if (typeNameHint == "Date")
+            {
+                typeNameHint = "DateDto";
+            }
+
             return base.Generate(schema, typeNameHint);
         }
     }


### PR DESCRIPTION
https://github.com/RicoSuter/NSwag/issues/3992

To fix a clash with the JavaScript 'Date' type if a property's name is 'Date'