### PR TITLE
Added check on SupportsTypeOnlyImports when TypeScript version is >= 4.3 and updated File.liquid template for TypeScript

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -164,6 +164,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether the target TypeScript version supports override keyword.</summary>
         public bool SupportsOverrideKeyword => _settings.TypeScriptGeneratorSettings.SupportsOverrideKeyword;
 
+        /// <summary>Gets a value indicating whether the target TypeScript version supports Type-Only imports</summary>
+        public bool SupportsTypeOnlyImports => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 4.3m;
+
         private string GenerateExtensionCodeAfter()
         {
             var clientClassesVariable = "{" + string.Join(", ", _clientTypes

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -165,7 +165,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         public bool SupportsOverrideKeyword => _settings.TypeScriptGeneratorSettings.SupportsOverrideKeyword;
 
         /// <summary>Gets a value indicating whether the target TypeScript version supports Type-Only imports</summary>
-        public bool SupportsTypeOnlyImports => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 4.3m;
+        public bool SupportsTypeOnlyImports => _settings.TypeScriptGeneratorSettings.TypeScriptVersion >= 3.8m;
 
         private string GenerateExtensionCodeAfter()
         {

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -42,8 +42,12 @@ import { HttpClient, RequestInit } from 'aurelia-fetch-client';
 import * as ng from 'angular';
 {%-        endif -%}
 {%-        if Framework.IsAxios -%}
-
+{%-         if SupportsTypeOnlyImports -%}
+import axios, { AxiosError } from 'axios';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
+{%-         else -%}
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
+{%-         endif -%}
 {%-        endif -%}
 {%-        if Framework.IsKnockout -%}
 


### PR DESCRIPTION
- The TypeScript compiler type checking produces an error for the import of the axios types
- Not possible to change the preserveValueImports or isolatedModules compiler options because they are needed by vite-vue
- also see Issue 3964 - type-only imports for axios (https://github.com/RicoSuter/NSwag/issues/3964)
- Changed axios imports to support import type when typescript version >= 4.3 by adding SupportsTypeOnlyImports in TypeScriptFileTemplateModel.cs
- It is supported as from TypeScript version 3.8 but only versions 2.7, 4.3, so picked 4.3 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)