### PR TITLE
Add ability to make all methods protected

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -91,7 +91,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
             {
                 var controllerName = _settings.GenerateControllerName(ControllerName);
                 var settings = _settings as CSharpClientGeneratorSettings;
-                if (settings != null && (settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToUpperCamelCase(OperationName, false) + "Async") == true || settings.ProtectedMethods?.Contains("all") == true))
+                if (settings != null && (settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToUpperCamelCase(OperationName, false) + "Async") == true || settings.ProtectedMethods?.Contains("*") == true))
                 {
                     return "protected";
                 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -91,7 +91,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
             {
                 var controllerName = _settings.GenerateControllerName(ControllerName);
                 var settings = _settings as CSharpClientGeneratorSettings;
-                if (settings != null && settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToUpperCamelCase(OperationName, false) + "Async") == true)
+                if (settings != null && (settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToUpperCamelCase(OperationName, false) + "Async") == true || settings.ProtectedMethods?.Contains("all") == true))
                 {
                     return "protected";
                 }

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -142,7 +142,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
             get
             {
                 var controllerName = _settings.GenerateControllerName(ControllerName);
-                if (_settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToLowerCamelCase(OperationName, false)) == true)
+                if (_settings.ProtectedMethods?.Contains(controllerName + "." + ConversionUtilities.ConvertToLowerCamelCase(OperationName, false)) == true || _settings.ProtectedMethods?.Contains("*") == true)
                 {
                     return "protected ";
                 }


### PR DESCRIPTION
Add ability to make all methods protected without specifying their name

Sometimes you don't know method names beforehands, so it becomes impossible to make them protected :(