### PR TITLE
Add ability to customize the type name for generated DTOs/models

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGenerator.cs
@@ -24,7 +24,7 @@ namespace NSwag.CodeGeneration.CSharp
         /// <param name="settings">The settings.</param>
         /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
         public CSharpClientGenerator(OpenApiDocument document, CSharpClientGeneratorSettings settings)
-            : this(document, settings, CreateResolverWithExceptionSchema(settings.CSharpGeneratorSettings, document))
+            : this(document, settings, CreateResolverWithExceptionSchema(settings, document))
         {
         }
 

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -15,6 +15,7 @@ namespace NSwag.CodeGeneration.CSharp
         public CSharpClientGeneratorSettings()
         {
             ClassName = "{controller}Client";
+            ModelClassName = "{model}";
 
             GenerateExceptionClasses = true;
             ExceptionClass = "ApiException";

--- a/src/NSwag.CodeGeneration.CSharp/CSharpControllerGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpControllerGenerator.cs
@@ -25,7 +25,7 @@ namespace NSwag.CodeGeneration.CSharp
         /// <param name="settings">The settings.</param>
         /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
         public CSharpControllerGenerator(OpenApiDocument document, CSharpControllerGeneratorSettings settings)
-            : this(document, settings, CreateResolverWithExceptionSchema(settings.CSharpGeneratorSettings, document))
+            : this(document, settings, CreateResolverWithExceptionSchema(settings, document))
         {
         }
 

--- a/src/NSwag.CodeGeneration.CSharp/CSharpControllerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpControllerGeneratorSettings.cs
@@ -19,6 +19,7 @@ namespace NSwag.CodeGeneration.CSharp
         public CSharpControllerGeneratorSettings()
         {
             ClassName = "{controller}";
+            ModelClassName = "{model}";
             CSharpGeneratorSettings.ArrayType = "System.Collections.Generic.List";
             CSharpGeneratorSettings.ArrayInstanceType = "System.Collections.Generic.List";
             ControllerStyle = CSharpControllerStyle.Partial;

--- a/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBase.cs
@@ -74,14 +74,14 @@ namespace NSwag.CodeGeneration.CSharp
         /// <summary>Creates a new resolver, adds the given schema definitions and registers an exception schema if available.</summary>
         /// <param name="settings">The settings.</param>
         /// <param name="document">The document </param>
-        public static CSharpTypeResolver CreateResolverWithExceptionSchema(CSharpGeneratorSettings settings, OpenApiDocument document)
+        public static CSharpTypeResolver CreateResolverWithExceptionSchema(CSharpGeneratorBaseSettings settings, OpenApiDocument document)
         {
             var exceptionSchema = document.Definitions.ContainsKey("Exception") ? document.Definitions["Exception"] : null;
 
-            var resolver = new CSharpTypeResolver(settings, exceptionSchema);
+            var resolver = new CSharpTypeResolver(settings.CSharpGeneratorSettings, exceptionSchema);
             resolver.RegisterSchemaDefinitions(document.Definitions
                 .Where(p => p.Value != exceptionSchema)
-                .ToDictionary(p => p.Key, p => p.Value));
+                .ToDictionary(p => settings.GenerateModelName(p.Key), p => p.Value));
 
             return resolver;
         }

--- a/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -35,6 +35,46 @@ namespace NSwag.CodeGeneration.Tests
         }
 
         [Fact]
+        public void When_generating_CSharp_code_then_output_contains_expected_classes_with_class_name_pre_and_postfix()
+        {
+            // Arrange
+            var document = CreateDocument();
+            
+            // Act
+            var settings = new CSharpClientGeneratorSettings
+                {ClassName = "MyClass", ModelClassName = "CustomPrefix{model}CustomPostfix"};
+            settings.CSharpGeneratorSettings.Namespace = "MyNamespace";
+            
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+            
+            // Assert
+            Assert.Contains("class MyClass", code);
+            Assert.Contains("class CustomPrefixPersonCustomPostfix", code);
+            Assert.Contains("class CustomPrefixAddressCustomPostfix", code);
+        }
+        
+        [Fact]
+        public void When_generating_CSharp_code_then_output_contains_expected_classes_skipping_model_class_name_if_missing_template()
+        {
+            // Arrange
+            var document = CreateDocument();
+            
+            // Act
+            var settings = new CSharpClientGeneratorSettings
+                {ClassName = "MyClass", ModelClassName = "CustomPrefix}model{CustomPostfix"};
+            settings.CSharpGeneratorSettings.Namespace = "MyNamespace";
+
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+            
+            // Assert
+            Assert.Contains("class MyClass", code);
+            Assert.Contains("class Person", code);
+            Assert.Contains("class Address", code);
+        }
+        
+        [Fact]
         public void When_generating_CSharp_code_with_SystemTextJson_then_output_contains_expected_code()
         {
             // Arrange

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -21,6 +21,7 @@ namespace NSwag.CodeGeneration.TypeScript
         public TypeScriptClientGeneratorSettings()
         {
             ClassName = "{controller}Client";
+            ModelClassName = "{model}";
             ExceptionClass = "ApiException";
             Template = TypeScriptTemplate.Fetch;
             PromiseType = PromiseType.Promise;

--- a/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
@@ -37,6 +37,9 @@ namespace NSwag.CodeGeneration
         /// <summary>Gets or sets the class name of the service client or controller.</summary>
         public string ClassName { get; set; }
 
+        /// <summary>Gets or sets the class name prefix for model classes.</summary>
+        public string ModelClassName { get; set; }
+        
         /// <summary>Gets or sets a value indicating whether to generate DTO classes (default: true).</summary>
         public bool GenerateDtoTypes { get; set; }
 
@@ -66,6 +69,14 @@ namespace NSwag.CodeGeneration
             return ClassName.Replace("{controller}", ConversionUtilities.ConvertToUpperCamelCase(controllerName, false));
         }
 
+        /// <summary>Generates the name of the model based on the provided settings.</summary>
+        /// <param name="modelName">Name of the model.</param>
+        /// <returns>The model name.</returns>
+        public string GenerateModelName(string modelName)
+        {
+            return !string.IsNullOrWhiteSpace(ModelClassName) && ModelClassName.Contains("{model}") ? ModelClassName.Replace("{model}", modelName): modelName;
+        }
+        
         /// <summary>Gets or sets a value indicating whether to wrap success responses to allow full response access.</summary>
         public bool WrapResponses { get; set; }
 

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -29,6 +29,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.ClassName = value; }
         }
 
+        [Argument(Name = "ModelClassName", IsRequired = false, Description = "The template to use for class names of the generated DTOs.")]
+        public string ModelClassName
+        {
+            get { return Settings.ModelClassName; }
+            set { Settings.ModelClassName = value; }
+        }
+        
         [Argument(Name = "OperationGenerationMode", IsRequired = false, Description = "The operation generation mode ('SingleClientFromOperationId' or 'MultipleClientsFromPathSegments').")]
         public OperationGenerationMode OperationGenerationMode
         {

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -38,6 +38,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.ClassName = value; }
         }
 
+        [Argument(Name = "ModelClassName", IsRequired = false, Description = "The template to use for class names of the generated DTOs.")]
+        public string ModelClassName
+        {
+            get { return Settings.ModelClassName; }
+            set { Settings.ModelClassName = value; }
+        }
+        
         [Argument(Name = "ModuleName", IsRequired = false, Description = "The TypeScript module name (default: '', no module).")]
         public string ModuleName
         {

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -98,6 +98,9 @@
                                 <TextBlock Text="Class Name" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox Text="{Binding Command.ClassName, Mode=TwoWay}" ToolTip="ClassName" Margin="0,0,0,12" />
 
+                                <TextBlock Text="Model class name template" FontWeight="Bold" Margin="0,0,0,6" />
+                                <TextBox Text="{Binding Command.ModelClassName, Mode=TwoWay}" ToolTip="ModelClassName" Margin="0,0,0,12" />
+                                
                                 <TextBlock Text="Client class access modifier" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox Text="{Binding Command.ClientClassAccessModifier, Mode=TwoWay}" 
                                          ToolTip="ClientClassAccessModifier" Margin="0,0,0,12" />

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpControllerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpControllerGeneratorView.xaml
@@ -106,6 +106,9 @@
                                     <TextBlock Text="Controller Base Class Name (optional, use 'Microsoft.AspNetCore.Mvc.Controller' for ASP.NET Core)" FontWeight="Bold" Margin="0,0,0,6" />
                                     <TextBox Text="{Binding Command.ControllerBaseClass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,12" />
 
+                                    <TextBlock Text="Model class name template" FontWeight="Bold" Margin="0,0,0,6" />
+                                    <TextBox Text="{Binding Command.ModelClassName, Mode=TwoWay}" ToolTip="ModelClassName" Margin="0,0,0,12" />
+                                    
                                     <TextBlock Margin="0,0,0,6" TextWrapping="Wrap">
                                     <Run Text="Operation Generation Mode" FontWeight="Bold" />
                                     <LineBreak />

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToTypeScriptClientGeneratorView.xaml
@@ -135,6 +135,9 @@
 
                                 <TextBlock Text="Class Name" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox Text="{Binding Command.ClassName, Mode=TwoWay}" ToolTip="ClassName" Margin="0,0,0,12" />
+                                
+                                <TextBlock Text="Model class name template" FontWeight="Bold" Margin="0,0,0,6" />
+                                <TextBox Text="{Binding Command.ModelClassName, Mode=TwoWay}" ToolTip="ModelClassName" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Base Class Name (optional, must be imported or implemented in the extension code)"
                                            FontWeight="Bold" Margin="0,0,0,6" />


### PR DESCRIPTION
Models/Dto class names were picked from the spec provided when generating the code. This PR adds the ability yo customize the name of models with a template string, e.g. "My{model}IsNicer".

The main reason for me for adding this is for convinience when searching for types in an IDE where there also exist other model classes with similar names it is nicer to be able to add a prefix to the generated classes so that they don't show as the initial suggestions.

This could already be acomplished by setting the `TypeNameGenerator` property on the settings. However, that is a bit more complicated and not as accessible as having this property.

Note that if the template string does not contain "{model}" it will be ignored. That way the generated code doesn't become too messed up if someone just specified an explicit name (which all models would then be called, which is likely not what the user wants).