### PR TITLE
Fix Wrong Method Name generation with invalid characters

### DIFF
--- a/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
 using NSwag.CodeGeneration.Models;
@@ -159,6 +160,9 @@ namespace NSwag.CodeGeneration
                     var operation = p.Value;
 
                     var operationName = BaseSettings.OperationNameGenerator.GetOperationName(document, path, httpMethod, operation);
+
+                    // Strip any character that is not a word character or a period
+                    operationName = Regex.Replace(operationName, @"[^\w\.]", "", RegexOptions.None);
 
                     if (operationName.Contains("."))
                     {


### PR DESCRIPTION
when there is a route with parameters inside like this:

GET /api/details/data/{code}

the client is generated with wrong signatures:

System.Threading.Tasks.Task<Utente> Conto{code}Async(string code);
System.Threading.Tasks.Task<Utente> Conto{code}Async(string code, System.Threading.CancellationToken cancellationToken);

This fix will remove any invalid character from  the signature