### PR TITLE
Elaborate when no assemblies are loaded from AssemblyPaths

### DIFF
--- a/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/Generation/OpenApiGeneratorCommandBase.cs
@@ -309,7 +309,7 @@ namespace NSwag.Commands.Generation
             else
             {
                 var assemblies = LoadAssemblies(AssemblyPaths, assemblyLoader);
-                var firstAssembly = assemblies.FirstOrDefault() ?? throw new InvalidOperationException("No assembly are be loaded from AssemblyPaths.");
+                var firstAssembly = assemblies.FirstOrDefault() ?? throw new InvalidOperationException("No assemblies loaded from AssemblyPaths:" + string.Join(",", AssemblyPaths));
                 return ServiceProviderResolver.GetServiceProvider(firstAssembly);
             }
         }


### PR DESCRIPTION
While the current error message is unique:

```
System.InvalidOperationException: No assembly are be loaded from AssemblyPaths.
```

It doesn't give much to go on when troubleshooting.