### PR TITLE
Support object parameters in query

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -53,6 +53,10 @@ else if ({{ parameter.VariableName }} !== undefined)
     url_ += "{{ parameter.Name }}=" + encodeURIComponent({{ parameter.VariableName }} ? "" + {{ parameter.VariableName }}.{{ parameter.GetDateTimeToString }} : "{{ QueryNullValue }}") + "&";
 {%    elsif parameter.IsArray -%}
     {{ parameter.VariableName }} && {{ parameter.VariableName }}.forEach(item => { url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + item) + "&"; });
+{%    elsif parameter.IsObject -%}
+    for (const [key, value] of Object.entries({{ parameter.Name }})) {
+        url_ += encodeURIComponent("" + key) + "=" + encodeURIComponent("" + value) + "&";
+    }
 {%    else -%}
     url_ += "{{ parameter.Name }}=" + encodeURIComponent("" + {{ parameter.VariableName }}) + "&";
 {%    endif -%}


### PR DESCRIPTION
Given a controller action with `Dictionary<string, string>` parameter NSwag generates a proper schema with `type: "object"`:

Sample controller:

```cs
[ApiController]
public class SampleController : ControllerBase
{
    [HttpGet]
    [Route("sample")]
    public string GetSample([FromQuery] Dictionary<string, string> extra) => string.Empty;
}
```

Generated schema for `extra` parameter:

```json
{
  "name": "extra",
  "in": "query",
  "schema": {
    "type": "object",
    "nullable": true,
    "additionalProperties": {
      "type": "string"
    }
  }
}
```

Both ASP.NET Core and Swagger UI handle such parameters just fine.

Given http://localhost/sample?a=hello&b=world
`extra` is deserialized as `{ ["a"] = "hello", ["b"] = "world" }`


However, TypeScript client incorrectly encodes `extra` as `[object Object]` or similar:

```ts
getSample(extra?: { [key: string]: string; } | null | undefined) {
   // ...
   if (extra !== undefined && extra !== null)
      url_ += "extra=" + encodeURIComponent("" + extra) + "&";
   // ...
}
```

This PR makes it encode each key/value pair instead:

```ts
getSample(extra?: { [key: string]: string; } | null | undefined) {
    // ...
    if (extra !== undefined && extra !== null)
        for (const [key, value] of Object.entries(extra)) {
            url_ += encodeURIComponent("" + key) + "=" + encodeURIComponent("" + value) + "&";
        }
   // ...
}
```