### PR TITLE
Support filename downloads with special characters

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -6,8 +6,14 @@ const contentDisposition = response.headers ? response.headers["content-disposit
 {%     else -%}
 const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
 {%     endif -%}
-const fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
-const fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+let fileNameMatch = contentDisposition ? /filename\*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+if (fileName) {
+	fileName = decodeURIComponent(fileName);
+} else {
+	fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+	fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+}
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}
 return {{ Framework.RxJs.ObservableOfMethod }}(new {{ operation.ResponseClass }}(status, _headers, { fileName: fileName, data: {% if Framework.Angular.UseHttpClient %}responseBlob as any{% else %}response.blob() as any{% endif %}, status: status, headers: _headers }));

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.HandleStatusCode.liquid
@@ -9,10 +9,10 @@ const contentDisposition = response.headers ? response.headers.get("content-disp
 let fileNameMatch = contentDisposition ? /filename\*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
 let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
 if (fileName) {
-	fileName = decodeURIComponent(fileName);
+    fileName = decodeURIComponent(fileName);
 } else {
-	fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
-	fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+    fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+    fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
 }
 {%     if operation.WrapResponse -%}
 {%         if Framework.IsAngular -%}


### PR DESCRIPTION
**FileResponse enhancments**
This commit fixes an issue with the fileResponse when the fileName contains special characters (such as Umlaute).


To support special characters in a filename in asp.net, one can use the ContentDisposition.FileNameStar property (instead of FileName). Example in the C# code below: 

```
            var response = new HttpResponseMessage(HttpStatusCode.OK);
            byte[] contents = GetFileResponse(out string filename);
            response.Content = new ByteArrayContent(contents);
            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment");

            // fileresponse without support for special characters (e.g.: Umlaute) 
            // response.Content.Headers.ContentDisposition.FileName = filename; // filename="=?utf-8?B?w6TDpMOkMjAyMjAxMDZfMTc0ODUzLkNTVg==?="  (incorrect with special characters)

            // or with support for special characters (e.g. Umlaute)
            response.Content.Headers.ContentDisposition.FileNameStar = filename; // filename*=utf-8''%C3%A4%C3%A4%C3%A420220106_174853.CSV

            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");      
```

Regarding the regex, please have a look at: 

[](https://stackoverflow.com/questions/23054475/javascript-regex-for-extracting-filename-from-content-disposition-header)
(regex used from a comment of the accepted answer since the accepted answer did have some issues. Tested quite well)



Remark: this PR is related to pull request 3867 which in its first version did not support the case when the server sent a filename with special characters but also a filename without it. This version first uses the filename with special characters and the one without as fallback (same behavior as Mozilla Firefox).  See also the discussion in https://github.com/RicoSuter/NSwag/pull/3867