### PR TITLE
Add support for System.Web.Mvc.AcceptVerbsAttribute to WebApiOpenApiDocumentGenerator

### DIFF
--- a/src/NSwag.Generation.WebApi.Tests/RouteTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/RouteTests.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSwag.Annotations;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSwag.Annotations;
+using AcceptVerbsMvc = System.Web.Mvc.AcceptVerbsAttribute;
+using HttpVerbsMvc = System.Web.Mvc.HttpVerbs;
+using RouteMvcAttribute = System.Web.Mvc.RouteAttribute;
 
 namespace NSwag.Generation.WebApi.Tests
 {
@@ -86,6 +89,65 @@ namespace NSwag.Generation.WebApi.Tests
             }
         }
 
+        public class ProductsMvcController : ApiController
+        {
+            [SwaggerOperation("GetProducts")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Get), RouteMvc("products")]
+            public Task<IHttpActionResult> GetProducts([FromUri] ProductPagedResult payload)
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+
+            [SwaggerOperation("GetProductByUserDefinedId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Get), RouteMvc("products/{userDefinedId}")]
+            public IHttpActionResult GetProduct(string userDefinedId)
+            {
+                return null;
+            }
+
+            [SwaggerOperation("GetProductByUniqueId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Get), RouteMvc("products/{id:guid}")]
+            public IHttpActionResult GetProductByUniqueId(Guid id)
+            {
+                return null;
+            }
+
+            [SwaggerOperation("DeleteProductByUserDefinedId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Delete), RouteMvc("products/{userDefinedId}")]
+            public Task<IHttpActionResult> Delete(string userDefinedId)
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+
+            [SwaggerOperation("DeleteProductByUniqueId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Delete), RouteMvc("products/{id:guid}")]
+            public Task<IHttpActionResult> DeleteByUniqueId()
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+
+            [SwaggerOperation("PutProductByUserDefinedId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Put), RouteMvc("products/{userDefinedId}")]
+            public Task<IHttpActionResult> Put(string userDefinedId, [FromBody] Product data)
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+
+            [SwaggerOperation("PutProductByUniqueId")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Put), RouteMvc("products/{id:guid}")]
+            public Task<IHttpActionResult> Put(Guid id, [FromBody] Product data)
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+
+            [SwaggerOperation("PostProducts")]
+            [AcceptVerbsMvc(HttpVerbsMvc.Post), RouteMvc("products")]
+            public Task<IHttpActionResult> FetchAll([FromBody] AddProductPayload data)
+            {
+                return Task.FromResult<IHttpActionResult>(null);
+            }
+        }
+
         [TestMethod]
         public async Task When_swagger_spec_is_generated_then_no_route_problem_is_detected()
         {
@@ -99,6 +161,25 @@ namespace NSwag.Generation.WebApi.Tests
             // Act
             var generator = new WebApiOpenApiDocumentGenerator(settings);
             var document = await generator.GenerateForControllerAsync<ProductsController>();
+            var swaggerSpecification = document.ToJson();
+
+            // Assert
+            Assert.IsNotNull(swaggerSpecification);
+        }
+
+        [TestMethod]
+        public async Task When_swagger_spec_is_generated_for_Mvc_then_no_route_problem_is_detected()
+        {
+            // Arrange
+            var settings = new WebApiOpenApiDocumentGeneratorSettings
+            {
+                DefaultUrlTemplate = "{controller}/{id}",
+                AddMissingPathParameters = false,
+            };
+
+            // Act
+            var generator = new WebApiOpenApiDocumentGenerator(settings);
+            var document = await generator.GenerateForControllerAsync<ProductsMvcController>();
             var swaggerSpecification = document.ToJson();
 
             // Assert

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -594,9 +594,18 @@ namespace NSwag.Generation.WebApi
 
             if (acceptVerbsAttribute != null)
             {
-                var httpMethods = acceptVerbsAttribute.HttpMethods is ICollection
-                    ? ((ICollection)acceptVerbsAttribute.HttpMethods).OfType<object>().Select(v => v.ToString().ToLowerInvariant())
-                    : ((IEnumerable<string>)acceptVerbsAttribute.HttpMethods).Select(v => v.ToLowerInvariant());
+                IEnumerable<string> httpMethods = new List<string>();
+
+                if (ObjectExtensions.HasProperty(acceptVerbsAttribute, "HttpMethods"))
+                {
+                    httpMethods = acceptVerbsAttribute.HttpMethods is ICollection
+                        ? ((ICollection)acceptVerbsAttribute.HttpMethods).OfType<object>().Select(v => v.ToString().ToLowerInvariant())
+                        : ((IEnumerable<string>)acceptVerbsAttribute.HttpMethods).Select(v => v.ToLowerInvariant());
+                }
+                else if (ObjectExtensions.HasProperty(acceptVerbsAttribute, "Verbs"))
+                {
+                    httpMethods = ((IEnumerable<string>)acceptVerbsAttribute.Verbs).Select(v => v.ToLowerInvariant());
+                }
 
                 foreach (var verb in httpMethods)
                 {


### PR DESCRIPTION
I noticed System.Web.Mvc.AcceptVerbsAttribute leads to an exception in WebApiOpenApiDocumentGenerator when determining HttpMethods. In case NSwag wants to support this, I would like to suggest this change. Please let me know if there are any improvements I can make or whether this is something you would not like to pursue.

Adds support for System.Web.Mvc.AcceptVerbsAttribute to WebApiOpenApiDocumentGenerator

#4103 
WebApiOpenApiDocumentGenerator throws when encountering AcceptVerbsAttribute on projects using System.Web.Mvc.

`httpMethods = acceptVerbsAttribute.HttpMethods is ICollection
`
System.Web.Mvc uses [AcceptVerbsAttribute.Verbs](https://docs.microsoft.com/en-us/dotnet/api/system.web.mvc.acceptverbsattribute?view=aspnet-mvc-5.2)-property instead of [AcceptVerbsAttribute.HttpMethods](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.acceptverbsattribute.httpmethods?view=aspnetcore-7.0)-property used by ASP.NET Core.