### PR TITLE
Allow both the summary and description from OpenAPI to be added as summary and remarks in c# generated code

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Method.Documentation.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Method.Documentation.liquid
@@ -3,6 +3,11 @@
 /// {{ operation.Summary | csharpdocs }}
 /// </summary>
 {% endif -%}
+{% if operation.HasDescription -%}
+/// <remarks>
+/// {{ operation.Description | csharpdocs }}
+/// </remarks>
+{% endif -%}
 {% for parameter in operation.Parameters -%}
 {%     if parameter.HasDescription -%}
 /// <param name="{{ parameter.VariableIdentifier }}">{{ parameter.Description | csharpdocs }}</param>

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -8,6 +8,11 @@ public interface I{{ Class }}Controller
     /// {{ operation.Summary | csharpdocs }}
     /// </summary>
 {%-         endif %}
+{%          if operation.HasDescription -%}
+    /// <remarks>
+    /// {{ operation.Description | csharpdocs }}
+    /// </remarks>
+{%          endif -%}
 {%-         for parameter in operation.Parameters %}
 {%-             if parameter.HasDescription %}
     /// <param name="{{ parameter.VariableName }}">{{ parameter.Description | csharpdocs }}</param>
@@ -49,6 +54,11 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
     /// <summary>
     /// {{ operation.Summary | csharpdocs }}
     /// </summary>
+{%         endif -%}
+{%         if operation.HasDescription -%}
+    /// <remarks>
+    /// {{ operation.Description | csharpdocs }}
+    /// </remarks>
 {%         endif -%}
 {%         for parameter in operation.Parameters -%}
 {%             if parameter.HasDescription -%}
@@ -101,6 +111,11 @@ public abstract class {{ Class }}ControllerBase : {% if HasBaseClass %}{{ BaseCl
     /// <summary>
     /// {{ operation.Summary | csharpdocs }}
     /// </summary>
+{%         endif -%}
+{%         if operation.HasDescription -%}
+    /// <remarks>
+    /// {{ operation.Description | csharpdocs }}
+    /// </remarks>
 {%         endif -%}
 {%         for parameter in operation.Parameters -%}
 {%             if parameter.HasDescription -%}

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -224,6 +224,12 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets the summary text.</summary>
         public string Summary => ConversionUtilities.TrimWhiteSpaces(_operation.Summary);
 
+        /// <summary>Gets a value indicating whether the operation has description.</summary>
+        public bool HasDescription => !string.IsNullOrEmpty(Description);
+
+        /// <summary>Gets the remarks text.</summary>
+        public string Description => ConversionUtilities.TrimWhiteSpaces(_operation.Description);
+
         /// <summary>Gets a value indicating whether the operation has any documentation.</summary>
         public bool HasDocumentation => HasSummary || HasResultDescription || Parameters.Any(p => p.HasDescription) || _operation.IsDeprecated;
 

--- a/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
+++ b/src/NSwag.Generation.Tests/Processors/OperationSummaryAndDescriptionProcessorTests.cs
@@ -12,19 +12,22 @@ namespace NSwag.Generation.Tests.Processors
     {
         public class DocumentedController
         {
-            [OpenApiOperation("\r\n\t This method is documented. \r\n\t", "")]
+            [OpenApiOperation("\r\n\t This method has a summary. \r\n\t", "\r\n\t This method has a description. \r\n\t")]
             public void DocumentedMethodWithOpenApiOperationAttribute()
             {
             }
             
-            [Description("\r\n\t This method is documented. \r\n\t")]
+            [Description("\r\n\t This method has a description. \r\n\t")]
             public void DocumentedMethodWithDescriptionAttribute()
             {
             }
 
             /// <summary>
-            ///     This method is documented.
+            ///     This method has a summary.
             /// </summary>
+            /// <remarks>
+            ///     This method has a description.
+            /// </remarks>
             public void DocumentedMethodWithSummary()
             {
             }
@@ -45,7 +48,10 @@ namespace NSwag.Generation.Tests.Processors
 
             //// Assert
             var summary = context.OperationDescription.Operation.Summary;
-            Assert.Equal("This method is documented.", summary);
+            Assert.Equal("This method has a summary.", summary);
+
+            var description = context.OperationDescription.Operation.Description;
+            Assert.Equal("This method has a description.", description);
         }
         
         [Fact]
@@ -63,7 +69,10 @@ namespace NSwag.Generation.Tests.Processors
 
             //// Assert
             var summary = context.OperationDescription.Operation.Summary;
-            Assert.Equal("This method is documented.", summary);
+            Assert.Equal("This method has a description.", summary);
+
+            var description = context.OperationDescription.Operation.Description;
+            Assert.Null(description);
         }
         
         [Fact]
@@ -81,7 +90,10 @@ namespace NSwag.Generation.Tests.Processors
 
             //// Assert
             var summary = context.OperationDescription.Operation.Summary;
-            Assert.Equal("This method is documented.", summary);
+            Assert.Equal("This method has a summary.", summary);
+
+            var description = context.OperationDescription.Operation.Description;
+            Assert.Equal("This method has a description.", description);
         }
         
         private OperationProcessorContext GetContext(Type controllerType, MethodInfo methodInfo)

--- a/src/NSwag.Generation/Processors/OperationSummaryAndDescriptionProcessor.cs
+++ b/src/NSwag.Generation/Processors/OperationSummaryAndDescriptionProcessor.cs
@@ -71,7 +71,7 @@ namespace NSwag.Generation.Processors
 
             if (!string.IsNullOrEmpty(description))
             {
-                context.OperationDescription.Operation.Description = description;
+                context.OperationDescription.Operation.Description = description.Trim();
             }
         }
     }


### PR DESCRIPTION
The following changes will add the `description` property from an OpenAPI operation under the `<remarks>` xml comment in c# client code. Unit tests were updated to check for the annotations. My OpenAPI specs are typically quite detailed in the summary and description and and I wanted to add that documentation to the generated controllers and clients.