### PR TITLE
WebApiOpenApiDocumentGenerator: Support multiple Route-attributes on Controller level

### DIFF
--- a/src/NSwag.Generation.WebApi.Tests/Attributes/RouteTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/Attributes/RouteTests.cs
@@ -27,8 +27,8 @@ namespace NSwag.Generation.WebApi.Tests.Attributes
             }
         }
 
-        [System.Web.Http.Route("api1/{regionId:int}/food")]
-        [System.Web.Http.Route("api2/{regionId:int}/food")]
+        [System.Web.Http.Route("api/{regionId:int}/beverages")]
+        [System.Web.Http.Route("api/{regionId:int}/fluids")]
         public class BeveragesController : RegionalItemController
         {
             [System.Web.Http.HttpGet]
@@ -66,8 +66,8 @@ namespace NSwag.Generation.WebApi.Tests.Attributes
 
             // Assert
             var operations = document.Operations.ToArray();
-            Assert.IsTrue(operations[0].Path.Contains("api1"));
-            Assert.IsTrue(operations[1].Path.Contains("api2"));
+            Assert.IsTrue(operations[0].Path.Contains("beverages"));
+            Assert.IsTrue(operations[1].Path.Contains("fluids"));
             Assert.AreEqual("regionId", operations[0].Operation.Parameters.First().Name);
             Assert.AreEqual("regionId", operations[1].Operation.Parameters.First().Name);
         }

--- a/src/NSwag.Generation.WebApi.Tests/Attributes/RouteTests.cs
+++ b/src/NSwag.Generation.WebApi.Tests/Attributes/RouteTests.cs
@@ -27,6 +27,17 @@ namespace NSwag.Generation.WebApi.Tests.Attributes
             }
         }
 
+        [System.Web.Http.Route("api1/{regionId:int}/food")]
+        [System.Web.Http.Route("api2/{regionId:int}/food")]
+        public class BeveragesController : RegionalItemController
+        {
+            [System.Web.Http.HttpGet]
+            public string[] Get(int regionId)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         [TestMethod]
         public async Task When_route_contains_path_parameter_and_action_method_proper_parameter_then_it_is_generated_as_parameter()
         {
@@ -41,6 +52,24 @@ namespace NSwag.Generation.WebApi.Tests.Attributes
             var operation = document.Operations.First();
             Assert.IsTrue(operation.Path.Contains("{regionId}"));
             Assert.AreEqual("regionId", operation.Operation.Parameters.First().Name);
+        }
+
+        [TestMethod]
+        public async Task When_controller_contains_multiple_route_attributes_then_multiple_paths_generated()
+        {
+            // Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings { IsAspNetCore = true });
+
+            // Act
+            var document = await generator.GenerateForControllerAsync<BeveragesController>();
+            var json = document.ToJson();
+
+            // Assert
+            var operations = document.Operations.ToArray();
+            Assert.IsTrue(operations[0].Path.Contains("api1"));
+            Assert.IsTrue(operations[1].Path.Contains("api2"));
+            Assert.AreEqual("regionId", operations[0].Operation.Parameters.First().Name);
+            Assert.AreEqual("regionId", operations[1].Operation.Parameters.First().Name);
         }
     }
 }

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -454,7 +454,7 @@ namespace NSwag.Generation.WebApi
                 var attributes = type.GetTypeInfo().GetCustomAttributes(false).Cast<Attribute>();
 
                 var routeAttributes = GetRouteAttributes(attributes);
-                if (routeAttributes != null)
+                if (routeAttributes != null && routeAttributes.Any())
                 {
                     return routeAttributes;
                 }

--- a/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.WebApi/WebApiOpenApiDocumentGenerator.cs
@@ -343,7 +343,7 @@ namespace NSwag.Generation.WebApi
             var routeAttributes = GetRouteAttributes(method.GetCustomAttributes()).ToList();
 
             // .NET Core: RouteAttribute on class level
-            var routeAttributeOnClass = GetRouteAttribute(controllerType);
+            var routeAttributesOnClass = GetAllRouteAttributes(controllerType);
             var routePrefixAttribute = GetRoutePrefixAttribute(controllerType);
 
             if (routeAttributes.Any())
@@ -358,7 +358,7 @@ namespace NSwag.Generation.WebApi
                     {
                         httpPaths.Add(routePrefixAttribute.Prefix + "/" + attribute.Template);
                     }
-                    else if (routeAttributeOnClass != null)
+                    else if (routeAttributesOnClass != null)
                     {
                         if (attribute.Template.StartsWith("/"))
                         {
@@ -366,7 +366,10 @@ namespace NSwag.Generation.WebApi
                         }
                         else
                         {
-                            httpPaths.Add(routeAttributeOnClass.Template + "/" + attribute.Template);
+                            foreach (var routeAttributeOnClass in routeAttributesOnClass)
+                            {
+                                httpPaths.Add(routeAttributeOnClass.Template + "/" + attribute.Template);
+                            }
                         }
                     }
                     else
@@ -375,17 +378,23 @@ namespace NSwag.Generation.WebApi
                     }
                 }
             }
-            else if (routePrefixAttribute != null && routeAttributeOnClass != null)
+            else if (routePrefixAttribute != null && routeAttributesOnClass != null)
             {
-                httpPaths.Add(routePrefixAttribute.Prefix + "/" + routeAttributeOnClass.Template);
+                foreach (var routeAttributeOnClass in routeAttributesOnClass)
+                {
+                    httpPaths.Add(routePrefixAttribute.Prefix + "/" + routeAttributeOnClass.Template);
+                }
             }
             else if (routePrefixAttribute != null)
             {
                 httpPaths.Add(routePrefixAttribute.Prefix);
             }
-            else if (routeAttributeOnClass != null)
+            else if (routeAttributesOnClass != null)
             {
-                httpPaths.Add(routeAttributeOnClass.Template);
+                foreach (var routeAttributeOnClass in routeAttributesOnClass)
+                {
+                    httpPaths.Add(routeAttributeOnClass.Template);
+                }
             }
             else
             {
@@ -438,16 +447,16 @@ namespace NSwag.Generation.WebApi
             yield return path;
         }
 
-        private RouteAttributeFacade GetRouteAttribute(Type type)
+        private IEnumerable<RouteAttributeFacade> GetAllRouteAttributes(Type type)
         {
             do
             {
                 var attributes = type.GetTypeInfo().GetCustomAttributes(false).Cast<Attribute>();
 
-                var attribute = GetRouteAttributes(attributes).SingleOrDefault();
-                if (attribute != null)
+                var routeAttributes = GetRouteAttributes(attributes);
+                if (routeAttributes != null)
                 {
-                    return attribute;
+                    return routeAttributes;
                 }
 
                 type = type.GetTypeInfo().BaseType;


### PR DESCRIPTION
This PR adds support for multiple Route-attributes on controller-level. For example, an API could respond both as api/beverages and api/fluids.

```
        [System.Web.Http.Route("api/{regionId:int}/beverages")]
        [System.Web.Http.Route("api/{regionId:int}/fluids")]
        public class BeveragesController : RegionalItemController
        {
            [System.Web.Http.HttpGet]
            public string[] Get(int regionId)
            {
                throw new NotImplementedException();
            }
        }
```

**Observed behavior:** WebApiOpenApiDocumentGenerator threw an exception, as it only allowed one Route-attribute on controller level

**Expected behavior:** Two paths get created.

Issue addressed partly: [1354 NSwag.MSBuild does not support API versioning or multiple routes](https://github.com/RicoSuter/NSwag/issues/1354) 