### PR TITLE
OpenApiDocument return sorted dictionary

### DIFF
--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,9 +83,15 @@ namespace NSwag
         [JsonProperty(PropertyName = "servers", Order = 10, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public ICollection<OpenApiServer> Servers { get; private set; } = new Collection<OpenApiServer>();
 
-        /// <summary>Gets or sets the operations.</summary>
-        [JsonProperty(PropertyName = "paths", Order = 11, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        /// <summary>Gets the operations.</summary>
+        [JsonIgnore]
         public IDictionary<string, OpenApiPathItem> Paths => _paths;
+
+        /// <summary>
+        /// This property is used to output the paths sorted by key
+        /// </summary>
+        [JsonProperty(PropertyName = "paths", Order = 11, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        internal IDictionary<string, OpenApiPathItem> SortedPaths => new SortedDictionary<string, OpenApiPathItem>(_paths);
 
         /// <summary>Gets or sets the components.</summary>
         [JsonProperty(PropertyName = "components", Order = 12, DefaultValueHandling = DefaultValueHandling.Ignore)]


### PR DESCRIPTION

When generating `swagger.json` files paths are randomly returned,  Which makes difficult to compare from one version to another.

I think this simple change solves this and help to generate a constant output.

`OpenApiDocument.cs`
```
   [JsonProperty(PropertyName = "paths", Order = 11, DefaultValueHandling = DefaultValueHandling.Ignore)]
   public IDictionary<string, OpenApiPathItem> Paths => new SortedDictionary<string, OpenApiPathItem>(_paths);

```

I am working on a code migration project and we need to generate data contract that closely matches from one system (version) to another.

