### PR TITLE
Client code generation in Console app fails with NullReferenceException

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -269,7 +269,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
                 }
             }
 
-            if (schema.Type == JsonObjectType.Array && schema.Item.IsBinary)
+            if (schema.Type == JsonObjectType.Array && (schema.Item?.IsBinary ?? false))
             {
                 return "System.Collections.Generic.IEnumerable<FileParameter>";
             }


### PR DESCRIPTION
This affected the C# console app.
Issue: https://github.com/RicoSuter/NSwag/issues/2530