### PR TITLE
add new MultipleClientsFromFirstTagAndOperationNameGenerator

### DIFF
--- a/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NJsonSchema;
@@ -224,6 +226,56 @@ public static Person FromJson(string data)
             Assert.DoesNotContain("{", operationName);
             Assert.DoesNotContain("}", operationName);
             Assert.False(string.IsNullOrWhiteSpace(operationName));
+        }
+
+        [Theory(DisplayName = "Ensure expected client name generation when using MultipleClientsFromFirstTagAndOperationName behavior")]
+        [InlineData(new string[] { "firstTag", "secondTag" }, "FirstTag")]
+        [InlineData(new string[] { "firsttag", "secondtag" }, "Firsttag")]
+        public void When_using_MultipleClientsFromFirstTagAndOperationName_then_ensure_that_clientname_is_from_first_tag(string[] tags, string expectedClientName)
+        {
+            // Arrange
+            var operation = new OpenApiOperation
+            {
+                Tags = tags.ToList()
+            };
+            var generator = new MultipleClientsFromFirstTagAndOperationNameGenerator();
+
+            var document = new OpenApiDocument();
+            var path = string.Empty;
+            var httpMethod = string.Empty;
+
+            // Act
+            string clientName = generator.GetClientName(document, path, httpMethod, operation);
+
+            // Assert
+            Assert.Equal(expectedClientName, clientName);
+        }
+
+        [Theory(DisplayName = "Ensure expected operation name generation when using MultipleClientsFromFirstTagAndOperationName behavior")]
+        [InlineData("OperationId_SecondUnderscore_Test", "Test")]
+        [InlineData("OperationId_MultipleUnderscores_Client_Test", "Test")]
+        [InlineData("OperationId_Test", "Test")]
+        [InlineData("UnderscoreLast_", "UnderscoreLast_")]
+        [InlineData("_UnderscoreFirst", "UnderscoreFirst")]
+        [InlineData("NoUnderscore", "NoUnderscore")]
+        public void When_using_MultipleClientsFromFirstTagAndOperationName_then_ensure_that_operationname_is_last_part_of_operation_id(string operationId, string expectedOperationName)
+        {
+            // Arrange
+            var operation = new OpenApiOperation
+            {
+                OperationId = operationId
+            };
+            var generator = new MultipleClientsFromFirstTagAndOperationNameGenerator();
+
+            var document = new OpenApiDocument();
+            var path = string.Empty;
+            var httpMethod = string.Empty;
+
+            // Act
+            string operationName = generator.GetOperationName(document, path, httpMethod, operation);
+
+            // Assert
+            Assert.Equal(expectedOperationName, operationName);
         }
 
         [Theory(DisplayName = "Ensure expected client name generation with different operationIds when using the MultipleClientsFromOperationId behavior")]

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromFirstTagAndOperationNameGenerator.cs
@@ -1,0 +1,28 @@
+//-----------------------------------------------------------------------
+// <copyright file="MultipleClientsFromFirstTagAndOperationNameGenerator.cs" company="NSwag">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+
+using NJsonSchema;
+using System.Linq;
+
+namespace NSwag.CodeGeneration.OperationNameGenerators
+{
+    /// <summary>Generates the client name based on the first tag and operation names based on the Swagger operation ID (underscore separated).</summary>
+    public class MultipleClientsFromFirstTagAndOperationNameGenerator : MultipleClientsFromOperationIdOperationNameGenerator, IOperationNameGenerator
+    {
+        /// <summary>Gets the client name for a given operation (may be empty).</summary>
+        /// <param name="document">The Swagger document.</param>
+        /// <param name="path">The HTTP path.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="operation">The operation.</param>
+        /// <returns>The client name.</returns>
+        public override string GetClientName(OpenApiDocument document, string path, string httpMethod, OpenApiOperation operation)
+        {
+            return ConversionUtilities.ConvertToUpperCamelCase(operation.Tags.FirstOrDefault(), false);
+        }
+    }
+}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OperationGenerationMode.cs
@@ -28,5 +28,8 @@ namespace NSwag.Commands.CodeGeneration
 
         /// <summary>From path segments suffixed by HTTP operation name</summary>
         SingleClientFromPathSegments,
+
+        /// <summary>From the first operation tag and operation name (underscore separated from operation id)</summary>
+        MultipleClientsFromFirstTagAndOperationName,
     }
 }

--- a/src/NSwag.Commands/OperationGenerationModeConverter.cs
+++ b/src/NSwag.Commands/OperationGenerationModeConverter.cs
@@ -35,6 +35,11 @@ namespace NSwag.Commands
                 return OperationGenerationMode.MultipleClientsFromFirstTagAndOperationId;
             }
 
+            if (operationNameGenerator is MultipleClientsFromFirstTagAndOperationNameGenerator)
+            {
+                return OperationGenerationMode.MultipleClientsFromFirstTagAndOperationName;
+            }
+
             if (operationNameGenerator is SingleClientFromOperationIdOperationNameGenerator)
             {
                 return OperationGenerationMode.SingleClientFromOperationId;
@@ -65,6 +70,10 @@ namespace NSwag.Commands
             else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromFirstTagAndOperationId)
             {
                 return new MultipleClientsFromFirstTagAndOperationIdGenerator();
+            }
+            else if (operationGenerationMode == OperationGenerationMode.MultipleClientsFromFirstTagAndOperationName)
+            {
+                return new MultipleClientsFromFirstTagAndOperationNameGenerator();
             }
             else if (operationGenerationMode == OperationGenerationMode.SingleClientFromOperationId)
             {


### PR DESCRIPTION
Added a new OperationNameGenerator which takes first tag for clientName and the operationName (underscore separated from the operationId). Inherits from the already existing MultipleClientsFromOperationIdOperationNameGenerator.

This allows to have several small controllers that are tagged the same, to be generated into a single client.
```
[Tags("stuff")]
public class AController { public void A () {} }

[Tags("stuff")]
public class BController { public void B() {} }

public class CController { public void C() {} }
```

would then result in 

```
public class StuffClient
{
    public void A () {}
    public void B () {}
}

public class CClient 
{
    public void C() {}
}
```