### PR TITLE
export namespace

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -79,7 +79,7 @@ import { DateTime, Duration } from "luxon";
 {% if ExportTypes %}export {% endif %}module {{ ModuleName }} {
 {%- endif -%}
 {% if HasNamespace -%}
-namespace {{ Namespace }} {
+{% if ExportTypes %}export {% endif %}namespace {{ Namespace }} {
 {%- endif -%}
 {% if GenerateClientClasses and Framework.IsAngular -%}
 {% if ExportTypes %}export {% endif %}const {{ Framework.Angular.BaseUrlTokenName }} = new {{ Framework.Angular.InjectionTokenType }}{% if Framework.Angular.InjectionTokenType == "InjectionToken" %}<string>{% endif %}('{{ Framework.Angular.BaseUrlTokenName }}');


### PR DESCRIPTION
when generate typescipt with namespace and export types, the export keyword is missing in namespace declaration