### PR TITLE
Expose tags in operation model base

### DIFF
--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -289,6 +289,9 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets the operation extension data.</summary>
         public IDictionary<string, object> ExtensionData => _operation.ExtensionData;
 
+        /// <summary>Gets the operation tags </summary>
+        public string Tags => string.Join(",", _operation.Tags);
+
         /// <summary>Gets the success response.</summary>
         /// <returns>The response.</returns>
         protected KeyValuePair<string, OpenApiResponse> GetSuccessResponse()


### PR DESCRIPTION
Expose operation tags in the OperationModelBase. These will come very handy on overriding template and to make it easy to work with from liquid I have exposed these as a comma delimited string.

Please kindly accept this PR if this change is reasonable and adheres to standards, thanks.