### PR TITLE
Add default colon-to-underscore parameter name conversion in C# generator

### DIFF
--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -32,6 +32,7 @@ namespace NSwag.CodeGeneration
             var variableName = ConversionUtilities.ConvertToLowerCamelCase(name
                 .Replace("-", "_")
                 .Replace(".", "_")
+                .Replace(":", "_")
                 .Replace("$", string.Empty)
                 .Replace("@", string.Empty)
                 .Replace("[", string.Empty)


### PR DESCRIPTION
I wasn't able to test this directly (because I can't build master, as described in #4191 with a fix in #4221 ), but I did test this with the changes in that PR and it all seems to be okay. I couldn't find any specific tests for the parameter name generation, so I've not added any more tests, but if there are some that I missed and you want them added I'd be happy to do that too.

Fixes #4188