### PR TITLE
Use GNU tar for cache and install .NET in single step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,24 +34,19 @@ jobs:
     steps:
       - name: 'Allow long file path'
         run: git config --system core.longpaths true
-      - uses: actions/checkout@v1
+      - if: ${{ runner.os == 'Windows' }}
+        name: 'Use GNU tar'
+        shell: cmd
+        run: |
+          echo "Adding GNU tar to PATH"
+          echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 2.1.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 3.1.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 5.0.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.0.*
+          dotnet-version: |
+            2.1.*
+      - uses: actions/checkout@v3
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
@@ -64,7 +59,7 @@ jobs:
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,24 +32,19 @@ jobs:
     steps:
       - name: 'Allow long file path'
         run: git config --system core.longpaths true
-      - uses: actions/checkout@v1
+      - if: ${{ runner.os == 'Windows' }}
+        name: 'Use GNU tar'
+        shell: cmd
+        run: |
+          echo "Adding GNU tar to PATH"
+          echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 2.1.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 3.1.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 5.0.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.*
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.0.*
+          dotnet-version: |
+            2.1.*
+      - uses: actions/checkout@v3
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "ChocoApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Configuration": {
           "type": "string",
@@ -33,6 +33,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -48,7 +49,7 @@
         },
         "MyGetApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "NoLogo": {
           "type": "boolean",
@@ -56,11 +57,11 @@
         },
         "NpmAuthToken": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "NuGetApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Partition": {
           "type": "string",

--- a/build.ps1
+++ b/build.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.CI.GitHubActions.Configuration;
 using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 
-[CustomGitHubActionsAttribute(
+[CustomGitHubActions(
     "pr",
     GitHubActionsImage.WindowsServer2022,
     // GitHubActionsImage.UbuntuLatest,
@@ -16,7 +17,7 @@ using Nuke.Common.Utilities;
     InvokedTargets = new[] { nameof(InstallDependencies), nameof(Compile), nameof(Test), nameof(Pack) },
     CacheKeyFiles = new[] { "global.json", "src/**/*.csproj", "src/**/package.json" }),
 ]
-[CustomGitHubActionsAttribute(
+[CustomGitHubActions(
     "build",
     GitHubActionsImage.WindowsServer2022,
     // GitHubActionsImage.UbuntuLatest,
@@ -45,14 +46,11 @@ class CustomGitHubActionsAttribute : GitHubActionsAttribute
         var job = base.GetJobs(image, relevantTargets);
 
         var newSteps = new List<GitHubActionsStep>(job.Steps);
-        foreach (var version in new[] { "7.0.*", "6.0.*", "5.0.*", "3.1.*", "2.1.*" })
-        {
-            newSteps.Insert(1, new GitHubActionsSetupDotNetStep
-            {
-                Version = version
-            });
-        }
-        
+
+        // only need to list the ones that are missing from default image
+        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(new[] { "2.1.*" }));
+
+        newSteps.Insert(0, new GitHubActionsUseGnuTarStep());
         newSteps.Insert(0, new GitHubActionsConfigureLongPathsStep());
 
         job.Steps = newSteps.ToArray();
@@ -74,7 +72,12 @@ class GitHubActionsConfigureLongPathsStep : GitHubActionsStep
 
 class GitHubActionsSetupDotNetStep : GitHubActionsStep
 {
-    public string Version { get; init; }
+    public GitHubActionsSetupDotNetStep(string[] versions)
+    {
+        Versions = versions;
+    }
+
+    string[] Versions { get; }
 
     public override void Write(CustomFileWriter writer)
     {
@@ -85,7 +88,33 @@ class GitHubActionsSetupDotNetStep : GitHubActionsStep
             writer.WriteLine("with:");
             using (writer.Indent())
             {
-                writer.WriteLine($"dotnet-version: {Version}");
+                writer.WriteLine("dotnet-version: |");
+                using (writer.Indent())
+                {
+                    foreach (var version in Versions)
+                    {
+                        writer.WriteLine(version);
+                    }
+                }
+            }
+        }
+    }
+}
+
+class GitHubActionsUseGnuTarStep : GitHubActionsStep
+{
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine("- if: ${{ runner.os == 'Windows' }}");
+        using (writer.Indent())
+        {
+            writer.WriteLine("name: 'Use GNU tar'");
+            writer.WriteLine("shell: cmd");
+            writer.WriteLine("run: |");
+            using (writer.Indent())
+            {
+                writer.WriteLine("echo \"Adding GNU tar to PATH\"");
+                writer.WriteLine("echo C:\\Program Files\\Git\\usr\\bin>>\"%GITHUB_PATH%\"");
             }
         }
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -6,7 +6,6 @@ using System.Xml.Linq;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Locator;
 using Nuke.Common;
-using Nuke.Common.Execution;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
@@ -18,7 +17,6 @@ using Nuke.Common.Tools.VSTest;
 using Nuke.Common.Utilities.Collections;
 
 using static Nuke.Common.IO.FileSystemTasks;
-using static Nuke.Common.Logger;
 using static Nuke.Common.Tooling.ProcessTasks;
 using static Nuke.Common.Tools.Chocolatey.ChocolateyTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -27,7 +25,6 @@ using static Nuke.Common.Tools.Npm.NpmTasks;
 using static Nuke.Common.Tools.VSTest.VSTestTasks;
 using Project = Nuke.Common.ProjectModel.Project;
 
-[CheckBuildProjectConfigurations]
 partial class Build : NukeBuild
 {
     public Build()

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageReference Include="Nuke.Common" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* GNU tar performs better and [is suggested to be used on Windows](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching)
* Install .NET as single step (and currently only 2.1 is needed as others come with the image), supersedes  #4241