### PR TITLE
Use all text MIME types to determine if body is a text

### DIFF
--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -243,7 +243,7 @@ namespace NSwag.CodeGeneration.Models
         public bool HasBinaryBodyParameter => Parameters.Any(p => p.IsBinaryBodyParameter);
 
         /// <summary>Gets a value indicating whether this operation has a text/plain body parameter.</summary>
-        public bool HasPlainTextBodyParameter => Consumes == "text/plain";
+        public bool HasPlainTextBodyParameter => Consumes == "text/plain" || Consumes == "text/html" || Consumes == "text/xml" || Consumes == "text/richtext";
 
         /// <summary>Gets the mime type of the request body.</summary>
         public string Consumes


### PR DESCRIPTION
There are more MIME types than text/plain that should be handled as plain text