### PR TITLE
Ignore "schema" property of OpenApiParameter

### DIFF
--- a/src/NSwag.Core/OpenApiDocument.Serialization.cs
+++ b/src/NSwag.Core/OpenApiDocument.Serialization.cs
@@ -107,6 +107,8 @@ namespace NSwag
                 resolver.IgnoreProperty(typeof(OpenApiSecurityScheme), "authorizationUrl");
                 resolver.IgnoreProperty(typeof(OpenApiSecurityScheme), "tokenUrl");
                 resolver.IgnoreProperty(typeof(OpenApiSecurityScheme), "scopes");
+                
+                resolver.IgnoreProperty(typeof(OpenApiParameter), "schema");
             }
             else
             {


### PR DESCRIPTION
#2486 - Referencing parameter does not create /schema suffix anymore