### PR TITLE
Remove reflection call in AspNetCoreOperationSecurityScopeProcessor

### DIFF
--- a/src/NSwag.Generation.AspNetCore/Processors/AspNetCoreOperationSecurityScopeProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/AspNetCoreOperationSecurityScopeProcessor.cs
@@ -41,7 +41,7 @@ namespace NSwag.Generation.Processors.Security
         {
             var aspNetCoreContext = (AspNetCoreOperationProcessorContext)context;
 
-            var endpointMetadata = aspNetCoreContext?.ApiDescription?.ActionDescriptor?.TryGetPropertyValue<IList<object>>("EndpointMetadata");
+            var endpointMetadata = aspNetCoreContext?.ApiDescription?.ActionDescriptor?.EndpointMetadata;
             if (endpointMetadata != null)
             {
                 var allowAnonymous = endpointMetadata.OfType<AllowAnonymousAttribute>().Any();


### PR DESCRIPTION
The `EndpointMetadata` property has been made public so reflection is not needed any more.