### PR TITLE
Remove description from OpenApiResponse when serializing for Swagger v2

### DIFF
--- a/src/NSwag.Core.Tests/Serialization/MediaTypesSerializationTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/MediaTypesSerializationTests.cs
@@ -22,7 +22,6 @@ namespace NSwag.Core.Tests.Serialization
         ""operationId"": ""foo"",
         ""responses"": {
           ""200"": {
-            ""description"": """",
             ""schema"": {
               ""type"": ""string""
             },
@@ -93,7 +92,6 @@ namespace NSwag.Core.Tests.Serialization
         ""operationId"": ""foo"",
         ""responses"": {
           ""200"": {
-            ""description"": """",
             ""schema"": {
               ""type"": ""file""
             },

--- a/src/NSwag.Core/OpenApiDocument.Serialization.cs
+++ b/src/NSwag.Core/OpenApiDocument.Serialization.cs
@@ -67,6 +67,7 @@ namespace NSwag
                 resolver.IgnoreProperty(typeof(OpenApiParameter), "x-position");
 
                 resolver.IgnoreProperty(typeof(OpenApiResponse), "content");
+                resolver.IgnoreProperty(typeof(OpenApiResponse), "description");
                 resolver.IgnoreProperty(typeof(OpenApiResponse), "links");
 
                 resolver.IgnoreProperty(typeof(OpenApiSecurityScheme), "scheme");


### PR DESCRIPTION
Remove description from OpenApiResponse when serializing for Swagger v2 to prevent error "Structural error at paths.somepath.get.responses.304 should NOT have additional properties additionalProperty: description".

Because the C# specification of `OpenApiResponse` is adapted to comply with OpenAPI v3, the generation of Swagger v2 yields an invalid result. Specifically the "description" property of `OpenApiResponse` is not allowed with Swagger v2, but is always generated into the Swagger when calling `ToJson`.

This commit fixes this bug by ignoring the description property at all, since it is invalid anyways.