### PR TITLE
Correctly preserve IsRequired for form parameters in OAPI 3.0 (#4379)

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
@@ -186,6 +186,9 @@ components:
             ""multipart/form-data"": {
               ""schema"": {
                 ""type"": ""object"",
+                ""required"": [
+                    ""file""
+                ],
                 ""properties"": {
                   ""file"": {
                     ""type"": ""string"",
@@ -221,10 +224,11 @@ components:
             var document = await OpenApiDocument.FromJsonAsync(json);
 
             // Act
-            var codeGenerator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var codeGenerator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings { GenerateOptionalParameters = true });
             var code = codeGenerator.GenerateFile();
 
             // Assert
+            Assert.Contains("UploadFileAsync(FileParameter file, string test = null", code);
             Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
             Assert.Contains("var content_file_ = new System.Net.Http.StreamContent(file.Data);", code);
             Assert.Contains("class FileParameter", code);

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -363,7 +363,8 @@ namespace NSwag.CodeGeneration.Models
                         OpenApiParameterCollectionFormat.Multi : OpenApiParameterCollectionFormat.Undefined,
                     //Explode = p.Value.Type.HasFlag(JsonObjectType.Array) && p.Value.Item != null,
                     //Schema = p.Value.Type.HasFlag(JsonObjectType.Array) && p.Value.Item != null ? p.Value.Item : p.Value,
-                    Position = parameters.Count + 100 + i
+                    Position = parameters.Count + 100 + i,
+                    IsRequired = p.Value.IsRequired
                 })).ToList();
             }
 

--- a/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Parameters/FileUploadController.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests.Web/Controllers/Parameters/FileUploadController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NJsonSchema.Annotations;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
@@ -11,13 +12,13 @@ namespace NSwag.Generation.AspNetCore.Tests.Web.Controllers.Parameters
     public class FileUploadController : Controller
     {
         [HttpPost("UploadFile")]
-        public ActionResult UploadFile([NotNull] IFormFile file, [FromForm, NotNull]string test)
+        public ActionResult UploadFile([NotNull] IFormFile file, [FromForm, NotNull] string test, [FromForm, BindRequired] string test2)
         {
             return Ok();
         }
 
         [HttpPost("UploadFiles")]
-        public ActionResult UploadFiles([NotNull, FromForm] IFormFile[] files, [FromForm, NotNull]string test)
+        public ActionResult UploadFiles([NotNull, FromForm] IFormFile[] files, [FromForm, NotNull] string test)
         {
             return Ok();
         }

--- a/src/NSwag.Generation.AspNetCore.Tests/Parameters/FormDataTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/Parameters/FormDataTests.cs
@@ -25,6 +25,8 @@ namespace NSwag.Generation.AspNetCore.Tests.Parameters
             Assert.Equal("binary", schema.Properties["file"].Format);
             Assert.Equal(JsonObjectType.String, schema.Properties["file"].Type);
             Assert.Equal(JsonObjectType.String, schema.Properties["test"].Type);
+            Assert.Equal(JsonObjectType.String, schema.Properties["test2"].Type);
+            Assert.True(schema.Properties["test2"].IsRequired);
 
             Assert.Contains(@"    ""/api/FileUpload/UploadFiles"": {
       ""post"": {

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -168,7 +168,7 @@ namespace NSwag.Generation.AspNetCore.Processors
                     else
                     {
                         var schema = CreateOrGetFormDataSchema(context);
-                        schema.Properties[extendedApiParameter.ApiParameter.Name] = CreateFormDataProperty(context, extendedApiParameter, schema);
+                        CreateFormDataProperty(context, extendedApiParameter, schema);
                     }
                 }
                 else
@@ -315,7 +315,7 @@ namespace NSwag.Generation.AspNetCore.Processors
             {
                 var schema = CreateOrGetFormDataSchema(context);
                 schema.Type = JsonObjectType.Object;
-                schema.Properties[extendedApiParameter.ApiParameter.Name] = CreateFormDataProperty(context, extendedApiParameter, schema);
+                CreateFormDataProperty(context, extendedApiParameter, schema);
             }
         }
 
@@ -343,10 +343,33 @@ namespace NSwag.Generation.AspNetCore.Processors
             return requestBody.Content[MultipartFormData].Schema;
         }
 
-        private static JsonSchemaProperty CreateFormDataProperty(OperationProcessorContext context, ExtendedApiParameterDescription extendedApiParameter, JsonSchema schema)
+        private void CreateFormDataProperty(OperationProcessorContext context, ExtendedApiParameterDescription extendedApiParameter, JsonSchema schema)
         {
-            return context.SchemaGenerator.GenerateWithReferenceAndNullability<JsonSchemaProperty>(
+            var contextualParameterType = extendedApiParameter.ParameterType
+                .ToContextualType(extendedApiParameter.Attributes);
+
+            var property = context.SchemaGenerator.GenerateWithReferenceAndNullability<JsonSchemaProperty>(
                extendedApiParameter.ApiParameter.Type.ToContextualType(extendedApiParameter.Attributes), context.SchemaResolver);
+            schema.Properties[extendedApiParameter.ApiParameter.Name] = property;
+
+            property.Description = extendedApiParameter.GetDocumentation();
+
+            var exampleValue = extendedApiParameter.PropertyInfo != null ?
+                context.SchemaGenerator.GenerateExample(extendedApiParameter.PropertyInfo.ToContextualAccessor()) : null;
+
+            var hasExampleValue = exampleValue != null;
+            var hasDefaultValue = extendedApiParameter.ParameterInfo?.HasDefaultValue == true;
+
+            if (hasExampleValue || hasDefaultValue)
+            {
+                var defaultValue = hasDefaultValue ? context.SchemaGenerator
+                    .ConvertDefaultValue(contextualParameterType, extendedApiParameter.ParameterInfo.DefaultValue) : null;
+
+                property.Default = defaultValue;
+                property.Example = exampleValue;
+            }
+
+            property.IsRequired = extendedApiParameter.IsRequired(_settings.RequireParametersWithoutDefault);
         }
 
         private bool IsFileArray(Type type, JsonTypeDescription typeInfo)


### PR DESCRIPTION
- Set `IsRequired`, `Description`, `Default`, and `Example` when creating OAPI3.0 form parameters in `OperationParameterProcessor`
- Set `IsRequired` when getting OAPI 3.0 form data parameters in `OperationModelBase`
- See #4379 