### PR TITLE
Descriptive exception for duplicate XML doc line (#2863)

### DIFF
--- a/src/NSwag.Generation/Processors/OperationResponseProcessorBase.cs
+++ b/src/NSwag.Generation/Processors/OperationResponseProcessorBase.cs
@@ -94,7 +94,14 @@ namespace NSwag.Generation.Processors
         protected XElement GetResponseXmlDocsElement(MethodInfo methodInfo, string responseCode)
         {
             var operationXmlDocsNodes = GetResponseXmlDocsNodes(methodInfo);
-            return operationXmlDocsNodes?.SingleOrDefault(n => n.Name == "response" && n.Attributes().Any(a => a.Name == "code" && a.Value == responseCode));
+            try 
+            {
+                return operationXmlDocsNodes?.SingleOrDefault(n => n.Name == "response" && n.Attributes().Any(a => a.Name == "code" && a.Value == responseCode));
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException($"Multiple response tags with code '{responseCode}' found in XML documentation for method '{methodInfo.Name}'.", ex);
+            }
         }
 
         private IEnumerable<XElement> GetResponseXmlDocsNodes(MethodInfo methodInfo)


### PR DESCRIPTION
Duplicate response code in XML documentation response xml tag causes somewhat hard to debug exception, which is now made more descriptive.

Did not yet figure out how to make an unit test for this one or if some other other exception type would be more suitable than InvalidOperationException.

Bug: Duplicate return code declaration causes nasty exception
id: #2863