### PR TITLE
Add CS0612 to the File.Header.liquid

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
@@ -1,6 +1,7 @@
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
 #pragma warning disable 472 // Disable "CS0472 The result of the expression is always 'false' since a value of type 'Int32' is never equal to 'null' of type 'Int32?'
+#pragma warning disable 612 // Disable "CS0612 '...' is obsolete"
 #pragma warning disable 1573 // Disable "CS1573 Parameter '...' has no matching param tag in the XML comment for ...
 #pragma warning disable 1591 // Disable "CS1591 Missing XML comment for publicly visible type or member ..."
 #pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"


### PR DESCRIPTION
OpenApi which contains deprecated schemas correctly generates `[Obsolete]` attribute. If the API document does not propagate `deprecate` all the way to path/method resulting c# code produce warning CS0612: '...' is obsolete