### PR TITLE
Disable warning CS8604 "Possible null reference argument for parameter" in generated code

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
@@ -7,3 +7,4 @@
 #pragma warning restore 8073
 #pragma warning restore 3016
 #pragma warning restore 8603
+#pragma warning restore 8604

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
@@ -7,3 +7,4 @@
 #pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
+#pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"


### PR DESCRIPTION
We'd like to use `<WarningsAsErrors>nullable</WarningsAsErrors>` in our code base to enforce strict NRT checks. However, a lot of `CS8604` warnings are emitted in generated NSwag code, causing build errors when enabling this build property.

![image](https://github.com/RicoSuter/NSwag/assets/31079637/63324c72-9af4-451a-aa3d-8f806ca14fdb)

Seeing that `CS8603` is already disabled, it seems reasonable to disable `CS8604` as well.

An alternative would be to disable NRT warnings in generated code altogether, using `#nullable disable warnings`, which disables [these warnings](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings) if I'm not mistaken.