### PR TITLE
Add Encoding and Media Type to StringContent for form data

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
@@ -73,7 +73,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             // Assert
             Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
             Assert.Contains("var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(propertyDto, _settings.Value)", code);
-            Assert.Contains("content_.Add(new System.Net.Http.StringContent(json_), \"propertyDto\");", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(json_, Encoding.UTF8, \"application/json\"), \"propertyDto\");", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ObjectParameterTests.cs
@@ -73,7 +73,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             // Assert
             Assert.Contains("var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);", code);
             Assert.Contains("var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(propertyDto, _settings.Value)", code);
-            Assert.Contains("content_.Add(new System.Net.Http.StringContent(json_, Encoding.UTF8, \"application/json\"), \"propertyDto\");", code);
+            Assert.Contains("content_.Add(new System.Net.Http.StringContent(json_, System.Text.Encoding.UTF8, \"application/json\"), \"propertyDto\");", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -270,7 +270,7 @@
                     }
 {%                     elsif parameter.IsObject -%}
                     var json_ = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.Serialize{% else %}Newtonsoft.Json.JsonConvert.SerializeObject{% endif %}({{ parameter.VariableName }}, {% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value);
-                    content_.Add(new System.Net.Http.StringContent(json_), "{{ parameter.Name }}");
+                    content_.Add(new System.Net.Http.StringContent(json_, Encoding.UTF8, "application/json"), "{{ parameter.Name }}");
 {%                     else -%}
                     content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
 {%                     endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -270,7 +270,7 @@
                     }
 {%                     elsif parameter.IsObject -%}
                     var json_ = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.Serialize{% else %}Newtonsoft.Json.JsonConvert.SerializeObject{% endif %}({{ parameter.VariableName }}, {% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value);
-                    content_.Add(new System.Net.Http.StringContent(json_, Encoding.UTF8, "application/json"), "{{ parameter.Name }}");
+                    content_.Add(new System.Net.Http.StringContent(json_, System.Text.Encoding.UTF8, "application/json"), "{{ parameter.Name }}");
 {%                     else -%}
                     content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
 {%                     endif -%}


### PR DESCRIPTION
This PR adds media type and encoding to the c# generated StringContent for objects in form data to the c# Client.Class.liquid template.

Fixes #4486 