### PR TITLE
Generate controller with multiple response types

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpControllerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpControllerGeneratorSettings.cs
@@ -61,6 +61,9 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether ASP.Net Core (2.1) ActionResult type is used (default: false).</summary>
         public bool UseActionResultType { get; set; }
+        
+        /// <summary>Use IActionResult as return type and generate ProducesResponseType attributes (default: false)</summary>
+        public bool UseResponseTypeAttributes { get; set; }
 
         /// <summary>Gets or sets the base path on which the API is served, which is relative to the Host.</summary>
         public string BasePath { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -73,6 +73,9 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
 {%         endif -%}
     {% template Controller.Method.Annotations %}
     [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
+{%         if operation.HasResponseTypeAttributes -%}
+    {{ operation.ResponseTypeAttributes }}
+{%         endif -%}
     public {% if IsAspNetCore and operation.WrapResponse %}async System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult>{% elsif operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsQuery %}[{{ AspNetNamespace }}.{% if IsAspNetCore -%}FromQuery{% else -%}FromUri{%- endif %}{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsHeader %}[{% if IsAspNetCore -%}{{ AspNetNamespace }}.{%- endif %}FromHeader{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsBody and parameter.IsBinaryBody == false %}[{{ AspNetNamespace }}.FromBody] {% endif %}{% if GenerateModelValidationAttributes and parameter.IsRequired %}[{{ RequiredAttributeType }}] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})
     {
 {%-         if IsAspNetCore and operation.WrapResponse %}
@@ -130,6 +133,9 @@ public abstract class {{ Class }}ControllerBase : {% if HasBaseClass %}{{ BaseCl
 {%         endif -%}
     {% template Controller.Method.Annotations %}
     [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
+{%         if operation.HasResponseTypeAttributes -%}
+    {{ operation.ResponseTypeAttributes }}
+{%         endif -%}
     public abstract {%  if operation.WrapResponse %}System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsQuery %}[{{ AspNetNamespace }}.{% if IsAspNetCore -%}FromQuery{% else -%}FromUri{%- endif %}{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsHeader %}[{% if IsAspNetCore -%}{{ AspNetNamespace }}.{%- endif %}FromHeader{% if parameter.IsValidIdentifier == false %}(Name = "{{ parameter.Name }}"){% endif %}] {% endif %}{% if parameter.IsBody and parameter.IsBinaryBody == false %}[{{ AspNetNamespace }}.FromBody] {% endif %}{% if GenerateModelValidationAttributes and parameter.IsRequired %}[{{ RequiredAttributeType }}] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if parameter.HasDefault %} = {{parameter.Default}}{% endif %}{% if GenerateOptionalParameters and parameter.IsOptional and parameter.HasDefault == false %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken){% endif %});
 
 {%     endfor -%}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpControllerCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpControllerCommand.cs
@@ -63,6 +63,13 @@ namespace NSwag.Commands.CodeGeneration
             get { return Settings.UseActionResultType; }
             set { Settings.UseActionResultType = value; }
         }
+        
+        [Argument(Name = "UseResponseTypeAttributes", Description = "Use IActionResult as return type and generate ProducesResponseType attributes (default: false)", IsRequired = false)]
+        public bool UseResponseTypeAttributes
+        {
+            get { return Settings.UseResponseTypeAttributes; }
+            set { Settings.UseResponseTypeAttributes = value; }
+        }
 
         [Argument(Name = "GenerateModelValidationAttributes", Description = "Add model validation attributes (default: false).", IsRequired = false)]
         public bool GenerateModelValidationAttributes


### PR DESCRIPTION
The OpenAPI specification facilitates the use of distinct response types based on different HTTP status codes. A common scenario involves designating one response type for successful requests and another for error responses. In ASP.NET Core this is typically implemented, on the server side, by modify the return type of controller actions to `IActionResult` and apply the `ProducesResponseType` attribute to specify the desired return type. This commit introduces a new setting, `UseResponseTypeAttributes`. When activated, generated controllers returns type is adjusted and attributes are added.

Here's a snippet illustrating the generated code:
```
[Microsoft.AspNetCore.Mvc.HttpPost, Microsoft.AspNetCore.Mvc.Route("MultipleResponseTypes")]
[Microsoft.AspNetCore.Mvc.ProducesResponseType(200, Type = typeof(ComplexType))]
[Microsoft.AspNetCore.Mvc.ProducesResponseType(400, Type = typeof(ErrorResponse))]
public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult> MultipleResponseTypes([Microsoft.AspNetCore.Mvc.FromBody] ComplexType complexType)
{
    return _implementation.ComplexRequired2Async(complexType);
}
```