### PR TITLE
Update AxiosClient.liquid so instance and baseUrl are protected

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -8,8 +8,8 @@
 {%- endif %}
 
 {% if ExportTypes %}export {% endif %}class {{ Class }} {% if HasBaseClass %}extends {{ BaseClass }} {% endif %}{% if GenerateClientInterfaces %}implements I{{ Class }} {% endif %}{
-    private instance: AxiosInstance;
-    private baseUrl: string;
+    protected instance: AxiosInstance;
+    protected baseUrl: string;
     protected jsonParseReviver: {% if SupportsStrictNullChecks %}((key: string, value: any) => any) | undefined{% else %}(key: string, value: any) => any{% endif %} = undefined;
 
 {%- if HasExtendedConstructor == false %}


### PR DESCRIPTION
The `baseURL` and Axios instance are `private`, we implemented our Client as a singleton and as a result there is no way to change the `baseURL` after it's created.

When testing our application, we will point our app to different API URLs but are unable to do so because this is `private`.

Making this `protected` will at least allow us to extend the client and add some hooks.   Making them `public` would not be the worse option either.