### PR TITLE
Set correct parameter position

### DIFF
--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -49,7 +49,7 @@ namespace NSwag.Generation.AspNetCore.Processors
             var parameters = context.ApiDescription.ParameterDescriptions;
             var methodParameters = context.MethodInfo?.GetParameters() ?? new ParameterInfo[0];
 
-            var position = 1;
+            var position = operationProcessorContext.Parameters.Count;
             foreach (var apiParameter in parameters.Where(p =>
                 p.Source != null &&
                 (p.ModelMetadata == null || p.ModelMetadata.IsBindingAllowed)))

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -40,7 +40,7 @@ namespace NSwag.Generation.AspNetCore.Processors
         /// <returns>true if the operation should be added to the Swagger specification.</returns>
         public bool Process(OperationProcessorContext operationProcessorContext)
         {
-            if (!(operationProcessorContext is AspNetCoreOperationProcessorContext context))
+            if (operationProcessorContext is not AspNetCoreOperationProcessorContext context)
             {
                 return false;
             }

--- a/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -47,7 +47,7 @@ namespace NSwag.Generation.AspNetCore.Processors
 
             var httpPath = context.OperationDescription.Path;
             var parameters = context.ApiDescription.ParameterDescriptions;
-            var methodParameters = context.MethodInfo?.GetParameters() ?? new ParameterInfo[0];
+            var methodParameters = context.MethodInfo?.GetParameters() ?? Array.Empty<ParameterInfo>();
 
             var position = operationProcessorContext.Parameters.Count;
             foreach (var apiParameter in parameters.Where(p =>


### PR DESCRIPTION
If you implement a custom `IOperationProcessor` which adds parameter(s), and it runs before the `OperationParameterProcessor` the `x-position` property is not generated correctly