### PR TITLE
Exclude IHostedService implementations when running Console Commands

### DIFF
--- a/src/NSwag.Commands/HostApplication.cs
+++ b/src/NSwag.Commands/HostApplication.cs
@@ -106,6 +106,18 @@ namespace NSwag.Commands
                 {
                     services.AddSingleton<IServer, NoopServer>();
                     services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+
+                    for (var i = services.Count - 1; i >= 0; i--)
+                    {
+                        // exclude all implementations of IHostedService
+                        // except Microsoft.AspNetCore.Hosting.GenericWebHostService because that one will build/configure
+                        // the WebApplication/Middleware pipeline in the case of the GenericWebHostBuilder.
+                        if (typeof(IHostedService).IsAssignableFrom(services[i].ServiceType)
+                            && services[i].ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
+                        {
+                            services.RemoveAt(i);
+                        }
+                    }
                 });
             }
 


### PR DESCRIPTION
Exclude all IHostedService implementations except GenericWebHostService because it Configures the pipeline.

By removing the IHostedService implementations it will stop running these when starting the app which happens with the WebApplication builder.

Currently the CLI is running all registered Hosted Services (IHostedService). It's needed to start the application because otherwise the app.Use*/app.Map* configuration is not run. Because it's starting the application (with a NoopServer) it is running all registered HostedServices.

Because the Console Commands are almost always run in the context of a build it would be nice to not run those registered hosted services. This would also solve instances of for example HangFire or other things which start an IHostedService.