### PR TITLE
add support for '1XX' type format response, fixes #4383

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -316,7 +316,20 @@
 
                     var status_ = (int)response_.StatusCode;
 {%     for response in operation.Responses -%}
-                    if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
+{% liquid
+        assign statusEnding = response.StatusCode | slice: 1,2
+        if statusEnding == "XX"
+            assign statusPrefix = response.StatusCode | slice: 0,1
+            assign firstValue = statusPrefix | append: "00"
+            assign lastValue = statusPrefix | append: "99"
+            assign comparisonFirst = "status_ >= " | append: firstValue
+            assign comparisonSecond = "status_ <= " | append: lastValue
+            assign statusCodeComparison = comparisonFirst | append: " && " | append: comparisonSecond
+        else
+            assign statusCodeComparison = "status_ == " | append: response.StatusCode
+        endif
+-%}
+                    if ({{ statusCodeComparison }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
                     {
                         {% template Client.Class.ProcessResponse %}
                     }


### PR DESCRIPTION
These formats including XX for the second and third digits of the response code is supported by spec

https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#patterned-fields-1