### PR TITLE
headers dictionary with IgnoreCase comparer

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -301,7 +301,7 @@
                 var disposeResponse_ = true;
                 try
                 {
-                    var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                    var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value, System.StringComparer.OrdinalIgnoreCase);
                     if (response_.Content != null && response_.Content.Headers != null)
                     {
                         foreach (var item_ in response_.Content.Headers)


### PR DESCRIPTION
 I'm facing a problem when a generated nswag client has a Headers field that is case sensitive.
I suggest adding StringComparer.OrdinalIgnoreCase since HTTP2 requires lower case headers (https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2).