### PR TITLE
Remove support for ASP.NET Core on full framework in AspNetCoreToOpenApiGenerator

### DIFF
--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiCommand.cs
@@ -17,7 +17,7 @@ using NConsole;
 using Newtonsoft.Json;
 using NSwag.Generation;
 
-#if NETCOREAPP || NETSTANDARD
+#if !NETFRAMEWORK
 using System.Runtime.Loader;
 #endif
 

--- a/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
+++ b/src/NSwag.Commands/Commands/Generation/AspNetCore/AspNetCoreToOpenApiGeneratorCommandEntryPoint.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -19,6 +20,9 @@ namespace NSwag.Commands.Generation.AspNetCore
     {
         public static void Process(string commandContent, string outputFile, string applicationName)
         {
+#if NETFRAMEWORK
+            throw new NotSupportedException("ASP.NET Core running on Full Framework is not supported");
+#else
             var command = JsonConvert.DeserializeObject<AspNetCoreToOpenApiCommand>(commandContent);
             var previousWorkingDirectory = command.ChangeWorkingDirectoryAndSetAspNetCoreEnvironment();
 
@@ -32,6 +36,7 @@ namespace NSwag.Commands.Generation.AspNetCore
             var outputPathDirectory = Path.GetDirectoryName(outputFile);
             Directory.CreateDirectory(outputPathDirectory);
             File.WriteAllText(outputFile, json);
+#endif
         }
     }
 }

--- a/src/NSwag.Commands/HostApplication.cs
+++ b/src/NSwag.Commands/HostApplication.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if !NETFRAMEWORK
+
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -47,7 +49,6 @@ namespace NSwag.Commands
                             null, createWebHostMethod.GetParameters().Length > 0 ? new object[] { args } : Array.Empty<object>());
                         serviceProvider = webHostBuilder.Build().Services;
                     }
-#if NETCOREAPP3_0_OR_GREATER
                     else
                     {
                         var createHostMethod =
@@ -61,7 +62,6 @@ namespace NSwag.Commands
                             serviceProvider = webHostBuilder.Build().Services;
                         }
                     }
-#endif
                 }
             }
 
@@ -92,9 +92,6 @@ namespace NSwag.Commands
 
         internal static IServiceProvider GetServiceProviderWithHostFactoryResolver(Assembly assembly)
         {
-#if NETFRAMEWORK
-            return null;
-#else
             // We're disabling the default server and the console host lifetime. This will disable:
             // 1. Listening on ports
             // 2. Logging to the console from the default host.
@@ -152,13 +149,9 @@ namespace NSwag.Commands
             try
             {
                 // Get the IServiceProvider from the host
-#if NET6_0_OR_GREATER
                 var assemblyName = assembly.GetName()?.FullName ?? string.Empty;
                 // We should set the application name to the startup assembly to avoid falling back to the entry assembly.
                 var services = ((IHost)factory(new[] { $"--{HostDefaults.ApplicationKey}={assemblyName}" })).Services;
-#else
-                var services = ((IHost)factory(Array.Empty<string>())).Services;
-#endif
 
                 // Wait for the application to start so that we know it's fully configured. This is important because
                 // we need the middleware pipeline to be configured before we access the ISwaggerProvider in
@@ -177,7 +170,6 @@ namespace NSwag.Commands
             }
 
             return null;
-#endif
         }
 
         private class NoopHostLifetime : IHostLifetime
@@ -195,3 +187,5 @@ namespace NSwag.Commands
         }
     }
 }
+
+#endif

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <!-- obsolete usage, missing comments -->
     <NoWarn>$(NoWarn),618,1591</NoWarn>
@@ -22,18 +22,11 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-rc.1.23419.4" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0-rc.1.23421.29" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.Generation.AspNetCore.Tests/SystemTextJsonTests.cs
+++ b/src/NSwag.Generation.AspNetCore.Tests/SystemTextJsonTests.cs
@@ -1,8 +1,8 @@
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
+
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Converters;
 using NSwag.AspNetCore;
 using Xunit;
 using NJsonSchema.Generation;

--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -75,7 +75,7 @@ namespace NSwag.Generation.AspNetCore
                 }
             }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             dynamic options = GetJsonOptionsWithReflection(serviceProvider);
 #else
             object options = null;
@@ -202,7 +202,7 @@ namespace NSwag.Generation.AspNetCore
                         }
 
                         var method = (item.Item2 as ControllerActionDescriptor)?.MethodInfo ??
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
                             item.Item2?.EndpointMetadata?.OfType<MethodInfo>().FirstOrDefault();
 #else
                             null;


### PR DESCRIPTION
ASP.NET Core hasn't been supported with full framework for a long time and currently causes dependency to ancient and vulnerable ASP.NET Core 2.2 hosting bundle. `HostApplication` type can now conditionally compiled when `!NETFRAMEWORK`.