### PR TITLE
Remove unnecessary string creations from OpenApiDocumentMiddleware

### DIFF
--- a/src/NSwag.AspNet.Owin/Middlewares/OpenApiDocumentMiddleware.cs
+++ b/src/NSwag.AspNet.Owin/Middlewares/OpenApiDocumentMiddleware.cs
@@ -34,7 +34,7 @@ namespace NSwag.AspNet.Owin.Middlewares
         public OpenApiDocumentMiddleware(OwinMiddleware next, string path, IEnumerable<Type> controllerTypes, SwaggerSettings<WebApiOpenApiDocumentGeneratorSettings> settings)
             : base(next)
         {
-            _path = path;
+            _path = path.StartsWith("/") ? path : '/' + path;
             _controllerTypes = controllerTypes;
             _settings = settings;
         }
@@ -44,7 +44,7 @@ namespace NSwag.AspNet.Owin.Middlewares
         /// <returns>The task.</returns>
         public override async Task Invoke(IOwinContext context)
         {
-            if (context.Request.Path.HasValue && string.Equals(context.Request.Path.Value.Trim('/'), _path.Trim('/'), StringComparison.OrdinalIgnoreCase))
+            if (context.Request.Path.HasValue && string.Equals(context.Request.Path.Value, _path, StringComparison.OrdinalIgnoreCase))
             {
                 var schemaJson = await GetDocumentAsync(context);
 


### PR DESCRIPTION
Every time methods like `string.Trim()` or `string.ToLowerInvariant()` are invoked on an instance of a `string`, an new `string` instance is created.

Being a middleware, `OpenApiDocumentMiddleware` is on the hot path of every request.

This PR removes those string creations from `OpenApiDocumentMiddleware`.

To keep the same logic as before, `string.AsSpan()´ could be used, but that doesn't work as well on .NET Framework as in .NET, performance-wise.