### PR TITLE
Fix OpenApiReference for MSBuildRuntimeType=Core

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <_NSwagCommand>$(NSwagExe)</_NSwagCommand>
     <_NSwagCommand
-        Condition="'$(MSBuildRuntimeType)' == 'Core'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Core31)/dotnet-nswag.dll"</_NSwagCommand>
-    <_NSwagCommand
-        Condition="'$(TargetFramework)' == 'net6.0'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net60)/dotnet-nswag.dll"</_NSwagCommand>
+        Condition="'$(MSBuildRuntimeType)' == 'Core'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net60)/dotnet-nswag.dll"</_NSwagCommand>
     <_NSwagCommand
         Condition="'$(TargetFramework)' == 'net7.0'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net70)/dotnet-nswag.dll"</_NSwagCommand>
     <_NSwagCommand


### PR DESCRIPTION
Use .Net 6.0 version of dotnet-nswag.dll when building with dotnet CLI.
.Net 3.1 version is no longer provided in NSwag.MSBuild package.