### PR TITLE
Use supported versions of Microsoft.AspNetCore.*

### DIFF
--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -30,10 +30,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="[2.1.7, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.1.1, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.1.3, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.1.18, 2.2)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ASP.NET Core 2.1 on .NET Framework is still supported while version 2.2 is deprecated.
[.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)