### PR TITLE
Added feature to suppress the generation of the output of client classes and interfaces.

### DIFF
--- a/docs/tutorials/GenerateProxyClientWithCLI/generate-proxy-client.md
+++ b/docs/tutorials/GenerateProxyClientWithCLI/generate-proxy-client.md
@@ -77,7 +77,9 @@ nswag run sample.nswag /runtime:Net50
     "codeGenerators": {
         "openApiToCSharpClient": {
             "generateClientClasses": true,
+            "suppressClientClassesOutput": false,
             "generateClientInterfaces": true,
+            "suppressClientInterfacesOutput": false,
             "generateDtoTypes": true,
             "injectHttpClient": true,
             "disposeHttpClient": true,

--- a/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
@@ -173,5 +173,57 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             // Assert
             Assert.Contains("public partial interface IFooClient : IClientBase", code);
         }
+
+        [Fact]
+        public async Task When_client_class_generation_is_enabled_and_suppressed_then_client_class_is_not_generated()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaSettings = new NewtonsoftJsonSchemaGeneratorSettings()
+            });
+
+            var document = await swaggerGenerator.GenerateForControllerAsync<FooController>();
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientClasses = true,
+                SuppressClientClassesOutput = true,
+                GenerateClientInterfaces = true,
+                // SuppressClientInterfacesOutput = false, // default
+             });
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("public partial interface IFooClient", code);
+            Assert.DoesNotContain("public partial class FooClient : IFooClient", code);
+        }
+
+        [Fact]
+        public async Task When_client_interface_generation_is_enabled_and_suppressed_then_client_interface_is_not_generated()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaSettings = new NewtonsoftJsonSchemaGeneratorSettings()
+            });
+
+            var document = await swaggerGenerator.GenerateForControllerAsync<FooController>();
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientClasses = true,
+                // SuppressClientClassesOutput = false, // default
+                GenerateClientInterfaces = true,
+                SuppressClientInterfacesOutput = true,
+             });
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.DoesNotContain("public partial interface IFooClient", code);
+            Assert.Contains("public partial class FooClient : IFooClient", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGenerator.cs
@@ -58,14 +58,17 @@ namespace NSwag.CodeGeneration.CSharp
             var model = new CSharpClientTemplateModel(controllerName, controllerClassName, operations, exceptionSchema, _document, Settings);
             if (model.HasOperations)
             {
-                if (model.GenerateClientInterfaces)
+                if (model.GenerateClientInterfaces && !model.SuppressClientInterfacesOutput)
                 {
                     var interfaceTemplate = Settings.CSharpGeneratorSettings.TemplateFactory.CreateTemplate("CSharp", "Client.Interface", model);
                     yield return new CodeArtifact(model.Class, CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Contract, interfaceTemplate);
                 }
 
-                var classTemplate = Settings.CSharpGeneratorSettings.TemplateFactory.CreateTemplate("CSharp", "Client.Class", model);
-                yield return new CodeArtifact(model.Class, CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Client, classTemplate);
+                if (!model.SuppressClientClassesOutput)
+                {
+                    var classTemplate = Settings.CSharpGeneratorSettings.TemplateFactory.CreateTemplate("CSharp", "Client.Class", model);
+                    yield return new CodeArtifact(model.Class, CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Client, classTemplate);
+                }
             }
         }
 

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -83,6 +83,12 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether to generate client interfaces.</summary>
         public bool GenerateClientInterfaces => _settings.GenerateClientInterfaces;
 
+        /// <summary>Gets a value indicating whether to generate the output of client interfaces.</summary>
+        public bool SuppressClientInterfacesOutput => _settings.SuppressClientInterfacesOutput;
+
+        /// <summary>Gets a value indicating whether to generate the output of client classes.</summary>
+        public bool SuppressClientClassesOutput => _settings.SuppressClientClassesOutput;
+
         /// <summary>Gets client base interface.</summary>
         public string ClientBaseInterface => _settings.ClientBaseInterface;
 

--- a/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
@@ -19,6 +19,8 @@ namespace NSwag.CodeGeneration
         protected ClientGeneratorBaseSettings()
         {
             GenerateClientClasses = true;
+            SuppressClientClassesOutput = false;
+            SuppressClientInterfacesOutput = false;
             GenerateDtoTypes = true;
 
             OperationNameGenerator = new MultipleClientsFromOperationIdOperationNameGenerator();
@@ -43,8 +45,14 @@ namespace NSwag.CodeGeneration
         /// <summary>Gets or sets a value indicating whether to generate interfaces for the client classes (default: false).</summary>
         public bool GenerateClientInterfaces { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether to generate the output of interfaces for the client classes (default: false).</summary>
+        public bool SuppressClientInterfacesOutput { get; set; }
+
         /// <summary>Gets or sets a value indicating whether to generate client types (default: true).</summary>
         public bool GenerateClientClasses { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether to generate the output of client types (default: false).</summary>
+        public bool SuppressClientClassesOutput { get; set; }
 
         /// <summary>Gets or sets the operation name generator.</summary>
         public IOperationNameGenerator OperationNameGenerator { get; set; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -46,11 +46,25 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.GenerateClientClasses = value; }
         }
 
+        [Argument(Name = "SuppressClientClassesOutput", IsRequired = false, Description = "Specifies whether generate output for client classes.")]
+        public bool SuppressClientClassesOutput
+        {
+            get { return Settings.SuppressClientClassesOutput; }
+            set { Settings.SuppressClientClassesOutput = value; }
+        }
+
         [Argument(Name = "GenerateClientInterfaces", IsRequired = false, Description = "Specifies whether generate interfaces for the client classes.")]
         public bool GenerateClientInterfaces
         {
             get { return Settings.GenerateClientInterfaces; }
             set { Settings.GenerateClientInterfaces = value; }
+        }
+
+        [Argument(Name = "SuppressClientInterfacesOutput", IsRequired = false, Description = "Specifies whether generate output for interfaces for the client classes.")]
+        public bool SuppressClientInterfacesOutput
+        {
+            get { return Settings.SuppressClientInterfacesOutput; }
+            set { Settings.SuppressClientInterfacesOutput = value; }
         }
 
         [Argument(Name = "ClientBaseInterface", IsRequired = false, Description = "Base interface for client interfaces (empty for no client base interface).")]

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -90,6 +90,10 @@
                                       ToolTip="GenerateClientClasses"
                                       Content="Generate Client Classes" Margin="0,0,0,12" />
 
+                            <CheckBox IsChecked="{Binding Command.SuppressClientClassesOutput, Mode=TwoWay}" 
+                                      ToolTip="SuppressClientClassesOutput"
+                                      Content="Suppress output of generated Client Classes" Margin="0,0,0,12" />
+
                             <StackPanel Visibility="{Binding Command.GenerateClientClasses, Converter={StaticResource VisibilityConverter}}">
                                 <TextBlock Margin="0,0,0,6" TextWrapping="Wrap">
                                     <Run Text="Operation Generation Mode" FontWeight="Bold" />
@@ -153,6 +157,10 @@
                                 <CheckBox IsChecked="{Binding Command.GenerateClientInterfaces, Mode=TwoWay}" 
                                           ToolTip="GenerateClientInterfaces"
                                           Content="Generate interfaces for Client classes" Margin="0,0,0,12" />
+
+                                <CheckBox IsChecked="{Binding Command.SuppressClientInterfacesOutput, Mode=TwoWay}" 
+                                          ToolTip="SuppressClientInterfacesOutput"
+                                          Content="Suppress output of generated interfaces for Client classes" Margin="0,0,0,12" />
 
                                 <TextBlock Text="Base interface for Client Interfaces (optional)" FontWeight="Bold" Margin="0,0,0,6"
                                            Visibility="{Binding Command.GenerateClientInterfaces, Converter={StaticResource VisibilityConverter}}" />


### PR DESCRIPTION
This PR addresses #633 by adding a command-line argument to `OpenApiToCsharpCommand` `/SuppressClientClassesOutput` to suppress the output of the generated classes and a command-line argument `/SuppressClientInterfacesOutput` to suppress the output of the generated interfaces.

The objective here is for the usage of the tooling to be retro-compatible and to be just an additional feature.

If a user wants to generate a client class that implements an interface but not have the interface output as part of the generation, then `/GenerateClientClasses:true /GenerateClientInterfaces:true /SuppressClientInterfacesOutput:true`.

The same for interfaces. If a user wants to generate a client interface but not have the client class output as part of the generation, then `/GenerateClientClasses:true /SuppressClientClassesOutput:true /GenerateClientInterfaces:true /SuppressClientClassesOutput:true`.