### PR TITLE
Replace StringBuilder.Replace with StringBuilder.Append for building request URL

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
@@ -1,13 +1,13 @@
 {% if parameter.IsDateTimeArray -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
+urlBuilder_.Append(System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
 {% elsif parameter.IsDateArray -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
+urlBuilder_.Append(System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => s_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)))));
 {% elsif parameter.IsDateTime -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
+urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 {% elsif parameter.IsDate -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
+urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 {% elsif parameter.IsArray -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => ConvertToString(s_, System.Globalization.CultureInfo.InvariantCulture)))));
+urlBuilder_.Append(System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select({{ parameter.VariableName }}, s_ => ConvertToString(s_, System.Globalization.CultureInfo.InvariantCulture)))));
 {% else -%}
-urlBuilder_.Replace("{{ "{" }}{{ parameter.Name }}}", System.Uri.EscapeDataString(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)));
+urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)));
 {%- endif %}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -139,33 +139,6 @@
             throw new System.ArgumentNullException("{{ operation.ContentParameter.VariableName }}");
 
 {%     endif -%}
-        var urlBuilder_ = new System.Text.StringBuilder();
-        {% if UseBaseUrl %}if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);{% endif %}
-        urlBuilder_.Append("{{ operation.Path }}{% if operation.HasQueryParameters %}?{% endif %}");
-{%     for parameter in operation.PathParameters -%}
-{%         if parameter.IsOptional -%}
-        if ({{ parameter.VariableName }} != null)
-            {% template Client.Class.PathParameter %}
-        else
-            urlBuilder_.Replace("/{{ "{" }}{{ parameter.Name }}}", string.Empty);
-{%         else -%}
-        {% template Client.Class.PathParameter %}
-{%         endif -%}
-{%     endfor -%}
-{%     for parameter in operation.QueryParameters -%}
-{%         if parameter.IsOptional -%}
-        if ({{ parameter.VariableName }} != null)
-        {
-            {% template Client.Class.QueryParameter %}
-        }
-{%         else -%}
-        {% template Client.Class.QueryParameter %}
-{%         endif -%}
-{%     endfor -%}
-{%     if operation.HasQueryParameters -%}
-        urlBuilder_.Length--;
-{%     endif -%}
-
 {%     if InjectHttpClient -%}
         var client_ = _httpClient;
 {%     elsif UseHttpClientCreationMethod -%}
@@ -288,6 +261,56 @@
                 request_.Method = new System.Net.Http.HttpMethod("{{ operation.HttpMethodUpper | upcase }}");
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("{{ operation.Produces }}"));
+{%     endif -%}
+
+                var urlBuilder_ = new System.Text.StringBuilder();
+                {% if UseBaseUrl %}if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);{% endif %}
+{%     assign pathParts = operation.Path | split: "/" -%}
+{%     unless operation.Path == "" -%}
+{%         for pathPart in pathParts -%}
+{%             assign pathPartLength = pathPart | size -%}
+{%             unless pathPartLength == 0 -%}
+{%                 assign firstPathPartChar = pathPart | slice: 0 -%}
+{%                 assign lastPathPartChar = pathPart | slice: -1 -%}
+{%                 if firstPathPartChar == "{" and lastPathPartChar == "}" -%}
+{%                     assign pathParameterPartLength = pathPartLength | minus: 2 -%}
+{%                     assign pathParameterPart = pathPart | slice: 1, pathParameterPartLength -%}
+{%                     for parameter in operation.PathParameters -%}
+{%                         if parameter.Name == pathParameterPart -%}
+{%                             if parameter.IsOptional -%}
+        if ({{ parameter.VariableName }} != null)
+        {
+            {% template Client.Class.PathParameter %}
+        }
+        else
+            if (urlBuilder_.Length > 0) urlBuilder_.Length--;
+{%                         else -%}
+                {% template Client.Class.PathParameter %}
+{%                             endif -%}
+{%                         endif -%}
+{%                     endfor -%}
+{%                 else -%}
+                urlBuilder_.Append("{{ pathPart }}");
+{%                 endif -%}
+{%                 if forloop.last == false -%}
+                urlBuilder_.Append('/');
+{%                 endif -%}
+{%             endunless -%}
+{%         endfor -%}
+{%     endunless -%}
+{%     if operation.HasQueryParameters -%}
+        urlBuilder_.Append('?');
+{%         for parameter in operation.QueryParameters -%}
+{%             if parameter.IsOptional -%}
+        if ({{ parameter.VariableName }} != null)
+        {
+            {% template Client.Class.QueryParameter %}
+        }
+{%             else -%}
+        {% template Client.Class.QueryParameter %}
+{%             endif -%}
+{%         endfor -%}
+        urlBuilder_.Length--;
 {%     endif -%}
 
 {% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods %}

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -69,10 +69,6 @@ namespace MyNamespace
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<string> GetAsync(System.Threading.CancellationToken cancellationToken)
         {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("");
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -81,6 +77,9 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -148,12 +147,6 @@ namespace MyNamespace
             if (b == null)
                 throw new System.ArgumentNullException("b");
 
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("sum/{a}/{b}");
-            urlBuilder_.Replace("{a}", System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-            urlBuilder_.Replace("{b}", System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -162,6 +155,14 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    urlBuilder_.Append("sum");
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -366,10 +367,6 @@ namespace MyNamespace
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<FileResponse> GetAsync(System.Threading.CancellationToken cancellationToken)
         {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("examples");
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -378,6 +375,10 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    urlBuilder_.Append("examples");
 
                     PrepareRequest(client_, request_, urlBuilder_);
 

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -69,10 +69,6 @@ namespace MyNamespace
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<string> GetAsync(System.Threading.CancellationToken cancellationToken)
         {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("");
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -81,6 +77,9 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -148,12 +147,6 @@ namespace MyNamespace
             if (b == null)
                 throw new System.ArgumentNullException("b");
 
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("sum/{a}/{b}");
-            urlBuilder_.Replace("{a}", System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-            urlBuilder_.Replace("{b}", System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -162,6 +155,14 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    urlBuilder_.Append("sum");
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -366,10 +367,6 @@ namespace MyNamespace
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<FileResponse> GetAsync(System.Threading.CancellationToken cancellationToken)
         {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-            urlBuilder_.Append("examples");
-
             var client_ = _httpClient;
             var disposeClient_ = false;
             try
@@ -378,6 +375,10 @@ namespace MyNamespace
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    urlBuilder_.Append("examples");
 
                     PrepareRequest(client_, request_, urlBuilder_);
 


### PR DESCRIPTION
This PR replaces the use of `StringBuilder.Replace` in the generation of the request URL with appending URL parts.

**Before**:
```csharp
urlBuilder_.Append("sum/{a}/{b}");
urlBuilder_.Replace("{a}", System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
urlBuilder_.Replace("{b}", System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
```

**After**:
```csharp
urlBuilder_.Append("sum");
urlBuilder_.Append('/');
urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
urlBuilder_.Append('/');
urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
```


This would be easier if the model for generation produced the different path parts already split and classified.

