### PR TITLE
Remove path part concatenation for paths without parameters and removed append and concatenation of single characters

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ArrayParameterTests.cs
@@ -66,7 +66,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile();
 
             // Assert
-            Assert.Contains(@"foreach (var item_ in elementId) { urlBuilder_.Append(System.Uri.EscapeDataString(""elementId"") + ""="").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(""&""); }", code);
+            Assert.Contains(@"foreach (var item_ in elementId) { urlBuilder_.Append(System.Uri.EscapeDataString(""elementId"")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }", code);
         }
         
         [Fact]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ParameterTests.cs
@@ -270,7 +270,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile();
 
             // Assert
-            Assert.Contains(@"""options[optionalOrder.id]"") + ""=""", code);
+            Assert.Contains(@"""options[optionalOrder.id]"")).Append('=')", code);
             Assert.Contains("options.OptionalOrderId", code);
         }
 

--- a/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
@@ -72,10 +72,10 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.Contains(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"page\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(paging.Page, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"page\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(paging.Page, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
             Assert.Contains(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"limit\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(paging.Limit, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"limit\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(paging.Limit, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
         }
 
@@ -138,10 +138,10 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.DoesNotContain(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
             Assert.Contains(
-                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
                 code);
         }
 
@@ -206,10 +206,10 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.DoesNotContain(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
             Assert.Contains(
-                "foreach (var item_ in extendedProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                "foreach (var item_ in extendedProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
                 code);
         }
 
@@ -289,13 +289,13 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.DoesNotContain(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"extendedProperties\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
             Assert.Contains(
-                "urlBuilder_.Append(System.Uri.EscapeDataString(\"default\") + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties.Default, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\");",
+                "urlBuilder_.Append(System.Uri.EscapeDataString(\"default\")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(extendedProperties.Default, System.Globalization.CultureInfo.InvariantCulture))).Append('&');",
                 code);
             Assert.Contains(
-                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + \"=\").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append(\"&\"); }",
+                "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
                 code);
         }
     }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -1,44 +1,44 @@
 {% if parameter.IsDateTimeArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDateArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString(item_.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDateTime -%}
-urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
+urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% elsif parameter.IsDate -%}
-urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
+urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% elsif parameter.IsArray -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDictionary -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
 {
-    urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]") + "=").Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+    urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
 }
 {%     endfor -%}
 {%     for property in parameter.CollectionPropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null && {{parameter.Name}}.{{property.Name}}.Count > 0)
 {
-    urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]") + "=");
+    urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{property.Key}}]")).Append('=');
     foreach (var p_ in {{parameter.Name}}.{{property.Name}})
     {
-        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(",");
+        urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(p_, System.Globalization.CultureInfo.InvariantCulture))).Append(',');
     }
     urlBuilder_.Length--;
-    urlBuilder_.Append("&");
+    urlBuilder_.Append('&');
 }
 {%     endfor -%}
 {% elsif parameter.Explode and parameter.IsForm and parameter.IsObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)
 {
-    urlBuilder_.Append(System.Uri.EscapeDataString("{{property.Key}}") + "=").Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+    urlBuilder_.Append(System.Uri.EscapeDataString("{{property.Key}}")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString({{parameter.Name}}.{{property.Name}}, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
 }
 {%     endfor -%}
 {% elsif parameter.HasAdditionalProperties == false -%}
-urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=").Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append("&");
+urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% endif -%}
 {% if parameter.HasAdditionalProperties -%}
-foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key) + "=").Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&"); }
+foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -265,39 +265,50 @@
 
                 var urlBuilder_ = new System.Text.StringBuilder();
                 {% if UseBaseUrl %}if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);{% endif %}
-{%     assign pathParts = operation.Path | split: "/" -%}
-{%     unless operation.Path == "" -%}
-{%         for pathPart in pathParts -%}
-{%             assign pathPartLength = pathPart | size -%}
-{%             unless pathPartLength == 0 -%}
-{%                 assign firstPathPartChar = pathPart | slice: 0 -%}
-{%                 assign lastPathPartChar = pathPart | slice: -1 -%}
-{%                 if firstPathPartChar == "{" and lastPathPartChar == "}" -%}
-{%                     assign pathParameterPartLength = pathPartLength | minus: 2 -%}
-{%                     assign pathParameterPart = pathPart | slice: 1, pathParameterPartLength -%}
-{%                     for parameter in operation.PathParameters -%}
-{%                         if parameter.Name == pathParameterPart -%}
-{%                             if parameter.IsOptional -%}
+                // Operation Path: "{{ operation.Path }}"
+{%     if operation.Path contains "{" -%}
+{%        assign pathParts = operation.Path | split: "{" -%}
+{%        for pathPart in pathParts -%}
+{%            if pathPart contains "}" -%}
+{%                assign pathParameterParts = pathPart | split: "}" -%}
+{%                assign pathParameterFound = true -%}
+{%                for parameter in operation.PathParameters -%}
+{%                    if parameter.Name == pathParameterParts[0] -%}
+{%                        if parameter.IsOptional -%}
+{%                            assign pathParameterFound = false -%}
         if ({{ parameter.VariableName }} != null)
         {
             {% template Client.Class.PathParameter %}
         }
         else
             if (urlBuilder_.Length > 0) urlBuilder_.Length--;
-{%                         else -%}
+{%                        else -%}
                 {% template Client.Class.PathParameter %}
-{%                             endif -%}
-{%                         endif -%}
-{%                     endfor -%}
-{%                 else -%}
+{%                        endif -%}
+{%                    endif -%}
+{%                endfor -%}
+{%                comment -%} >>> just in case {% endcomment -%}
+{%                unless pathParameterFound -%}
+                urlBuilder_.Append("{{ '{' }}{{ pathParameterParts[0] }}{{ '}' }}");
+{%                endunless -%}
+{%                comment -%} <<< just in case {% endcomment -%}
+{%                assign nonParameterPartLengh = pathParameterParts[1] | size -%}
+{%                if nonParameterPartLengh == 1 -%}
+                urlBuilder_.Append('{{ pathParameterParts[1] }}');
+{%                elsif nonParameterPartLengh > 0 -%}
+                urlBuilder_.Append("{{ pathParameterParts[1] }}");
+{%                endif -%}
+{%            else -%}
+{%                 unless pathPart == "" -%}
                 urlBuilder_.Append("{{ pathPart }}");
-{%                 endif -%}
-{%                 if forloop.last == false -%}
-                urlBuilder_.Append('/');
-{%                 endif -%}
-{%             endunless -%}
-{%         endfor -%}
-{%     endunless -%}
+{%                 endunless -%}
+{%            endif -%}
+{%        endfor -%}
+{%    else -%}
+{%        unless operation.Path == "" -%}
+                urlBuilder_.Append("{{ operation.Path }}");
+{%        endunless -%}
+{%    endif -%}
 {%     if operation.HasQueryParameters -%}
         urlBuilder_.Append('?');
 {%         for parameter in operation.QueryParameters -%}

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -79,6 +79,7 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: ""
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -157,11 +158,90 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    urlBuilder_.Append("sum");
-                    urlBuilder_.Append('/');
+                    // Operation Path: "sum/{a}/{b}"
+                    urlBuilder_.Append("sum/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append('/');
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<int>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a)
+        {
+            return AbsoluteValueAsync(a, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a, System.Threading.CancellationToken cancellationToken)
+        {
+            if (a == null)
+                throw new System.ArgumentNullException("a");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "abs({a})"
+                    urlBuilder_.Append("abs(");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append(')');
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -376,6 +456,7 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "examples"
                     urlBuilder_.Append("examples");
 
                     PrepareRequest(client_, request_, urlBuilder_);

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -29,6 +29,9 @@ namespace MyNamespace
 
         System.Threading.Tasks.Task<int> CalculateSumAsync(int a, int b);
 
+
+        System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a);
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -54,6 +57,13 @@ namespace MyNamespace
         {
 
             return _implementation.CalculateSumAsync(a, b);
+        }
+
+        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("abs({a})")]
+        public System.Threading.Tasks.Task<int> AbsoluteValue(int a)
+        {
+
+            return _implementation.AbsoluteValueAsync(a);
         }
 
     }

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -93,6 +93,44 @@ export class Client {
         }
         return Promise.resolve<number>(null as any);
     }
+
+    absoluteValue(a: number): Promise<number> {
+        let url_ = this.baseUrl + "/abs({a})";
+        if (a === undefined || a === null)
+            throw new Error("The parameter 'a' must be defined.");
+        url_ = url_.replace("{a}", encodeURIComponent("" + a));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processAbsoluteValue(_response);
+        });
+    }
+
+    protected processAbsoluteValue(response: Response): Promise<number> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                result200 = resultData200 !== undefined ? resultData200 : <any>null;
+    
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<number>(null as any);
+    }
 }
 
 export class ExampleClient {

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60Minimal_targetFramework=net6.0_generatesCode=False.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60Minimal_targetFramework=net6.0_generatesCode=False.verified.txt
@@ -69,6 +69,39 @@
         }
       }
     },
+    "/abs({a})": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "AbsoluteValue",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60_targetFramework=net6.0_generatesCode=False.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60_targetFramework=net6.0_generatesCode=False.verified.txt
@@ -143,6 +143,38 @@
         }
       }
     },
+    "/api/Values/ToString({id})": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToString",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -69,6 +69,39 @@
         }
       }
     },
+    "/abs({a})": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "AbsoluteValue",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70_targetFramework=net7.0_generatesCode=False.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70_targetFramework=net7.0_generatesCode=False.verified.txt
@@ -143,6 +143,38 @@
         }
       }
     },
+    "/api/Values/ToString({id})": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToString",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET60/Controllers/ValuesController.cs
+++ b/src/NSwag.Sample.NET60/Controllers/ValuesController.cs
@@ -38,6 +38,13 @@ namespace NSwag.Sample.NET60.Controllers
             return TestEnum.Foo;
         }
 
+        // GET api/values/ToString(5)
+        [HttpGet("ToString({id})")]
+        public ActionResult<string> GetToString(int id)
+        {
+            return TestEnum.Foo.ToString();
+        }
+
         // GET api/values/5
         [HttpGet("{id}/foo")]
         public ActionResult<string> GetFooBar(int id)

--- a/src/NSwag.Sample.NET60/openapi.json
+++ b/src/NSwag.Sample.NET60/openapi.json
@@ -143,6 +143,38 @@
         }
       }
     },
+    "/api/Values/ToString({id})": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToString",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET60Minimal/Program.cs
+++ b/src/NSwag.Sample.NET60Minimal/Program.cs
@@ -29,6 +29,10 @@ app.MapGet("/sum/{a}/{b}", (int a, int b) => a + b)
     .WithName("CalculateSum")
     .WithTags("Calculator");
 
+app.MapGet("/abs({a})", (int a) => Math.Abs(a))
+    .WithName("AbsoluteValue")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.UseEndpoints(x =>

--- a/src/NSwag.Sample.NET60Minimal/openapi.json
+++ b/src/NSwag.Sample.NET60Minimal/openapi.json
@@ -69,6 +69,39 @@
         }
       }
     },
+    "/abs({a})": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "AbsoluteValue",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET70/Controllers/ValuesController.cs
+++ b/src/NSwag.Sample.NET70/Controllers/ValuesController.cs
@@ -38,6 +38,13 @@ namespace NSwag.Sample.NET70.Controllers
             return TestEnum.Foo;
         }
 
+        // GET api/values/ToString(5)
+        [HttpGet("ToString({id})")]
+        public ActionResult<string> GetToString(int id)
+        {
+            return TestEnum.Foo.ToString();
+        }
+
         // GET api/values/5
         [HttpGet("{id}/foo")]
         public ActionResult<string> GetFooBar(int id)

--- a/src/NSwag.Sample.NET70/openapi.json
+++ b/src/NSwag.Sample.NET70/openapi.json
@@ -143,6 +143,38 @@
         }
       }
     },
+    "/api/Values/ToString({id})": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToString",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -79,6 +79,7 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: ""
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -157,11 +158,90 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    urlBuilder_.Append("sum");
-                    urlBuilder_.Append('/');
+                    // Operation Path: "sum/{a}/{b}"
+                    urlBuilder_.Append("sum/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append('/');
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<int>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a)
+        {
+            return AbsoluteValueAsync(a, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a, System.Threading.CancellationToken cancellationToken)
+        {
+            if (a == null)
+                throw new System.ArgumentNullException("a");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "abs({a})"
+                    urlBuilder_.Append("abs(");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append(')');
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -376,6 +456,7 @@ namespace MyNamespace
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                     if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "examples"
                     urlBuilder_.Append("examples");
 
                     PrepareRequest(client_, request_, urlBuilder_);

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsTs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsTs.gen
@@ -93,6 +93,44 @@ export class Client {
         }
         return Promise.resolve<number>(null as any);
     }
+
+    absoluteValue(a: number): Promise<number> {
+        let url_ = this.baseUrl + "/abs({a})";
+        if (a === undefined || a === null)
+            throw new Error("The parameter 'a' must be defined.");
+        url_ = url_.replace("{a}", encodeURIComponent("" + a));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processAbsoluteValue(_response);
+        });
+    }
+
+    protected processAbsoluteValue(response: Response): Promise<number> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                result200 = resultData200 !== undefined ? resultData200 : <any>null;
+    
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<number>(null as any);
+    }
 }
 
 export class ExampleClient {

--- a/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
@@ -29,6 +29,9 @@ namespace MyNamespace
 
         System.Threading.Tasks.Task<int> CalculateSumAsync(int a, int b);
 
+
+        System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a);
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -54,6 +57,13 @@ namespace MyNamespace
         {
 
             return _implementation.CalculateSumAsync(a, b);
+        }
+
+        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("abs({a})")]
+        public System.Threading.Tasks.Task<int> AbsoluteValue(int a)
+        {
+
+            return _implementation.AbsoluteValueAsync(a);
         }
 
     }

--- a/src/NSwag.Sample.NET70Minimal/Program.cs
+++ b/src/NSwag.Sample.NET70Minimal/Program.cs
@@ -29,6 +29,10 @@ app.MapGet("/sum/{a}/{b}", (Func<int, int, int>)((a, b) => a + b))
     .WithName("CalculateSum")
     .WithTags("Calculator");
 
+app.MapGet("/abs({a})", (Func<int, int>)(a => Math.Abs(a)))
+    .WithName("AbsoluteValue")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.UseEndpoints(x =>

--- a/src/NSwag.Sample.NET70Minimal/nswag.json
+++ b/src/NSwag.Sample.NET70Minimal/nswag.json
@@ -101,6 +101,8 @@
       "exposeJsonSerializerSettings": false,
       "clientClassAccessModifier": "public",
       "typeAccessModifier": "public",
+      "propertySetterAccessModifier": "",
+      "generateNativeRecords": false,
       "generateContractsOutput": false,
       "contractsNamespace": null,
       "contractsOutputFilePath": null,

--- a/src/NSwag.Sample.NET70Minimal/openapi.json
+++ b/src/NSwag.Sample.NET70Minimal/openapi.json
@@ -69,6 +69,39 @@
         }
       }
     },
+    "/abs({a})": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "AbsoluteValue",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET80/Controllers/ValuesController.cs
+++ b/src/NSwag.Sample.NET80/Controllers/ValuesController.cs
@@ -38,6 +38,13 @@ namespace NSwag.Sample.NET80.Controllers
             return TestEnum.Foo;
         }
 
+        // GET api/values/ToString(5)
+        [HttpGet("ToString({id})")]
+        public ActionResult<string> GetToString(int id)
+        {
+            return TestEnum.Foo.ToString();
+        }
+
         // GET api/values/5
         [HttpGet("{id}/foo")]
         public ActionResult<string> GetFooBar(int id)

--- a/src/NSwag.Sample.NET80Minimal/Program.cs
+++ b/src/NSwag.Sample.NET80Minimal/Program.cs
@@ -29,6 +29,10 @@ app.MapGet("/sum/{a}/{b}", (Func<int, int, int>)((a, b) => a + b))
     .WithName("CalculateSum")
     .WithTags("Calculator");
 
+app.MapGet("/abs({a})", (Func<int, int>)(a => Math.Abs(a)))
+    .WithName("AbsoluteValue")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.MapControllers();


### PR DESCRIPTION
Improves on #4579.
Ddresses #4587.

Generated code is now:

```csharp
// Operation Path: "sum/{a}/{b}"
urlBuilder_.Append("sum/");
urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
urlBuilder_.Append('/');
urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
```

```csharp
// Operation Path: "abs({a})"
urlBuilder_.Append("abs(");
urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
urlBuilder_.Append(')');
```

Also replaces appending a single character string with appending a character and replaces string concatenation to be appending with appending of the two strings.