### PR TITLE
Use and support NET 8 SDK artifacts output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,8 @@
     <!-- reduce package size by only including english resources -->
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
 
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -37,8 +37,6 @@ public partial class Build
                 nugetVersion += "-" + VersionSuffix;
             }
 
-            ArtifactsDirectory.CreateOrCleanDirectory();
-
             // it seems to cause some headache with publishing, so let's dotnet pack only files we know are suitable
             var projects = SourceDirectory.GlobFiles("**/*.csproj")
                 .Where(x => !x.ToString().Contains("_build") &&

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -56,7 +56,7 @@ partial class Build : NukeBuild
     AbsolutePath SourceDirectory => RootDirectory / "src";
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
 
-    AbsolutePath NSwagStudioBinaries => SourceDirectory / "NSwagStudio" / "bin" / Configuration;
+    AbsolutePath NSwagStudioBinaries => ArtifactsDirectory / "bin" / "NSwagStudio" / Configuration;
     AbsolutePath NSwagNpmBinaries => SourceDirectory / "NSwag.Npm";
 
     static bool IsRunningOnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -75,7 +75,7 @@ partial class Build : NukeBuild
         }
         else
         {
-            var propsDocument = XDocument.Parse((SourceDirectory / "Directory.Build.props").ReadAllText());
+            var propsDocument = XDocument.Parse((RootDirectory / "Directory.Build.props").ReadAllText());
             versionPrefix = propsDocument.Element("Project").Element("PropertyGroup").Element("VersionPrefix").Value;
             Serilog.Log.Information("Version prefix {VersionPrefix} read from Directory.Build.props", versionPrefix);
         }
@@ -241,16 +241,15 @@ partial class Build : NukeBuild
         void CopyConsoleBinaries(AbsolutePath target)
         {
             // take just exe from X86 as other files are shared with console project
-            var consoleX86Directory = consoleX86Project.Directory / "bin" / Configuration / "net462" / "publish";
+            var consoleX86Directory = ArtifactsDirectory / "publish" / consoleX86Project.Name / Configuration;
             CopyFileToDirectory(consoleX86Directory / "NSwag.x86.exe", target / "Win");
             CopyFileToDirectory(consoleX86Directory / "NSwag.x86.exe.config", target / "Win");
 
-            CopyDirectoryRecursively(consoleProject.Directory / "bin" / Configuration / "net462" / "publish", target / "Win", DirectoryExistsPolicy.Merge);
+            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleProject.Name / Configuration, target / "Win", DirectoryExistsPolicy.Merge);
 
-            var consoleCoreDirectory = consoleCoreProject.Directory / "bin" / Configuration;
-            CopyDirectoryRecursively(consoleCoreDirectory / "net6.0" / "publish", target / "Net60");
-            CopyDirectoryRecursively(consoleCoreDirectory / "net7.0" / "publish", target / "Net70");
-            CopyDirectoryRecursively(consoleCoreDirectory / "net8.0" / "publish", target / "Net80");
+            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net6.0"), target / "Net60");
+            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net7.0"), target / "Net70");
+            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net7.0"), target / "Net80");
         }
 
         Serilog.Log.Information("Copy published Console for NSwagStudio");

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -9,6 +9,11 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <UseArtifactsOutput>false</UseArtifactsOutput>
+    <NukeExcludeConfig>true</NukeExcludeConfig>
+    <NukeExcludeDirectoryBuild>true</NukeExcludeDirectoryBuild>
+    <NukeExcludeLogs>true</NukeExcludeLogs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NSwag.Annotations/NSwag.Annotations.csproj
+++ b/src/NSwag.Annotations/NSwag.Annotations.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
+++ b/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>$(DefineConstants);AspNetOwin</DefineConstants>
   </PropertyGroup>
 

--- a/src/NSwag.AspNet.WebApi/NSwag.AspNet.WebApi.csproj
+++ b/src/NSwag.AspNet.WebApi/NSwag.AspNet.WebApi.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -4,6 +4,7 @@
     <PackageTags>Swagger Documentation AspNetCore NetCore TypeScript CodeGen</PackageTags>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
     <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Execute PopulateNuspec fairly late. -->
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);PopulateNuspec</GenerateNuspecDependsOn>
@@ -21,10 +22,6 @@
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
     <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -70,15 +70,15 @@
         <file src="..\..\assets\NuGetIcon.png" target="NuGetIcon.png" />
         <file src="build\*" target="build\" />
         <file src="buildMultiTargeting\*" target="buildMultiTargeting\" />
-        <file src="bin\$configuration$\net462\NSwag.AspNetCore.dll" target="lib\net462\" />
-        <file src="bin\$configuration$\net462\NSwag.AspNetCore.xml" target="lib\net462\" />
-        <file src="bin\$configuration$\netstandard2.0\NSwag.AspNetCore.dll" target="lib\netstandard2.0\" />
-        <file src="bin\$configuration$\netstandard2.0\NSwag.AspNetCore.xml" target="lib\netstandard2.0\" />
-        <file src="bin\$configuration$\net6.0\NSwag.AspNetCore.dll" target="lib\net6.0\" />
-        <file src="bin\$configuration$\net6.0\NSwag.AspNetCore.xml" target="lib\net6.0\" />
-        <file src="bin\$configuration$\net7.0\NSwag.AspNetCore.dll" target="lib\net7.0\" />
-        <file src="bin\$configuration$\net7.0\NSwag.AspNetCore.xml" target="lib\net7.0\" />
-        <file src="bin\$configuration$\net8.0\NSwag.AspNetCore.dll" target="lib\net8.0\" />
-        <file src="bin\$configuration$\net8.0\NSwag.AspNetCore.xml" target="lib\net8.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net462\NSwag.AspNetCore.dll" target="lib\net462\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net462\NSwag.AspNetCore.xml" target="lib\net462\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_netstandard2.0\NSwag.AspNetCore.dll" target="lib\netstandard2.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_netstandard2.0\NSwag.AspNetCore.xml" target="lib\netstandard2.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net6.0\NSwag.AspNetCore.dll" target="lib\net6.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net6.0\NSwag.AspNetCore.xml" target="lib\net6.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net7.0\NSwag.AspNetCore.dll" target="lib\net7.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net7.0\NSwag.AspNetCore.xml" target="lib\net7.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net8.0\NSwag.AspNetCore.dll" target="lib\net8.0\" />
+        <file src="..\..\artifacts\bin\NSwag.AspNetCore\$configuration$_net8.0\NSwag.AspNetCore.xml" target="lib\net8.0\" />
     </files>
 </package>

--- a/src/NSwag.CodeGeneration.CSharp/NSwag.CodeGeneration.CSharp.csproj
+++ b/src/NSwag.CodeGeneration.CSharp/NSwag.CodeGeneration.CSharp.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NSwag.CodeGeneration.TypeScript/NSwag.CodeGeneration.TypeScript.csproj
+++ b/src/NSwag.CodeGeneration.TypeScript/NSwag.CodeGeneration.TypeScript.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NSwag.CodeGeneration/NSwag.CodeGeneration.csproj
+++ b/src/NSwag.CodeGeneration/NSwag.CodeGeneration.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- obsolete usage, missing comments -->
     <NoWarn>$(NoWarn),618,1591</NoWarn>
   </PropertyGroup>

--- a/src/NSwag.Core/NSwag.Core.csproj
+++ b/src/NSwag.Core/NSwag.Core.csproj
@@ -2,12 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>NSwag</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NJsonSchema" Version="11.0.0-preview006" />
   </ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net462;netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageTags>Swagger Documentation AspNetCore</PackageTags>
     <DefineConstants>$(DefineConstants);ASPNETCORE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/NSwag.Generation.WebApi/NSwag.Generation.WebApi.csproj
+++ b/src/NSwag.Generation.WebApi/NSwag.Generation.WebApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NSwag.Generation/NSwag.Generation.csproj
+++ b/src/NSwag.Generation/NSwag.Generation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- obsolete warning -->
     <NoWarn>$(NoWarn),618</NoWarn>
   </PropertyGroup>

--- a/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
+++ b/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
@@ -22,14 +22,14 @@
     <file src="NSwag.MSBuild.props" target="buildCrossTargeting" />
     <file src="NSwag.MSBuild.props" target="buildTransitive" />
 
-    <file src="..\NSwag.Console\bin\Release\net462\*" target="tools/Win" />
-    <file src="..\NSwag.Console.x86\bin\Release\net462\NSwag.AspNetCore.Launcher.x86.exe" target="tools/Win" />
-    <file src="..\NSwag.Console.x86\bin\Release\net462\NSwag.AspNetCore.Launcher.x86.exe.config" target="tools/Win" />
-    <file src="..\NSwag.Console.x86\bin\Release\net462\NSwag.x86.exe" target="tools/Win" />
-    <file src="..\NSwag.Console.x86\bin\Release\net462\NSwag.x86.exe.config" target="tools/Win" />
+    <file src="..\..\artifacts\publish\NSwag.Console\$configuration$\*" target="tools/Win" />
+    <file src="..\..\artifacts\publish\NSwag.Console.x86\$configuration$\NSwag.AspNetCore.Launcher.x86.exe" target="tools/Win" />
+    <file src="..\..\artifacts\publish\NSwag.Console.x86\$configuration$\NSwag.AspNetCore.Launcher.x86.exe.config" target="tools/Win" />
+    <file src="..\..\artifacts\publish\NSwag.Console.x86\$configuration$\NSwag.x86.exe" target="tools/Win" />
+    <file src="..\..\artifacts\publish\NSwag.Console.x86\$configuration$\NSwag.x86.exe.config" target="tools/Win" />
 
-    <file src="..\NSwag.ConsoleCore\bin\release\net6.0\Publish\**" target="tools/Net60" />
-    <file src="..\NSwag.ConsoleCore\bin\release\net7.0\Publish\**" target="tools/Net70" />
-    <file src="..\NSwag.ConsoleCore\bin\release\net8.0\Publish\**" target="tools/Net80" />
+    <file src="..\..\artifacts\publish\NSwag.ConsoleCore\$configuration$_net6.0\**" target="tools/Net60" />
+    <file src="..\..\artifacts\publish\NSwag.ConsoleCore\$configuration$_net7.0\**" target="tools/Net70" />
+    <file src="..\..\artifacts\publish\NSwag.ConsoleCore\$configuration$_net8.0\**" target="tools/Net80" />
   </files>
 </package>

--- a/src/NSwag.sln
+++ b/src/NSwag.sln
@@ -113,9 +113,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.Sample.NETCore31", "N
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "00 Build", "00 Build", "{6F5E4FDF-0A82-42D5-94AC-A9CD43CC931D}"
 	ProjectSection(SolutionItems) = preProject
-		..\azure-pipelines.yml = ..\azure-pipelines.yml
-		Directory.Build.props = Directory.Build.props
-		..\global.json = ..\global.json
+		azure-pipelines.yml = ..\azure-pipelines.yml
+		Directory.Build.props = ..\Directory.Build.props
+		global.json = ..\global.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{AC3D8125-AE21-49FC-A217-D96C7B585FF9}"

--- a/src/NSwagStudio.Chocolatey/NSwagStudio.nuspec
+++ b/src/NSwagStudio.Chocolatey/NSwagStudio.nuspec
@@ -16,7 +16,7 @@
     <references />
   </metadata>
   <files>
-    <file src="..\NSwagStudio.Installer\bin\Release\NSwagStudio.msi" target="tools"/>
+    <file src="..\..\artifacts\bin\NSwagStudio.Installer\$configuration$\NSwagStudio.msi" target="tools"/>
 
     <file src="chocolateyInstall.ps1" target="tools"/>
     <file src="chocolateyUninstall.ps1" target="tools"/>

--- a/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
+++ b/src/NSwagStudio.Installer/NSwagStudio.Installer.wixproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <SuppressIces>ICE69</SuppressIces>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <OutputPath>..\..\artifacts\bin\NSwagStudio.Installer\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>..\..\artifacts\obj\NSwagStudio.Installer\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Generated.wxs" />
@@ -40,7 +40,7 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="Heat" AfterTargets="PreBuildEvent">
     <PropertyGroup>
-      <DefineConstants>SourcePath=..\NSwagStudio\bin\$(Configuration)</DefineConstants>
+      <DefineConstants>SourcePath=..\..\artifacts\bin\NSwagStudio\$(Configuration)</DefineConstants>
     </PropertyGroup>
     <HeatDirectory
             DirectoryRefId="RootDirectory"
@@ -51,7 +51,7 @@
             OutputFile="Generated.wxs"
             RunAsSeparateProcess="true"
             PreprocessorVariable="var.SourcePath"
-            Directory="..\NSwagStudio\bin\$(Configuration)"
+            Directory="..\..\artifacts\bin\NSwagStudio\$(Configuration)"
             ComponentGroupName="SourceComponentGroup"
             ToolPath="$(WixToolPath)" />
   </Target>


### PR DESCRIPTION
Use the new [NET 8 SDK artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) feature which consolidates `bin` and `obj` folders under artifacts directory. Need to move `Directory.Build.props` to root level for proper configuration.

To remove old cruft, might be good idea to run locally in solution root directory:

```powershell
Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }
```

This also improves the project metadata querying by trying to use the new [CLI-based metadata querying](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#cli-based-project-evaluation) , basically `obj `folder can now be anywhere and no need to give extensions path like before (for artifacts output enabled projects it would always fail). New retrieval should be faster too. If NET 8 SDK is not present, old logic will be used.