### PR TITLE
Allow customization of how values are converted to string

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -1,7 +1,7 @@
 ﻿{%              if GenerateNullableReferenceTypes -%}
-private string ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
+protected virtual string ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
 {%              else -%}
-private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+protected virtual string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
 {%              endif -%}
 {
     if (value == null)


### PR DESCRIPTION
Users can specify any type they want for dates, however currently they are at the mercy of whatever `System.Convert.ToString()` does for that type. This is particularly problematic for `DateTime` / `DateTimeOffset`, as there's no way for users to customize how the date is serialized.

This PR allows the `ConvertToString` method to be overridden in a derived class, such that users can implement custom serialization for dates in whatever format suits their use case.

#3558 
#3669 
#3684 
#3665 
#3625 