### PR TITLE
Introduce string builder factory template.

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.StringBuilder.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.StringBuilder.liquid
@@ -1,0 +1,3 @@
+private static global::System.Text.StringBuilder GetStringBuilder() => new global::System.Text.StringBuilder(8000);
+
+private partial static void ReturnStringBuilder(global::System.Text.StringBuilder sb);

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -263,9 +263,11 @@
                 request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("{{ operation.Produces }}"));
 {%     endif -%}
 
-                var urlBuilder_ = new System.Text.StringBuilder();
-                {% if UseBaseUrl %}if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);{% endif %}
-                // Operation Path: "{{ operation.Path }}"
+                string url_;
+                var urlBuilder_ = GetStringBuilder();
+                try
+                {
+                    // Operation Path: "{{ operation.Path }}"
 {%     if operation.Path contains "{" -%}
 {%        assign pathParts = operation.Path | split: "{" -%}
 {%        for pathPart in pathParts -%}
@@ -276,47 +278,47 @@
 {%                    if parameter.Name == pathParameterParts[0] -%}
 {%                        if parameter.IsOptional -%}
 {%                            assign pathParameterFound = false -%}
-        if ({{ parameter.VariableName }} != null)
-        {
-            {% template Client.Class.PathParameter %}
-        }
-        else
-            if (urlBuilder_.Length > 0) urlBuilder_.Length--;
+                    if ({{ parameter.VariableName }} != null)
+                    {
+                        {% template Client.Class.PathParameter %}
+                    }
+                    else
+                        if (urlBuilder_.Length > 0) urlBuilder_.Length--;
 {%                        else -%}
-                {% template Client.Class.PathParameter %}
+                            {% template Client.Class.PathParameter %}
 {%                        endif -%}
 {%                    endif -%}
 {%                endfor -%}
 {%                comment -%} >>> just in case {% endcomment -%}
 {%                unless pathParameterFound -%}
-                urlBuilder_.Append("{{ '{' }}{{ pathParameterParts[0] }}{{ '}' }}");
+                    urlBuilder_.Append("{{ '{' }}{{ pathParameterParts[0] }}{{ '}' }}");
 {%                endunless -%}
 {%                comment -%} <<< just in case {% endcomment -%}
 {%                assign nonParameterPartLengh = pathParameterParts[1] | size -%}
 {%                if nonParameterPartLengh == 1 -%}
-                urlBuilder_.Append('{{ pathParameterParts[1] }}');
+                    urlBuilder_.Append('{{ pathParameterParts[1] }}');
 {%                elsif nonParameterPartLengh > 0 -%}
-                urlBuilder_.Append("{{ pathParameterParts[1] }}");
+                    urlBuilder_.Append("{{ pathParameterParts[1] }}");
 {%                endif -%}
 {%            else -%}
 {%                 unless pathPart == "" -%}
-                urlBuilder_.Append("{{ pathPart }}");
+                    urlBuilder_.Append("{{ pathPart }}");
 {%                 endunless -%}
 {%            endif -%}
 {%        endfor -%}
 {%    else -%}
 {%        unless operation.Path == "" -%}
-                urlBuilder_.Append("{{ operation.Path }}");
+                    urlBuilder_.Append("{{ operation.Path }}");
 {%        endunless -%}
 {%    endif -%}
 {%     if operation.HasQueryParameters -%}
-        urlBuilder_.Append('?');
+                    urlBuilder_.Append('?');
 {%         for parameter in operation.QueryParameters -%}
 {%             if parameter.IsOptional -%}
-        if ({{ parameter.VariableName }} != null)
-        {
-            {% template Client.Class.QueryParameter %}
-        }
+                    if ({{ parameter.VariableName }} != null)
+                    {
+                        {% template Client.Class.QueryParameter %}
+                    }
 {%             else -%}
         {% template Client.Class.QueryParameter %}
 {%             endif -%}
@@ -325,12 +327,18 @@
 {%     endif -%}
 
 {% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods %}
-                await PrepareRequestAsync(client_, request_, urlBuilder_, cancellationToken).ConfigureAwait(false);
+                    await PrepareRequestAsync(client_, request_, urlBuilder_, cancellationToken).ConfigureAwait(false);
 {% else -%}
-                PrepareRequest(client_, request_, urlBuilder_);
+                    PrepareRequest(client_, request_, urlBuilder_);
 {% endif -%}
 
-                var url_ = urlBuilder_.ToString();
+                    url_ = urlBuilder_.ToString();
+                }
+                finally
+                {
+                    ReturnStringBuilder(urlBuilder_);
+                }
+
                 request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
 {% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods -%}
@@ -448,4 +456,6 @@
 
     {% template Client.Class.ConvertToString %}
     {% template Client.Class.Body %}
+
+    {% template Client.Class.StringBuilder %}
 }

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -77,13 +77,21 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: ""
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: ""
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -158,17 +166,25 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "sum/{a}/{b}"
-                    urlBuilder_.Append("sum/");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append('/');
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "sum/{a}/{b}"
+                        urlBuilder_.Append("sum/");
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                        urlBuilder_.Append('/');
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -240,16 +256,24 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "abs({a})"
-                    urlBuilder_.Append("abs(");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append(')');
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "abs({a})"
+                        urlBuilder_.Append("abs(");
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                        urlBuilder_.Append(')');
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -258,7 +282,9 @@ namespace MyNamespace
                     var disposeResponse_ = true;
                     try
                     {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
                         if (response_.Content != null && response_.Content.Headers != null)
                         {
                             foreach (var item_ in response_.Content.Headers)
@@ -407,6 +433,10 @@ namespace MyNamespace
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
+
+        private static global::System.Text.StringBuilder GetStringBuilder() => new global::System.Text.StringBuilder(8000);
+
+        private partial static void ReturnStringBuilder(global::System.Text.StringBuilder sb);
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -467,14 +497,22 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "examples"
-                    urlBuilder_.Append("examples");
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "examples"
+                        urlBuilder_.Append("examples");
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -632,6 +670,10 @@ namespace MyNamespace
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
+
+        private static global::System.Text.StringBuilder GetStringBuilder() => new global::System.Text.StringBuilder(8000);
+
+        private partial static void ReturnStringBuilder(global::System.Text.StringBuilder sb);
     }
 
     

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -77,13 +77,21 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: ""
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: ""
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -158,17 +166,25 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "sum/{a}/{b}"
-                    urlBuilder_.Append("sum/");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append('/');
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "sum/{a}/{b}"
+                        urlBuilder_.Append("sum/");
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                        urlBuilder_.Append('/');
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(b, System.Globalization.CultureInfo.InvariantCulture)));
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -240,16 +256,24 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "abs({a})"
-                    urlBuilder_.Append("abs(");
-                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
-                    urlBuilder_.Append(')');
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "abs({a})"
+                        urlBuilder_.Append("abs(");
+                                urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(a, System.Globalization.CultureInfo.InvariantCulture)));
+                        urlBuilder_.Append(')');
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -258,7 +282,9 @@ namespace MyNamespace
                     var disposeResponse_ = true;
                     try
                     {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
                         if (response_.Content != null && response_.Content.Headers != null)
                         {
                             foreach (var item_ in response_.Content.Headers)
@@ -407,6 +433,10 @@ namespace MyNamespace
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
+
+        private static global::System.Text.StringBuilder GetStringBuilder() => new global::System.Text.StringBuilder(8000);
+
+        private partial static void ReturnStringBuilder(global::System.Text.StringBuilder sb);
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -467,14 +497,22 @@ namespace MyNamespace
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/octet-stream"));
 
-                    var urlBuilder_ = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
-                    // Operation Path: "examples"
-                    urlBuilder_.Append("examples");
+                    string url_;
+                    var urlBuilder_ = GetStringBuilder();
+                    try
+                    {
+                        // Operation Path: "examples"
+                        urlBuilder_.Append("examples");
 
-                    PrepareRequest(client_, request_, urlBuilder_);
+                        PrepareRequest(client_, request_, urlBuilder_);
 
-                    var url_ = urlBuilder_.ToString();
+                        url_ = urlBuilder_.ToString();
+                    }
+                    finally
+                    {
+                        ReturnStringBuilder(urlBuilder_);
+                    }
+
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);
@@ -632,6 +670,10 @@ namespace MyNamespace
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
+
+        private static global::System.Text.StringBuilder GetStringBuilder() => new global::System.Text.StringBuilder(8000);
+
+        private partial static void ReturnStringBuilder(global::System.Text.StringBuilder sb);
     }
 
     


### PR DESCRIPTION
With this PR, the creation of the `StringBuilder` for building operation URLs is moved to the **Client.Class.StringBuilder.liquid** template.

This allows the user to replace it with a template that uses, for example, a [`StringBuilder` pool](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.objectpool.objectpoolproviderextensions.createstringbuilderpool).