### PR TITLE
Added .NET 8 runtime target to nswag.cmd

### DIFF
--- a/src/NSwagStudio/nswag.cmd
+++ b/src/NSwagStudio/nswag.cmd
@@ -16,5 +16,10 @@ IF NOT "%args:/runtime:net70=%" == "%args%" (
     GOTO end
 )
 
+IF NOT "%args:/runtime:net80=%" == "%args%" (
+    dotnet "%~dp0/Net80/dotnet-nswag.dll" %*
+    GOTO end
+)
+
 "%~dp0/Win/nswag.exe" %*
 :end


### PR DESCRIPTION
I noticed that for .NET 8 there is no target in nswag.smd