### PR TITLE
Added tests for "id:{id}" patterns.

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -3,7 +3,9 @@
 {{ ClientClassAccessModifier }} partial class {{ Class }} {% if HasBaseType %}: {% endif %}{% if HasBaseClass %}{{ BaseClass }}{% if GenerateClientInterfaces %}, {% endif %}{% endif %}{% if GenerateClientInterfaces %}I{{ Class }}{% endif %}
 {
 {% if UseBaseUrl and GenerateBaseUrlProperty -%}
+#pragma warning disable 8618 // Set by constructor via BaseUrl property
     private string _baseUrl;
+#pragma restore disable 8618 // Set by constructor via BaseUrl property
 {% endif -%}
 {% if InjectHttpClient -%}
     private {{ HttpClientType }} _httpClient;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -22,7 +22,9 @@ namespace MyNamespace
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class Client 
     {
+    #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
+    #pragma restore disable 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -299,6 +301,86 @@ namespace MyNamespace
             }
         }
 
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<int> IdentityAsync(int id)
+        {
+            return IdentityAsync(id, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<int> IdentityAsync(int id, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "id:{id}"
+                    urlBuilder_.Append("id:");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<int>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -414,7 +496,9 @@ namespace MyNamespace
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class ExampleClient 
     {
+    #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
+    #pragma restore disable 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -32,6 +32,9 @@ namespace MyNamespace
 
         System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a);
 
+
+        System.Threading.Tasks.Task<int> IdentityAsync(int id);
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -64,6 +67,13 @@ namespace MyNamespace
         {
 
             return _implementation.AbsoluteValueAsync(a);
+        }
+
+        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("id:{id}")]
+        public System.Threading.Tasks.Task<int> Identity(int id)
+        {
+
+            return _implementation.IdentityAsync(id);
         }
 
     }

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -131,6 +131,44 @@ export class Client {
         }
         return Promise.resolve<number>(null as any);
     }
+
+    identity(id: number): Promise<number> {
+        let url_ = this.baseUrl + "/id:{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processIdentity(_response);
+        });
+    }
+
+    protected processIdentity(response: Response): Promise<number> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                result200 = resultData200 !== undefined ? resultData200 : <any>null;
+    
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<number>(null as any);
+    }
 }
 
 export class ExampleClient {

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60Minimal_targetFramework=net6.0_generatesCode=False.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET60Minimal_targetFramework=net6.0_generatesCode=False.verified.txt
@@ -102,6 +102,39 @@
         }
       }
     },
+    "/id:{id}": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "Identity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -102,6 +102,39 @@
         }
       }
     },
+    "/id:{id}": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "Identity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70_targetFramework=net7.0_generatesCode=False.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.Should_generate_openapi_for_project_projectName=NSwag.Sample.NET70_targetFramework=net7.0_generatesCode=False.verified.txt
@@ -175,6 +175,38 @@
         }
       }
     },
+    "/api/Values/id:{id}": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToId",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET60Minimal/Program.cs
+++ b/src/NSwag.Sample.NET60Minimal/Program.cs
@@ -33,6 +33,10 @@ app.MapGet("/abs({a})", (int a) => Math.Abs(a))
     .WithName("AbsoluteValue")
     .WithTags("Calculator");
 
+app.MapGet("/id:{id}", (int id) =>id)
+    .WithName("Identity")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.UseEndpoints(x =>

--- a/src/NSwag.Sample.NET60Minimal/openapi.json
+++ b/src/NSwag.Sample.NET60Minimal/openapi.json
@@ -102,6 +102,39 @@
         }
       }
     },
+    "/id:{id}": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "Identity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET70/Controllers/ValuesController.cs
+++ b/src/NSwag.Sample.NET70/Controllers/ValuesController.cs
@@ -45,6 +45,13 @@ namespace NSwag.Sample.NET70.Controllers
             return TestEnum.Foo.ToString();
         }
 
+        // GET api/values/id:5
+        [HttpGet("id:{id}")]
+        public ActionResult<string> GetToId(int id)
+        {
+            return TestEnum.Foo.ToString();
+        }
+
         // GET api/values/5
         [HttpGet("{id}/foo")]
         public ActionResult<string> GetFooBar(int id)

--- a/src/NSwag.Sample.NET70/openapi.json
+++ b/src/NSwag.Sample.NET70/openapi.json
@@ -175,6 +175,38 @@
         }
       }
     },
+    "/api/Values/id:{id}": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Values_GetToId",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Values/{id}/foo": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -22,7 +22,9 @@ namespace MyNamespace
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class Client 
     {
+    #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
+    #pragma restore disable 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -299,6 +301,86 @@ namespace MyNamespace
             }
         }
 
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<int> IdentityAsync(int id)
+        {
+            return IdentityAsync(id, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<int> IdentityAsync(int id, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+                    // Operation Path: "id:{id}"
+                    urlBuilder_.Append("id:");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<int>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -414,7 +496,9 @@ namespace MyNamespace
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class ExampleClient 
     {
+    #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
+    #pragma restore disable 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsTs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsTs.gen
@@ -131,6 +131,44 @@ export class Client {
         }
         return Promise.resolve<number>(null as any);
     }
+
+    identity(id: number): Promise<number> {
+        let url_ = this.baseUrl + "/id:{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processIdentity(_response);
+        });
+    }
+
+    protected processIdentity(response: Response): Promise<number> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+                result200 = resultData200 !== undefined ? resultData200 : <any>null;
+    
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<number>(null as any);
+    }
 }
 
 export class ExampleClient {

--- a/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
@@ -32,6 +32,9 @@ namespace MyNamespace
 
         System.Threading.Tasks.Task<int> AbsoluteValueAsync(int a);
 
+
+        System.Threading.Tasks.Task<int> IdentityAsync(int id);
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -64,6 +67,13 @@ namespace MyNamespace
         {
 
             return _implementation.AbsoluteValueAsync(a);
+        }
+
+        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("id:{id}")]
+        public System.Threading.Tasks.Task<int> Identity(int id)
+        {
+
+            return _implementation.IdentityAsync(id);
         }
 
     }

--- a/src/NSwag.Sample.NET70Minimal/Program.cs
+++ b/src/NSwag.Sample.NET70Minimal/Program.cs
@@ -33,6 +33,10 @@ app.MapGet("/abs({a})", (Func<int, int>)(a => Math.Abs(a)))
     .WithName("AbsoluteValue")
     .WithTags("Calculator");
 
+app.MapGet("/id:{id}", (int id) => id)
+    .WithName("Identity")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.UseEndpoints(x =>

--- a/src/NSwag.Sample.NET70Minimal/openapi.json
+++ b/src/NSwag.Sample.NET70Minimal/openapi.json
@@ -102,6 +102,39 @@
         }
       }
     },
+    "/id:{id}": {
+      "get": {
+        "tags": [
+          "Calculator"
+        ],
+        "operationId": "Identity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/examples": {
       "get": {
         "tags": [

--- a/src/NSwag.Sample.NET80/Controllers/ValuesController.cs
+++ b/src/NSwag.Sample.NET80/Controllers/ValuesController.cs
@@ -45,6 +45,13 @@ namespace NSwag.Sample.NET80.Controllers
             return TestEnum.Foo.ToString();
         }
 
+        // GET api/values/id:5
+        [HttpGet("id:{id}")]
+        public ActionResult<string> GetToId(int id)
+        {
+            return TestEnum.Foo.ToString();
+        }
+
         // GET api/values/5
         [HttpGet("{id}/foo")]
         public ActionResult<string> GetFooBar(int id)

--- a/src/NSwag.Sample.NET80Minimal/Program.cs
+++ b/src/NSwag.Sample.NET80Minimal/Program.cs
@@ -33,6 +33,10 @@ app.MapGet("/abs({a})", (Func<int, int>)(a => Math.Abs(a)))
     .WithName("AbsoluteValue")
     .WithTags("Calculator");
 
+app.MapGet("/id:{id}", (int id) => id)
+    .WithName("Identity")
+    .WithTags("Calculator");
+
 // Optional: Use controllers
 app.UseRouting();
 app.MapControllers();


### PR DESCRIPTION
Addresses concerns in #4620.

Added disabling CS8618 for the declaration of the `_baseUrl` field as it is set via the `BaseUrl` property.

```csharp
#pragma warning disable 8618 // Set by constructor via BaseUrl property
    private string _baseUrl;
#pragma restore disable 8618 // Set by constructor via BaseUrl property
```