### PR TITLE
Remove NuGet dependencies version upper limits

### DIFF
--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -13,12 +13,12 @@
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.6</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.4</MicrosoftAspNetCoreStaticFilesPackageVersion>
     <MicrosoftExtensionsApiDescriptionServerPackageVersion>6.0.3</MicrosoftExtensionsApiDescriptionServerPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>[1.0.1, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>[3.1, 4.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>[5, 6.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>[6.0.0, 7.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet7>[7.0.0, 8.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet7>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>[8.0.0, 9.0)</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>3.1.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionCore31>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>5.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet5>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>6.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet6>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet7>7.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet7>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>8.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>
     <NETStandardLibraryPackageVersion>1.6.1</NETStandardLibraryPackageVersion>
     <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
     <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -30,10 +30,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="[2.1.7, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.1.1, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.1.3, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.1.18, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -14,14 +14,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6, 8)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[6, 8)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[7, 8)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[7, 8)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
Some packages have upper version limits on some of the dependencies which result in [NU1608](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1608) warnings.

Since this does not prevent the usage of upper version packages, this PR removes that limitation.

Closes #4638