### PR TITLE
Disable warning CS8625 "Cannot convert null literal to non-nullable reference type." in generated code

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
@@ -8,4 +8,4 @@
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
-#pragma warning disable 8625
+#pragma warning restore 8625

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Footer.liquid
@@ -8,3 +8,4 @@
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
+#pragma warning disable 8625

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
@@ -8,3 +8,4 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type."

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.Header.liquid
@@ -8,4 +8,4 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
-#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type."
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type"

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -14,6 +14,7 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type"
 
 namespace MyNamespace
 {
@@ -806,3 +807,4 @@ namespace MyNamespace
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
+#pragma warning restore 8625

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -14,6 +14,7 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type"
 
 namespace MyNamespace
 {
@@ -158,3 +159,4 @@ namespace MyNamespace
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
+#pragma warning restore 8625

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -14,6 +14,7 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type"
 
 namespace MyNamespace
 {
@@ -806,3 +807,4 @@ namespace MyNamespace
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
+#pragma warning restore 8625

--- a/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedControllersCs.gen
@@ -14,6 +14,7 @@
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 #pragma warning disable 8603 // Disable "CS8603 Possible null reference return"
 #pragma warning disable 8604 // Disable "CS8604 Possible null reference argument for parameter"
+#pragma warning disable 8625 // Disable "CS8625 Cannot convert null literal to non-nullable reference type"
 
 namespace MyNamespace
 {
@@ -158,3 +159,4 @@ namespace MyNamespace
 #pragma warning restore 3016
 #pragma warning restore 8603
 #pragma warning restore 8604
+#pragma warning restore 8625


### PR DESCRIPTION
Similar to https://github.com/RicoSuter/NSwag/pull/4422/files but for warning CS8625.

![image](https://github.com/RicoSuter/NSwag/assets/26460692/e18b4ba4-ecf6-4d99-bf17-ee2f4315e971)
