### PR TITLE
🐛 Fix generated C# clients using base URL

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -5,7 +5,7 @@
 {% if UseBaseUrl and GenerateBaseUrlProperty -%}
 #pragma warning disable 8618 // Set by constructor via BaseUrl property
     private string _baseUrl;
-#pragma restore disable 8618 // Set by constructor via BaseUrl property
+#pragma warning restore 8618 // Set by constructor via BaseUrl property
 {% endif -%}
 {% if InjectHttpClient -%}
     private {{ HttpClientType }} _httpClient;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -24,7 +24,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -498,7 +498,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -24,7 +24,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -498,7 +498,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 


### PR DESCRIPTION
I do believe that the following PR introduced a typo in the #pragma directive.
https://github.com/RicoSuter/NSwag/pull/4634/files#diff-65b33706483249f53a8138451372e3d3276b904d815dcb71d0ed0c8786ea2e70R8

I think it slipped through testing because it only concerns generated C# clients generated using the UseBaseUrl=true option.

When trying to generate my client with this option enabled (unfortunately, I can't do without it), I'm getting the following compiler error on the `#pragma restore disable 8618` line: `error CS1633: Unrecognized #pragma directive`.

I'm by no means an expert on these directives, but I do believe that the correct syntax is `#pragma warning restore 8618`.

This PR should fix the issue, introduced in NSwag 14.0.0.

Fixes: https://github.com/RicoSuter/NSwag/issues/4673