### PR TITLE
Correct incorrect pragma usage for restoring 8618

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -5,7 +5,7 @@
 {% if UseBaseUrl and GenerateBaseUrlProperty -%}
 #pragma warning disable 8618 // Set by constructor via BaseUrl property
     private string _baseUrl;
-#pragma restore disable 8618 // Set by constructor via BaseUrl property
+#pragma warning restore 8618 // Set by constructor via BaseUrl property
 {% endif -%}
 {% if InjectHttpClient -%}
     private {{ HttpClientType }} _httpClient;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -24,7 +24,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -498,7 +498,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -24,7 +24,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 
@@ -498,7 +498,7 @@ namespace MyNamespace
     {
     #pragma warning disable 8618 // Set by constructor via BaseUrl property
         private string _baseUrl;
-    #pragma restore disable 8618 // Set by constructor via BaseUrl property
+    #pragma warning restore 8618 // Set by constructor via BaseUrl property
         private System.Net.Http.HttpClient _httpClient;
         private static System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings, true);
 


### PR DESCRIPTION
Fixes compilation warning "Unrecognized #pragma directive"
