### PR TITLE
build: fix .net8 target while publishing artifacts

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -249,7 +249,7 @@ partial class Build : NukeBuild
 
             CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net6.0"), target / "Net60");
             CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net7.0"), target / "Net70");
-            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net7.0"), target / "Net80");
+            CopyDirectoryRecursively(ArtifactsDirectory / "publish" / consoleCoreProject.Name / (Configuration + "_net8.0"), target / "Net80");
         }
 
         Serilog.Log.Information("Copy published Console for NSwagStudio");

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- obsolete usage, missing comments -->
     <NoWarn>$(NoWarn),618,1591</NoWarn>


### PR DESCRIPTION
Seems like there is a bug (typo) and therefore the artifacts are copied into a different place