### PR TITLE
PropertyNameGenerator: add passing and failing tests demonstrating issue with CodeGeneration

### DIFF
--- a/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -51,8 +51,6 @@ namespace NSwag.CodeGeneration.Tests
             var generator = new CSharpClientGenerator(document, settings);
             var code = generator.GenerateFile();
 
-            // System.IO.File.WriteAllText("/Users/jreilly/code/github.com/NSwag/src/NSwag.CodeGeneration.Tests/test.cs", code);
-
             // Assert
             Assert.Contains("public string XX_Street { get; set; }", code);
             Assert.Contains("public string XX_City { get; set; }", code);

--- a/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -38,6 +38,34 @@ namespace NSwag.CodeGeneration.Tests
         }
 
         [Fact]
+        public void When_generating_CSharp_code_with_custom_PropertyNameGenerator_then_output_contains_expected_property_names()
+        {
+            // Arrange
+            var document = CreateDocument();
+
+            // Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            settings.CSharpGeneratorSettings.Namespace = "MyNamespace";
+            settings.CSharpGeneratorSettings.PropertyNameGenerator = new CustomPropertyNameGenerator();
+
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // System.IO.File.WriteAllText("/Users/jreilly/code/github.com/NSwag/src/NSwag.CodeGeneration.Tests/test.cs", code);
+
+            // Assert
+            Assert.Contains("public string XX_Street { get; set; }", code);
+            Assert.Contains("public string XX_City { get; set; }", code);
+            Assert.Contains("public string XX_FirstName { get; set; }", code);
+            Assert.Contains("public System.DateTimeOffset? XX_Birthday { get; set; }", code);
+            Assert.Contains("public Address XX_Address { get; set; }", code);
+        }
+
+        class CustomPropertyNameGenerator : NJsonSchema.CodeGeneration.IPropertyNameGenerator {
+            public virtual string Generate(JsonSchemaProperty property) => $"XX_{property.Name}";
+        }
+
+        [Fact]
         public void When_generating_CSharp_code_with_SystemTextJson_then_output_contains_expected_code()
         {
             // Arrange
@@ -174,6 +202,35 @@ public static Person FromJson(string data)
             Assert.Contains("export interface Person", code);
             Assert.Contains("export interface Address", code);
         }
+
+        [Theory(DisplayName = "Ensure expected property name generation on TypeScript clients when custom PropertyNameGenerator")]
+        [InlineData(TypeScriptTypeStyle.Class)]
+        [InlineData(TypeScriptTypeStyle.Interface)]
+        public void When_generating_TypeScript_code_with_custom_PropertyNameGenerator_then_output_contains_expected_property_names(TypeScriptTypeStyle typeStyle)
+        {
+            // Arrange
+            var document = CreateDocument();
+
+            // Act
+            var settings = new TypeScriptClientGeneratorSettings
+            {
+                TypeScriptGeneratorSettings =
+                {
+                    TypeStyle = typeStyle,
+                    PropertyNameGenerator = new CustomPropertyNameGenerator(),
+                }
+            };
+
+            var generator = new TypeScriptClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("XX_Street?: string | undefined;", code);
+            Assert.Contains("XX_City?: string | undefined;", code);
+            Assert.Contains("XX_FirstName: string;", code);
+            Assert.Contains("XX_Birthday?: Date | undefined;", code);
+            Assert.Contains("XX_Address?: Address | undefined;", code);
+        }        
 
         [Fact]
         public async Task When_using_json_schema_with_references_in_service_then_references_are_correctly_resolved()


### PR DESCRIPTION
As mentioned here: https://github.com/RicoSuter/NSwag/issues/1874#issuecomment-1890400894

I've identified an issue with the TypeScript code generation of clients when using the `PropertyNameGenerator` property to control naming.

Essentially, when using `TypeScriptTypeStyle.Class` this is respected.  When using `TypeScriptTypeStyle.Interface` it is ignored.  This is illustrated by the enclosing tests, one of which fails; demonstrating the issue.

I'd love to help get this fixed and I figured this was a first step!

I've also added a C# test as well as I thought it'd be useful for coverage.

With the following `CustomPropertyNameGenerator` we can demostrate the issue.

```cs
        class CustomPropertyNameGenerator : NJsonSchema.CodeGeneration.IPropertyNameGenerator {
            public virtual string Generate(JsonSchemaProperty property) => $"XX_{property.Name}";
        }
```

If this is working as expected, all property names should be prefixed with `XX_`:

```ts
export interface IPerson {
    XX_FirstName: string;
    XX_LastName?: string | undefined;
    XX_Birthday?: Date | undefined;
    XX_Sex?: Sex | undefined;
    XX_Address?: Address | undefined;
}
```

But if using `TypeScriptTypeStyle.Interface` it is ignored and instead this is generated:

```ts
export interface Person {
    FirstName: string;
    LastName?: string | undefined;
    Birthday?: Date | undefined;
    Sex?: Sex | undefined;
    Address?: Address | undefined;
}
```

Ideally the `CustomPropertyNameGenerator` should always be in play.

----

Having had a dig through the code I wonder if the issue lies in NJsonSchema somewhere:

https://github.com/RicoSuter/NJsonSchema/blob/master/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
https://github.com/RicoSuter/NJsonSchema/blob/3585d60e949e43284601e0bea16c33de4c6c21f5/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptGeneratorSettings.cs#L36