### PR TITLE
Update transitive Microsoft.AspNetCore dependencies in NSwag.Commands…

### DIFF
--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -31,6 +31,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.AspNetCore" Version="[2.1.7, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.1.34, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.1.25, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="[2.1.40, 2.2)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.1.1, 2.2)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.1.3, 2.2)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.1.18, 2.2)" />


### PR DESCRIPTION
… to fix reported security vulnerabilities

refs #2824 

Mend / Whitesource is complaining about libraries included in NSwag,MSBuild, but actually current Visual Studio versions will display warnings themselves in the package manager:
![image](https://github.com/RicoSuter/NSwag/assets/1178570/15fa102d-01de-46ef-814b-8996130df92a)
