### PR TITLE
Made GenerateControllerName virtual

### DIFF
--- a/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBaseSettings.cs
@@ -69,7 +69,7 @@ namespace NSwag.CodeGeneration
         /// <summary>Generates the name of the controller based on the provided settings.</summary>
         /// <param name="controllerName">Name of the controller.</param>
         /// <returns>The controller name.</returns>
-        public string GenerateControllerName(string controllerName)
+        public virtual string GenerateControllerName(string controllerName)
         {
             return ClassName.Replace("{controller}", ConversionUtilities.ConvertToUpperCamelCase(controllerName, false));
         }


### PR DESCRIPTION
This should allow consumers to implement this method with eg some additional validations/replacements or by using Roslyn nuget pacakges. In the future it could also allow to fix issue #4719 in CSharpClientGeneratorSettings