### PR TITLE
Enhance support for $ref in requestBody of endpoint

### DIFF
--- a/src/NSwag.Core/OpenApiOperation.cs
+++ b/src/NSwag.Core/OpenApiOperation.cs
@@ -292,12 +292,12 @@ namespace NSwag
         private void UpdateBodyParameter(OpenApiParameter parameter)
         {
             parameter.Kind = OpenApiParameterKind.Body;
-            parameter.Name = RequestBody.ActualName;
-            parameter.Position = RequestBody.Position;
-            parameter.Description = RequestBody.Description;
-            parameter.IsRequired = RequestBody.IsRequired;
-            parameter.Example = RequestBody.Content.FirstOrDefault().Value?.Example;
-            parameter.Schema = RequestBody.Content.FirstOrDefault().Value?.Schema;
+            parameter.Name = RequestBody.ActualRequestBody.ActualName;
+            parameter.Position = RequestBody.ActualRequestBody.Position;
+            parameter.Description = RequestBody.ActualRequestBody.Description;
+            parameter.IsRequired = RequestBody.ActualRequestBody.IsRequired;
+            parameter.Example = RequestBody.ActualRequestBody.Content.FirstOrDefault().Value?.Example;
+            parameter.Schema = RequestBody.ActualRequestBody.Content.FirstOrDefault().Value?.Schema;
         }
 
         private void UpdateRequestBody(NotifyCollectionChangedEventArgs args)

--- a/src/NSwag.Core/OpenApiRequestBody.cs
+++ b/src/NSwag.Core/OpenApiRequestBody.cs
@@ -111,5 +111,16 @@ namespace NSwag
         object IJsonReference.PossibleRoot => ParentOperation?.Parent?.Parent;
 
         #endregion
+
+        /// <summary>Gets or sets the referenced object.</summary>
+        public override OpenApiRequestBody Reference
+        {
+            get => base.Reference;
+            set
+            {
+                base.Reference = value;
+                (Parent as OpenApiOperation)?.UpdateBodyParameter();
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request enhances support for the `$ref` keyword in  request bodies. Given the following oas endpoint:
```
/end-point-uri:
    post:
      tags:
        - SomeTag
      summary: Search for something with a request body
      description: |
       Search something with a request body that is defined as a reference
      operationId: PostSearchSomething
      parameters:
        - $ref: '#/components/parameters/CorrelationId'
        - $ref: '#/components/parameters/ReferenceDate'
      requestBody:
        $ref: '#/components/requestBodies/PostSearchSomethingRequest'
```

The generator would generate the following function `PostSearchSomethingRequestAsync(object body)` with the supplied change it will generate `PostSearchSomethingRequestAsync(PostSearchSomethingRequest body)`.

Fixes #4093 as well I think