### PR TITLE
Apply ParameterDateFormat to date in header as well

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.HeaderParameter.liquid
@@ -1,7 +1,9 @@
 {% if parameter.IsStringArray -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
 {% elsif parameter.IsDateTime -%}
-request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}{% if parameter.IsNullable %}?{% endif %}.ToString("{{ ParameterDateTimeFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
+request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}{% if parameter.IsNullable or parameter.IsSystemNullable %}?{% endif %}.ToString("{{ ParameterDateTimeFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
+{% elsif parameter.IsDate -%}
+request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}{% if parameter.IsNullable or parameter.IsSystemNullable %}?{% endif %}.ToString("{{ ParameterDateFormat }}"), System.Globalization.CultureInfo.InvariantCulture));
 {% else -%}
 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
 {%- endif %}


### PR DESCRIPTION
Given the following parameter:
```
ReferenceDate:
  description: |
    A query date provided by the calling system. If non supplied the current system date will be used
  name: X-Reference-Date
  in: header
  schema:
    type: string
    format: date
  example: "2022-04-23"
```
The generated code would be:
```
if (x_Reference_Date != null)
    request_.Headers.TryAddWithoutValidation("X-Reference-Date", ConvertToString(x_Reference_Date, System.Globalization.CultureInfo.InvariantCulture));
```
In this case the date is passed as a full date including the timestamp in the US format. This causes the request to be rejected. 

The pull requests adds a check for `IsDate` in the same way it exists for query parameters. In addition a check for `IsSystemNullable` is added. The type for the parameter generated in the function call is `System.DateTimeOffset? x_Reference_Date`. Without the check the generated code does not generate the `?.ToString(` with the null-conditional oprator causing a compile error.