### PR TITLE
Only generate MemberNotNull if NET_5_0_OR_GREATER

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -85,7 +85,9 @@
     public string BaseUrl
     {
         get { return _baseUrl; }
+        #if NET5_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+        #endif
         set
         {
             _baseUrl = value;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -46,7 +46,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;
@@ -522,7 +524,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -46,7 +46,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;
@@ -522,7 +524,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -46,7 +46,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;
@@ -522,7 +524,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;

--- a/src/NSwag.Sample.NET80Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET80Minimal/GeneratedClientsCs.gen
@@ -46,7 +46,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;
@@ -522,7 +524,9 @@ namespace MyNamespace
         public string BaseUrl
         {
             get { return _baseUrl; }
+            #if NET5_0_OR_GREATER
             [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_baseUrl))]
+            #endif
             set
             {
                 _baseUrl = value;


### PR DESCRIPTION
With this change, .net standard will still produce CS8618, but will at least not fail.

The warning will need to be suppressed by other means.