### PR TITLE
Fix NSwag.ApiDescription.Client.targets

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -19,7 +19,7 @@
         <Command>$(_NSwagCommand) openapi2csclient /className:%(ClassName) /namespace:%(Namespace)</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
-        <Command Condition="!%(FirstForGenerator) OR !%(NSwagGenerateExceptionClasses)">%(Command) /GenerateExceptionClasses:false</Command>
+        <Command Condition="!%(FirstForGenerator) OR (%(NSwagGenerateExceptionClasses) != '' AND !%(NSwagGenerateExceptionClasses))">%(Command) /GenerateExceptionClasses:false</Command>
       </CurrentOpenApiReference>
       <CurrentOpenApiReference>
         <Command>%(Command) /input:"%(FullPath)" /output:"%(OutputPath)" %(Options)</Command>


### PR DESCRIPTION
Condition expression evaluation resulted in error when NSwagGenerateExceptionClasses is not defined.
Fixes #4633