### PR TITLE
Fix build error, because it referenced a non existent variable

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/JsonExceptionConverter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/JsonExceptionConverter.liquid
@@ -161,7 +161,7 @@ internal class JsonExceptionConverter : Newtonsoft.Json.JsonConverter
             var jsonPropertyName = resolver is Newtonsoft.Json.Serialization.DefaultContractResolver ? ((Newtonsoft.Json.Serialization.DefaultContractResolver)resolver).GetResolvedPropertyName(propertyName) : propertyName;
             foreach (var property in jObject.Properties())
             {
-                if (System.String.Equals(p.Name, jsonPropertyName, System.StringComparison.OrdinalIgnoreCase))
+                if (System.String.Equals(property.Name, jsonPropertyName, System.StringComparison.OrdinalIgnoreCase))
                 {
                     var fieldValue = property.Value.ToObject(field.FieldType, serializer);
                     field.SetValue(value, fieldValue);


### PR DESCRIPTION
The `JsonExceptionConverter.liquid` template contained a reference to the variable `p`, but this does not exists. The variable property is now being used.