### PR TITLE
Added explicit sub command for dotnet in NSwagExe

### DIFF
--- a/src/NSwag.MSBuild/NSwag.MSBuild.props
+++ b/src/NSwag.MSBuild/NSwag.MSBuild.props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <NSwagExe>"$(MSBuildThisFileDirectory)../tools/Win/NSwag.exe"</NSwagExe>
     <NSwagExe_x86>"$(MSBuildThisFileDirectory)../tools/Win/NSwag.x86.exe"</NSwagExe_x86>
-    <NSwagExe_Net60>dotnet "$(MSBuildThisFileDirectory)../tools/Net60/dotnet-nswag.dll"</NSwagExe_Net60>
-    <NSwagExe_Net70>dotnet "$(MSBuildThisFileDirectory)../tools/Net70/dotnet-nswag.dll"</NSwagExe_Net70>
-    <NSwagExe_Net80>dotnet "$(MSBuildThisFileDirectory)../tools/Net80/dotnet-nswag.dll"</NSwagExe_Net80>
+    <NSwagExe_Net60>dotnet exec "$(MSBuildThisFileDirectory)../tools/Net60/dotnet-nswag.dll"</NSwagExe_Net60>
+    <NSwagExe_Net70>dotnet exec "$(MSBuildThisFileDirectory)../tools/Net70/dotnet-nswag.dll"</NSwagExe_Net70>
+    <NSwagExe_Net80>dotnet exec "$(MSBuildThisFileDirectory)../tools/Net80/dotnet-nswag.dll"</NSwagExe_Net80>
 
     <NSwagDir>$(MSBuildThisFileDirectory)../tools/Win/</NSwagDir>
     <NSwagDir_Net60>$(MSBuildThisFileDirectory)../tools/Net60/</NSwagDir_Net60>


### PR DESCRIPTION
This PR resolves an issue where CodeQL could interpert the user intent incorrectly and accidently add invalid parameters to the NSwag execution.
 
In the following example, CodeQL would assume the `run` is the `dotnet` subcommand, but that is incorrect, its the arguments sent to NSwag.
```
<Target Name="NSwag" AfterTargets="Build">
<Exec Command="$(NSwagExe) run nswag.json /variables:Configuration=$(Configuration)" />
</Target>
```
 
This is because of how CodeQL detects the user intent, by ignoring parameters until it finds the first string that could be a subcommand, see:
https://github.com/github/codeql/blob/606a8fed0c57d1c4cad02f2c48acc3fa331d92a2/csharp/tools/tracing-config.lua#L70