### PR TITLE
Expose OpenApiOperation.Tags in OperationModelBase

### DIFF
--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -66,6 +66,9 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets the operation ID.</summary>
         public string Id => _operation.OperationId;
 
+        /// <summary>Gets the operation tags.</summary>
+        public string Tags => _operation.Tags;
+
         /// <summary>Gets or sets the HTTP path (i.e. the absolute route).</summary>
         public string Path { get; set; }
 

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -67,7 +67,7 @@ namespace NSwag.CodeGeneration.Models
         public string Id => _operation.OperationId;
 
         /// <summary>Gets the operation tags.</summary>
-        public string Tags => _operation.Tags;
+        public List<string> Tags => _operation.Tags;
 
         /// <summary>Gets or sets the HTTP path (i.e. the absolute route).</summary>
         public string Path { get; set; }


### PR DESCRIPTION
Expose OpenAPI tags in OperationModelBase to provide additional control over clients and controllers.

fixes #3607