### PR TITLE
Fix: Wrong use of extended parameter when parameter is an keyword

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/QueryParameterTests.cs
@@ -298,5 +298,85 @@ namespace NSwag.CodeGeneration.CSharp.Tests
                 "foreach (var item_ in extendedProperties.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
                 code);
         }
+
+        [Fact]
+        public void When_query_parameter_is_keyword_use_correct_variable_name_when_object_parameters_has_expanded()
+        {
+            var spec = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""1.0.0"",
+    ""title"": ""Query params tests""
+  },
+  ""servers"": [
+    {
+      ""url"": ""http://localhost:8080""
+    }
+  ],
+  ""paths"": {
+    ""/settings"": {
+      ""post"": {
+        ""summary"": ""List all settings"",
+        ""operationId"": ""listSettings"",
+        ""parameters"": [
+          {
+            ""name"": ""params"",
+            ""in"": ""query"",
+            ""required"": true,
+            ""schema"": {
+              ""$ref"": ""#/components/schemas/MultiValueMapStringObject""
+            }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""An array of settings""
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""MultiValueMapStringObject"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""all"": {
+            ""type"": ""object"",
+            ""additionalProperties"": {
+              ""type"": ""object""
+            },
+            ""writeOnly"": true
+          },
+          ""empty"": {
+            ""type"": ""boolean""
+          }
+        },
+        ""additionalProperties"": {
+          ""type"": ""array"",
+          ""items"": {
+            ""type"": ""object""
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+            var document = OpenApiDocument.FromJsonAsync(spec).Result;
+
+            // Act
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.DoesNotContain(
+                "foreach (var item_ in params.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
+                code);
+            Assert.Contains(
+                "foreach (var item_ in @params.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }",
+                code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -40,5 +40,5 @@ if ({{parameter.Name}}.{{property.Name}} != null)
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% endif -%}
 {% if parameter.HasAdditionalProperties -%}
-foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
+foreach (var item_ in {{ parameter.VariableName }}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% endif -%}


### PR DESCRIPTION
This PR fixes an wrong use of an extended query parameter (AdditionalProperties). The parameter name was used instead of the variable name which has an @ prefix in case of an C# keyword. 