### PR TITLE
Add an extension point after C# class definition

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -474,3 +474,5 @@
     {% template Client.Class.ConvertToString %}
     {% template Client.Class.Body %}
 }
+
+{% template Client.Class.AfterDefinition %}


### PR DESCRIPTION
This makes it possible to generate code that knows the name of the generated class.

(the practical use case I have is adding a method that would register several instances of the generated client (each with a different authentication method) in my DI)

Nb: an alternatives to this commit would be to leverage an extension point in the File.liquid, but at this point the name of the generated classes are not available