### PR TITLE
Allow setting of the client interface access modifier based on the model access modifier

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/CSharpClientSettingsTests.cs
@@ -174,6 +174,29 @@ namespace NSwag.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
+        public async Task When_client_base_interface_is_not_specified_then_client_interface_should_have_no_base_interface_and_has_correct_access_modifier()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaSettings = new NewtonsoftJsonSchemaGeneratorSettings()
+            });
+
+            var document = await swaggerGenerator.GenerateForControllerAsync<FooController>();
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientInterfaces = true,
+                ClientInterfaceAccessModifier = "internal"
+            });
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("internal partial interface IFooClient\n", code);
+        }
+
+        [Fact]
         public async Task When_client_base_interface_is_specified_then_client_interface_extends_it()
         {
             // Arrange
@@ -194,6 +217,30 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.Contains("public partial interface IFooClient : IClientBase", code);
+        }
+
+        [Fact]
+        public async Task When_client_base_interface_is_specified_with_access_modifier_then_client_interface_extends_it_and_has_correct_access_modifier()
+        {
+            // Arrange
+            var swaggerGenerator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaSettings = new NewtonsoftJsonSchemaGeneratorSettings()
+            });
+
+            var document = await swaggerGenerator.GenerateForControllerAsync<FooController>();
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateClientInterfaces = true,
+                ClientBaseInterface = "IClientBase",
+                ClientInterfaceAccessModifier = "internal"
+            });
+
+            // Act
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("internal partial interface IFooClient : IClientBase", code);
         }
 
         [Fact]

--- a/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpClientGeneratorSettings.cs
@@ -19,6 +19,7 @@ namespace NSwag.CodeGeneration.CSharp
             GenerateExceptionClasses = true;
             ExceptionClass = "ApiException";
             ClientClassAccessModifier = "public";
+            ClientInterfaceAccessModifier = "public";
             UseBaseUrl = true;
             HttpClientType = "System.Net.Http.HttpClient";
             WrapDtoExceptions = true;
@@ -69,6 +70,9 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the client class access modifier (default: public).</summary>
         public string ClientClassAccessModifier { get; set; }
+
+        /// <summary>Gets or sets the client interface access modifier (default: public).</summary>
+        public string ClientInterfaceAccessModifier { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to use and expose the base URL (default: true).</summary>
         public bool UseBaseUrl { get; set; }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpClientTemplateModel.cs
@@ -120,6 +120,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the client class access modifier.</summary>
         public string ClientClassAccessModifier => _settings.ClientClassAccessModifier;
 
+        /// <summary>Gets or sets the client interface access modifier.</summary>
+        public string ClientInterfaceAccessModifier => _settings.ClientInterfaceAccessModifier;
+
         /// <summary>Gets the operations.</summary>
         public IEnumerable<CSharpOperationModel> Operations { get; }
 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
@@ -1,6 +1,6 @@
 {% template Client.Interface.Annotations %}
 [System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
-public partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ ClientBaseInterface }}{% endif %}
+{{ ClientInterfaceAccessModifier }} partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ ClientBaseInterface }}{% endif %}
 {
     {% template Client.Interface.Body %}
 {% for operation in InterfaceOperations -%}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpClientCommand.cs
@@ -185,7 +185,11 @@ namespace NSwag.Commands.CodeGeneration
         public string TypeAccessModifier
         {
             get => Settings.CSharpGeneratorSettings.TypeAccessModifier;
-            set => Settings.CSharpGeneratorSettings.TypeAccessModifier = value;
+            set
+            { 
+                Settings.CSharpGeneratorSettings.TypeAccessModifier = value;
+                Settings.ClientInterfaceAccessModifier = value;
+            }
         }
 
         [Argument(Name = "PropertySetterAccessModifier", IsRequired = false, Description = "The access modifier of property setters (default: '').")]


### PR DESCRIPTION
This PR allows changing the client interface access modifier.  This PR is to address #1363.

 Changes:

- When run from the command line, the model type `TypeAccessModifier` is used. When `TypeAccessModifier` is set in the `OpenApiToCSharpClientCommand`, it sets the settings `ClientInterfaceAccessModifier` to the same value. This is required because `TypeAccessModifier` is found in the Newtonsoft library and not in `CSharpClientGeneratorSettings`.
- `CSharpClientGeneratorSettings` defaults `ClientInterfaceAccessModifier` to `public`
- Updates the C# `Client.Interface.liquid` to use the new  `ClientInterfaceAccessModifier` setting
- Add unit tests to ensure changing the access modifier is correctly changed in the generated C#.

This PR does not address valid combination of setting the generated C# class and model to public, but the interface internal. This would require additional work to expose additional arguments to the command line tool and changes to the UI tools. Someone would need to justify the use case that make this additional combination valid and the effort to implement.

Valid in the table means it is valid C# and will compile.  This PR really addresses the last item in the table.

| valid | class    | model    | interface  |  Handled?  |
|:---:|:-------- |:-------- |:---------- | -- |
| Yes | public   | public   | public     | Yes - worked this way before |
| Yes | public   | public   | internal | No - use case? |
| No | public   | internal | public    | No - not valid C# |
| No | public   | internal | internal | No - not valid C# |
| Yes | internal | public    | public   | Yes - worked this way before |
| Yes | internal | public    | internal | No - edge case? |
| No | internal |  internal  | public | No - not valid C# |
| Yes | internal |  internal  | internal  | **Yes** - This PR fixes this specific combination |

