### PR TITLE
Fix: C# Code Generation generates method with return default(void)

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -115,7 +115,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>
         /// The default value of the result type, i.e. default(T) or default(T)! depending on whether NRT are enabled.
         /// </summary>
-        public string UnwrappedResultDefaultValue => $"default({UnwrappedResultType}){(_settings is CSharpClientGeneratorSettings { CSharpGeneratorSettings.GenerateNullableReferenceTypes: true } ? "!" : "")}";
+        public string UnwrappedResultDefaultValue => HasResult
+            ? $"default({UnwrappedResultType}){(_settings is CSharpClientGeneratorSettings { CSharpGeneratorSettings.GenerateNullableReferenceTypes: true } ? "!" : "")}"
+            : null;
 
         /// <summary>Gets or sets the synchronous type of the result.</summary>
         public string SyncResultType

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -57,7 +57,7 @@ throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescri
 {%         if operation.WrapResponse -%}
 return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%         else -%}
-return {{ operation.UnwrappedResultDefaultValue }};
+{%             if operation.HasResult %}return {{ operation.UnwrappedResultDefaultValue }};{% else %}return;{% endif %}
 {%         endif -%}
 {%     else -%}
 {%         if operation.WrapResponse -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -413,7 +413,7 @@
 {%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" %}
                     return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%             else -%}
-                    return {{ operation.UnwrappedResultDefaultValue }};
+                    {% if operation.HasResult %}return {{ operation.UnwrappedResultDefaultValue }};{% else %}return;{% endif %}
 {%             endif -%}
 {%         elsif operation.WrapResponse -%}
                     return new {{ ResponseClass }}(status_, headers_);
@@ -431,7 +431,7 @@
 {%                 if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" %}
                         return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
 {%                 else -%}
-                        return {{ operation.UnwrappedResultDefaultValue }};
+                        {% if operation.HasResult %}return {{ operation.UnwrappedResultDefaultValue }};{% else %}return;{% endif %}
 {%                 endif -%}
 {%             elsif operation.WrapResponse -%}
                         return new {{ ResponseClass }}(status_, headers_);


### PR DESCRIPTION
This PR is made to avoid generation of C# code like this one (which leads to compilation error of course):
```
                        if (status_ == 204)
                        {
                            return default(void);
                        }
```

fixes #3912
fixes #3996