### PR TITLE
Fix parameter position ordering (not ignore Position property)

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -36,13 +36,13 @@ namespace NSwag.CodeGeneration.TypeScript.Models
             _settings = settings;
             _generator = generator;
 
-            var parameters = GetActualParameters();
+            var parameters = GetActualParameters().OrderBy(p => p.Position).ToList();
 
             if (settings.GenerateOptionalParameters)
             {
                 parameters = parameters
                     .OrderBy(p => p.Position ?? 0)
-                    .OrderBy(p => !p.IsRequired)
+                    .ThenBy(p => !p.IsRequired)
                     .ToList();
             }
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -60,7 +60,7 @@ import * as jQuery from 'jquery';
 {%-    endif -%}
 {%-    if Framework.UseMomentJS -%}
 
-import moment from 'moment';
+import * as moment from 'moment';
 {%-        if RequiresMomentJSDuration -%}
 import 'moment-duration-format';
 {%-        endif -%}


### PR DESCRIPTION
Fix parameter position ordering (not ignore Position property) at model. Fix moment import syntax error for typescript version 4.3 (rxJsVersion 7.0)