### PR TITLE
Fix for BaseUrl in base class not being used

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -2,7 +2,7 @@
 [System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
 {{ ClientClassAccessModifier }} partial class {{ Class }} {% if HasBaseType %}: {% endif %}{% if HasBaseClass %}{{ BaseClass }}{% if GenerateClientInterfaces %}, {% endif %}{% endif %}{% if GenerateClientInterfaces %}I{{ Class }}{% endif %}
 {
-{% if UseBaseUrl -%}
+{% if UseBaseUrl and HasBaseClass == false and GenerateBaseUrlProperty == true -%}
     #pragma warning disable 8618
     private string _baseUrl;
     #pragma warning restore 8618
@@ -34,7 +34,7 @@
     public {{ Class }}({{ constructorParameters }}){% if HasConfigurationClass and HasBaseClass -%}{{ " : base(configuration)"}}{% endif %}
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
-{%     if UseBaseUrl -%}
+{%      if UseBaseUrl and HasBaseClass == false and GenerateBaseUrlProperty == true -%}
 {%         if HasBaseUrl -%}
 {%             if GenerateBaseUrlProperty -%}
         BaseUrl = "{{ BaseUrl }}";
@@ -290,7 +290,11 @@
 {%     endif -%}
 
                 var urlBuilder_ = new System.Text.StringBuilder();
-                {% if UseBaseUrl %}if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);{% endif %}
+{%              if HasBaseClass == true and GenerateBaseUrlProperty == false -%}
+                    if (!string.IsNullOrEmpty(BaseUrl)) urlBuilder_.Append(BaseUrl);
+{%              else -%}
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+{%              endif -%}
                 // Operation Path: "{{ operation.Path }}"
 {%     if operation.Path contains "{" -%}
 {%        assign pathParts = operation.Path | split: "{" -%}


### PR DESCRIPTION
Fix to use the BaseUrl from the base class when there is a base class and GenerateBaseUrlProperty is not set.

See issue #4764