### PR TITLE
Expose OpenAPI security in OperationModelBase

### DIFF
--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -69,6 +69,9 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets the operation tags.</summary>
         public List<string> Tags => _operation.Tags;
 
+        /// <summary>Gets the operation security.</summary>
+        public IEnumerable<Dictionary<string, IEnumerable<string>>> Security => _operation.Security.Select(s => s.AsEnumerable().ToDictionary(kv => kv.Key, kv => kv.Value));
+
         /// <summary>Gets or sets the HTTP path (i.e. the absolute route).</summary>
         public string Path { get; set; }
 

--- a/src/NSwag.Core/OpenApiOperation.cs
+++ b/src/NSwag.Core/OpenApiOperation.cs
@@ -150,7 +150,7 @@ namespace NSwag
 
         /// <summary>Gets or sets a security description.</summary>
         [JsonProperty(PropertyName = "security", Order = 14, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ICollection<OpenApiSecurityRequirement> Security { get; set; }
+        public ICollection<OpenApiSecurityRequirement> Security { get; set; } = new Collection<OpenApiSecurityRequirement>();
 
         /// <summary>Gets or sets the servers (OpenAPI only).</summary>
         [JsonProperty(PropertyName = "servers", Order = 15, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]


### PR DESCRIPTION
Added an accessor for OpenApiSecurityRequirement to OperationModelBase, convert back to inherit Dictionary.
Added initialization of the collection in OpenApiOperation class.

Ref issue #4899
