### PR TITLE
Replace collection length checks for compatibility

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.PathParameter.liquid
@@ -1,11 +1,11 @@
 {% if parameter.IsDateTimeArray -%}
-for (var i = 0; i < {{ parameter.VariableName }}.Length; i++)
+for (var i = 0; i < {{ parameter.VariableName }}.Count(); i++)
 {
     if (i > 0) urlBuilder_.Append(',');
     urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}[i].ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 }
 {% elsif parameter.IsDateArray -%}
-for (var i = 0; i < {{ parameter.VariableName }}.Length; i++)
+for (var i = 0; i < {{ parameter.VariableName }}.Count(); i++)
 {
     if (i > 0) urlBuilder_.Append(',');
     urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}[i].ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
@@ -15,10 +15,10 @@ urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}.ToSt
 {% elsif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString({{ parameter.VariableName }}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture)));
 {% elsif parameter.IsArray -%}
-for (var i = 0; i < {{ parameter.VariableName }}.Length; i++)
+for (var i = 0; i < {{ parameter.VariableName }}.Count(); i++)
 {
     if (i > 0) urlBuilder_.Append(',');
-    urlBuilder_.Append(ConvertToString({{ parameter.VariableName }}[i], System.Globalization.CultureInfo.InvariantCulture));
+    urlBuilder_.Append(ConvertToString({{ parameter.VariableName }}.ElementAt(i), System.Globalization.CultureInfo.InvariantCulture));
 }
 {% else -%}
 urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)));


### PR DESCRIPTION
- Fixes: https://github.com/RicoSuter/NSwag/issues/4672
- Repro: https://github.com/jake-carpenter/nswag-4672-repro
- Cause: https://github.com/RicoSuter/NSwag/pull/4586/commits/961cb7b28fe97994ece7d0ff05cec090d4127fb4#diff-416f8759e9ce0cecba7578a64bf1fc4b9fee9325d331641eaf7b07d62e7455bb

Using the `Length` property assumes the collection will be a C# array, but that is based on the `parameterArrayType` setting for the C# client generator. By default, `IEnumerable` is used and the majority of other collection types won't accept Length.

For now, this fix utilizes the LINQ `Count()`, which theoretically should check for `Length` or `Count` properties on it's own before enumerating. This seems like it is still an improvement to the enumeration that was present before the linked changeset. I'm open to solving this a different way if there are ways to access the C# type during generation.

There are likely other templates where this is also a problem, but this fix is focused on path parameter generation.
