### PR TITLE
Support `$ref` in `requestBody`

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -96,7 +96,7 @@ namespace NSwag.CodeGeneration.CSharp.Models
         public bool RequiresFileParameterType =>
             _settings.CSharpGeneratorSettings.ExcludedTypeNames?.Contains("FileParameter") != true &&
             (_document.Operations.Any(o => o.Operation.ActualParameters.Any(p => p.ActualTypeSchema.IsBinary)) ||
-             _document.Operations.Any(o => o.Operation?.RequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true ||
+             _document.Operations.Any(o => o.Operation?.ActualRequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true ||
                                                                                        c.Value.Schema?.ActualSchema.ActualProperties.Any(p => p.Value.IsBinary ||
                                                                                                                                  p.Value.Item?.IsBinary == true ||
                                                                                                                                  p.Value.Items.Any(i => i.IsBinary)

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFileTemplateModel.cs
@@ -130,7 +130,7 @@ namespace NSwag.CodeGeneration.TypeScript.Models
         public bool RequiresFileParameterInterface =>
             !_settings.TypeScriptGeneratorSettings.ExcludedTypeNames.Contains("FileParameter") &&
             (_document.Operations.Any(o => o.Operation.ActualParameters.Any(p => p.ActualTypeSchema.IsBinary)) ||
-             _document.Operations.Any(o => o.Operation?.RequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true ||
+             _document.Operations.Any(o => o.Operation?.ActualRequestBody?.Content?.Any(c => c.Value.Schema?.IsBinary == true ||
                                                                                        c.Value.Schema?.ActualProperties.Any(p => p.Value.IsBinary ||
                                                                                                                                  p.Value.Item?.IsBinary == true ||
                                                                                                                                  p.Value.Items.Any(i => i.IsBinary)

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -216,7 +216,7 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether the operation consumes 'application/x-www-form-urlencoded'.</summary>
         public bool ConsumesFormUrlEncoded =>
             _operation.ActualConsumes?.Any(c => c == "application/x-www-form-urlencoded") == true ||
-            _operation.RequestBody?.Content.Any(mt => mt.Key == "application/x-www-form-urlencoded") == true;
+            _operation.ActualRequestBody?.Content.Any(mt => mt.Key == "application/x-www-form-urlencoded") == true;
 
         /// <summary>Gets the form parameters.</summary>
         public IEnumerable<TParameterModel> FormParameters => Parameters.Where(p => p.Kind == OpenApiParameterKind.FormData);
@@ -259,7 +259,7 @@ namespace NSwag.CodeGeneration.Models
                 }
 
                 return _operation.ActualConsumes?.FirstOrDefault() ??
-                    _operation.RequestBody?.Content.Keys.FirstOrDefault() ??
+                    _operation.ActualRequestBody?.Content.Keys.FirstOrDefault() ??
                     "application/json";
             }
         }
@@ -350,8 +350,8 @@ namespace NSwag.CodeGeneration.Models
                 .ToList();
 
             var formDataSchema =
-                _operation?.RequestBody?.Content?.ContainsKey("multipart/form-data") == true ?
-                _operation.RequestBody.Content["multipart/form-data"]?.Schema.ActualSchema: null;
+                _operation?.ActualRequestBody?.Content?.ContainsKey("multipart/form-data") == true ?
+                _operation.ActualRequestBody.Content["multipart/form-data"]?.Schema.ActualSchema: null;
 
             if (formDataSchema != null && formDataSchema.ActualProperties.Count > 0)
             {

--- a/src/NSwag.Core.Tests/Serialization/ExternalReferenceTests.cs
+++ b/src/NSwag.Core.Tests/Serialization/ExternalReferenceTests.cs
@@ -25,6 +25,15 @@ namespace NSwag.Core.Tests.Serialization
         }
 
         [Fact]
+        public async Task When_file_contains_requestBody_reference_to_another_file_it_is_loaded()
+        {
+            var document = await OpenApiDocument.FromFileAsync("TestFiles/requestBody-reference.json");
+
+            Assert.NotNull(document);
+            Assert.Equal("External request body", document.Paths.First().Value.Values.First().RequestBody.ActualRequestBody.Description);
+        }
+
+        [Fact]
         public async Task When_file_contains_response_reference_to_another_file_it_is_loaded()
         {
             var document = await OpenApiDocument.FromFileAsync("TestFiles/response-reference.json");

--- a/src/NSwag.Core.Tests/TestFiles/common.json
+++ b/src/NSwag.Core.Tests/TestFiles/common.json
@@ -55,6 +55,19 @@
         "additionalProperties": true
       }
     },
+    "requestBodies": {
+      "TestRequest": {
+        "description": "External request body",
+        "required": true,
+        "content": {
+          "text/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestObject"
+            }
+          }
+        }
+      }
+    },
     "responses": {
       "TestResponse": {
         "description": "External response",

--- a/src/NSwag.Core.Tests/TestFiles/requestBody-reference.json
+++ b/src/NSwag.Core.Tests/TestFiles/requestBody-reference.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.0.2",
+  "paths": {
+    "/test": {
+      "get": {
+        "description": "Test path",
+        "requestBody": {
+          "$ref": "./common.json#/components/requestBodies/TestRequest"
+        },
+        "responses": {}
+      }
+    }
+  }
+}

--- a/src/NSwag.Core/OpenApiComponents.cs
+++ b/src/NSwag.Core/OpenApiComponents.cs
@@ -38,6 +38,16 @@ namespace NSwag
             };
             Schemas = schemas;
 
+            var requestBodies = new ObservableDictionary<string, OpenApiRequestBody>();
+            requestBodies.CollectionChanged += (sender, args) =>
+            {
+                foreach (var path in RequestBodies.Values)
+                {
+                    path.Parent = document;
+                }
+            };
+            RequestBodies = requestBodies;
+
             var responses = new ObservableDictionary<string, OpenApiResponse>();
             responses.CollectionChanged += (sender, args) =>
             {
@@ -85,6 +95,10 @@ namespace NSwag
         /// <summary>Gets or sets the types.</summary>
         [JsonProperty(PropertyName = "schemas", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IDictionary<string, JsonSchema> Schemas { get; }
+
+        /// <summary>Gets or sets the responses which can be used for all operations.</summary>
+        [JsonProperty(PropertyName = "requestBodies", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public IDictionary<string, OpenApiRequestBody> RequestBodies { get; }
 
         /// <summary>Gets or sets the responses which can be used for all operations.</summary>
         [JsonProperty(PropertyName = "responses", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/src/NSwag.Core/OpenApiMediaType.cs
+++ b/src/NSwag.Core/OpenApiMediaType.cs
@@ -29,7 +29,7 @@ namespace NSwag
             set
             {
                 _schema = value;
-                Parent?.Parent?.UpdateBodyParameter();
+                Parent?.ParentOperation?.UpdateBodyParameter();
             }
         }
 
@@ -41,7 +41,7 @@ namespace NSwag
             set
             {
                 _example = value;
-                Parent?.Parent?.UpdateBodyParameter();
+                Parent?.ParentOperation?.UpdateBodyParameter();
             }
         }
 

--- a/src/NSwag.Core/OpenApiOperation.cs
+++ b/src/NSwag.Core/OpenApiOperation.cs
@@ -168,6 +168,10 @@ namespace NSwag
         [JsonIgnore]
         public ICollection<OpenApiSchema> ActualSchemes => Schemes ?? Parent.Parent.Schemes;
 
+        /// <summary>Gets the response body and dereferences it if necessary.</summary>
+        [JsonIgnore]
+        public OpenApiRequestBody ActualRequestBody => RequestBody.ActualRequestBody;
+
         /// <summary>Gets the responses from the operation and from the <see cref="OpenApiDocument"/> and dereferences them if necessary.</summary>
         [JsonIgnore]
         public IReadOnlyDictionary<string, OpenApiResponse> ActualResponses => Responses.ToDictionary(t => t.Key, t => t.Value.ActualResponse);

--- a/src/NSwag.Core/OpenApiOperation.cs
+++ b/src/NSwag.Core/OpenApiOperation.cs
@@ -170,7 +170,7 @@ namespace NSwag
 
         /// <summary>Gets the response body and dereferences it if necessary.</summary>
         [JsonIgnore]
-        public OpenApiRequestBody ActualRequestBody => RequestBody.ActualRequestBody;
+        public OpenApiRequestBody ActualRequestBody => RequestBody?.ActualRequestBody;
 
         /// <summary>Gets the responses from the operation and from the <see cref="OpenApiDocument"/> and dereferences them if necessary.</summary>
         [JsonIgnore]

--- a/src/NSwag.Core/OpenApiParameter.cs
+++ b/src/NSwag.Core/OpenApiParameter.cs
@@ -225,7 +225,7 @@ namespace NSwag
                 var parent = Parent as OpenApiOperation;
                 var consumes = parent?.ActualConsumes?.Any() == true ?
                     parent.ActualConsumes :
-                    parent?.RequestBody?.Content.Keys;
+                    parent?.ActualRequestBody?.Content.Keys;
 
                 return consumes?.Any() == true &&
                        consumes.Any(p => p.Contains("application/xml")) &&
@@ -256,7 +256,7 @@ namespace NSwag
                 }
                 else
                 {
-                    var consumes = parent?.RequestBody?.Content;
+                    var consumes = parent?.ActualRequestBody?.Content;
                     return (consumes?.Any(p => p.Key == "multipart/form-data") == true ||
                             consumes?.Any(p => p.Value.Schema?.IsBinary != false) == true) &&
                            consumes.Any(p => p.Key.Contains("*/*") && p.Value.Schema?.IsBinary != true) == false &&
@@ -286,7 +286,7 @@ namespace NSwag
                 }
                 else
                 {
-                    var consumes = parent?.RequestBody?.Content;
+                    var consumes = parent?.ActualRequestBody?.Content;
                     return consumes?.Any() == true &&
                            (consumes.Count() > 1 ||
                             consumes.Any(p => p.Key.Contains("*")));

--- a/src/NSwag.Core/OpenApiRequestBody.cs
+++ b/src/NSwag.Core/OpenApiRequestBody.cs
@@ -32,13 +32,16 @@ namespace NSwag
                     mediaType.Parent = this;
                 }
 
-                Parent?.UpdateBodyParameter();
+                ParentOperation?.UpdateBodyParameter();
             };
             Content = content;
         }
 
         [JsonIgnore]
-        internal OpenApiOperation Parent { get; set; }
+        internal object Parent { get; set; }
+
+        [JsonIgnore]
+        internal OpenApiOperation ParentOperation => Parent as OpenApiOperation;
 
         /// <summary>Gets the actual request body, either this or the referenced request body.</summary>
         [JsonIgnore]
@@ -52,7 +55,7 @@ namespace NSwag
             set
             {
                 _name = value;
-                Parent?.UpdateBodyParameter();
+                ParentOperation?.UpdateBodyParameter();
             }
         }
 
@@ -64,7 +67,7 @@ namespace NSwag
             set
             {
                 _description = value;
-                Parent?.UpdateBodyParameter();
+                ParentOperation?.UpdateBodyParameter();
             }
         }
 
@@ -80,7 +83,7 @@ namespace NSwag
             set
             {
                 _isRequired = value;
-                Parent?.UpdateBodyParameter();
+                ParentOperation?.UpdateBodyParameter();
             }
         }
 
@@ -92,7 +95,7 @@ namespace NSwag
             set
             {
                 _position = value;
-                Parent?.UpdateBodyParameter();
+                ParentOperation?.UpdateBodyParameter();
             }
         }
 
@@ -106,7 +109,7 @@ namespace NSwag
         IJsonReference IJsonReference.ActualObject => ActualRequestBody;
 
         [JsonIgnore]
-        object IJsonReference.PossibleRoot => Parent?.Parent?.Parent;
+        object IJsonReference.PossibleRoot => ParentOperation?.Parent?.Parent;
 
         #endregion
     }

--- a/src/NSwag.Core/OpenApiRequestBody.cs
+++ b/src/NSwag.Core/OpenApiRequestBody.cs
@@ -8,12 +8,13 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using NJsonSchema.References;
 using NSwag.Collections;
 
 namespace NSwag
 {
     /// <summary>The OpenApi request body (OpenAPI only).</summary>
-    public class OpenApiRequestBody
+    public class OpenApiRequestBody : JsonReferenceBase<OpenApiRequestBody>, IJsonReference
     {
         private string _name;
         private bool _isRequired;
@@ -38,6 +39,10 @@ namespace NSwag
 
         [JsonIgnore]
         internal OpenApiOperation Parent { get; set; }
+
+        /// <summary>Gets the actual request body, either this or the referenced request body.</summary>
+        [JsonIgnore]
+        public OpenApiRequestBody ActualRequestBody => Reference ?? this;
 
         /// <summary>Gets or sets the name.</summary>
         [JsonProperty(PropertyName = "x-name", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -94,5 +99,15 @@ namespace NSwag
         /// <summary>Gets the actual name of the request body parameter.</summary>
         [JsonIgnore]
         public string ActualName => string.IsNullOrEmpty(Name) ? "body" : Name;
+ 
+        #region Implementation of IJsonReference
+
+        [JsonIgnore]
+        IJsonReference IJsonReference.ActualObject => ActualRequestBody;
+
+        [JsonIgnore]
+        object IJsonReference.PossibleRoot => Parent?.Parent?.Parent;
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #2122

This MR adds support for `$ref` in `requestBody`, as well as `requestBodies` in `components`.

Since the existing implementation does not attempt to do cross-updates between `OpenApiRequestBody` and a referenced `OpenApiParameter`, so this MR does not attempt to cross-update the other direction.