### PR TITLE
Adds a setting-option to add swagger plugins.

### DIFF
--- a/src/NSwag.AspNet.Owin/SwaggerUi/index.html
+++ b/src/NSwag.AspNet.Owin/SwaggerUi/index.html
@@ -17,6 +17,8 @@
 
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+
+    {PluginScripts}
     <script>
 window.onload = function() {
   var url = window.location.search.match(/url=([^&]+)/);
@@ -60,6 +62,7 @@ window.onload = function() {
     plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
         disableTryItOutPlugin
+        {AdditionalPlugins}
     ],
     layout: "StandaloneLayout"
   });

--- a/src/NSwag.AspNetCore/ReDocSettings.cs
+++ b/src/NSwag.AspNetCore/ReDocSettings.cs
@@ -44,7 +44,7 @@ namespace NSwag.AspNetCore
         {
             html = html.Replace("{AdditionalSettings}", GenerateAdditionalSettings(AdditionalSettings));
             html = html.Replace("{CustomStyle}", GetCustomStyleHtml(request));
-            html = html.Replace("{CustomScript}", GetCustomScriptHtml(request));
+            html = html.Replace("{CustomScript}", GetCustomScriptHtml(CustomJavaScriptPath, request));
             html = html.Replace("{DocumentTitle}", DocumentTitle);
             return Task.FromResult(html);
         }

--- a/src/NSwag.AspNetCore/SwaggerUi/index.html
+++ b/src/NSwag.AspNetCore/SwaggerUi/index.html
@@ -17,6 +17,9 @@
 
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+
+    {PluginScripts}
+
     <script>
 window.onload = function() {
   var url = window.location.search.match(/url=([^&]+)/);
@@ -59,7 +62,8 @@ window.onload = function() {
     ],
     plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
-        disableTryItOutPlugin
+        disableTryItOutPlugin 
+        {AdditionalPlugins}
     ],
     layout: "StandaloneLayout"
   });

--- a/src/NSwag.AspNetCore/SwaggerUiSettings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettings.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="SwaggerUiOwinSettings.cs" company="NSwag">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
@@ -179,9 +179,12 @@ namespace NSwag.AspNetCore
                           "/oauth2-redirect.html\""
                         : "\"" + ServerUrl + TransformToExternalPath(Path, request) + "/oauth2-redirect.html\"")
                 .Replace("{CustomStyle}", GetCustomStyleHtml(request))
-                .Replace("{CustomScript}", GetCustomScriptHtml(request))
+                .Replace("{CustomScript}", GetCustomScriptHtml(CustomJavaScriptPath,request))
                 .Replace("{CustomHeadContent}", CustomHeadContent)
-                .Replace("{DocumentTitle}", DocumentTitle);
+                .Replace("{DocumentTitle}", DocumentTitle)
+                .Replace("{AdditionalPlugins}", GeneratePluginsList(AdditionalPlugins.Keys.ToArray()))
+                .Replace("{PluginScripts}", GetCustomScripts(AdditionalPlugins.Values.ToArray(), request));
+
 
             return htmlBuilder.ToString();
         }


### PR DESCRIPTION
I wanted a way to add swagger plugins through NSwag. 

Changed the signature of GetCustomScriptHtml to allow reuse.
Added setting for plugin with name and script path.
Script must be hosted in your application and reachable by swagger.