### PR TITLE
♻️ CodeGen - CSharp - generate additional properties as a `deepObject`

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -39,6 +39,7 @@ if ({{parameter.Name}}.{{property.Name}} != null)
 {% elsif parameter.HasAdditionalProperties == false -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% endif -%}
-{% if parameter.HasAdditionalProperties -%}
+{% if parameter.HasAdditionalProperties and parameter.IsDeepObject == false -%}
 foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
+{% elsif parameter.HasAdditionalProperties and parameter.IsDeepObject -%}foreach (var item_ in {{parameter.Name}}.AdditionalProperties) { urlBuilder_.Append(System.Uri.EscapeDataString("{{parameter.Name}}[{{item_.Key}}]")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% endif -%}


### PR DESCRIPTION
Currently, additionalProperties are generated like a dictionary, regardless of the `"style" = "deepObject"`

#### example parameter from openapi spec
```json
{
  "name": "attributes",
  "in": "query",
  "required": false,
  "explode": true,
  "style": "deepObject",
  "schema": {
    "minProperties": 1,
    "type": "object",
    "properties": {
      "name": {
        "type": "string"
      }
    },
    "additionalProperties": {
      "type": "string"
    }
  }
}
```

Currently, named properties such as `name` in the example json, generate correctly in the C# code, however un-named additional properties do not, and should.

as per https://swagger.io/docs/specification/serialization/
![image](https://github.com/user-attachments/assets/455e2cc3-5f62-4429-8a4c-7c8bc838f17f)
![image](https://github.com/user-attachments/assets/5ef10e0f-b2bd-4e01-96bb-df294fc23895)
