### PR TITLE
Case sensitive parameter name matching for path parameters

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -304,7 +304,9 @@
 {%                assign pathParameterParts = pathPart | split: "}" -%}
 {%                assign pathParameterFound = true -%}
 {%                for parameter in operation.PathParameters -%}
-{%                    if parameter.Name == pathParameterParts[0] -%}
+{%                      assign parameterNameLowerCased = parameter.Name | downcase -%}
+{%                      assign partLowerCased = pathParameterParts[0] | downcase -%}
+{%                    if parameterNameLowerCased == partLowerCased -%}
 {%                        if parameter.IsOptional -%}
 {%                            assign pathParameterFound = false -%}
                 if ({{ parameter.VariableName }} != null)


### PR DESCRIPTION
When scanning parameter list for path parameters, match parameter names on a case insensitive basis.  Otherwise some parameters won't match if the schema isn't 100% correct

I had an openapi operation with path "/api/ocrforms/{formid}/active" but the parameter collection had name "formId".  This was from a third party API that I didn't create.

Nswag either needs to work in case insensitive mode or inject "TODO" or some exception code to make it obvious when path segments don't match parameter names for a given operation.