### PR TITLE
Fix for unwanted parameter explosion in C# client 

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -6,7 +6,7 @@ foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% elsif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
-{% elsif parameter.IsArray and parameter.Explode == false and parameter.CollectionFormat == "csv" or parameter.CollectionFormat == nil -%}
+{% elsif parameter.IsArray and parameter.Explode != nil and parameter.Explode == false and parameter.CollectionFormat == "csv" or parameter.CollectionFormat == nil -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=");
 foreach (var item_ in {{ parameter.VariableName }}) { 
     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(","); }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -6,6 +6,12 @@ foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateTimeFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
 {% elsif parameter.IsDate -%}
 urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString({% if parameter.IsNullable and parameter.IsRequired %}{{ parameter.VariableName }} != null ? {% endif %}{{ parameter.VariableName }}{% if parameter.IsSystemNullable %}.Value{% endif %}.ToString("{{ ParameterDateFormat }}", System.Globalization.CultureInfo.InvariantCulture){% if parameter.IsNullable and parameter.IsRequired %} : "{{ QueryNullValue }}"{% endif %})).Append('&');
+{% elsif parameter.IsArray and parameter.Explode == false and parameter.CollectionFormat == "csv" or parameter.CollectionFormat == nil -%}
+urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}") + "=");
+foreach (var item_ in {{ parameter.VariableName }}) { 
+    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append(","); }
+urlBuilder_.Length--;
+urlBuilder_.Append("&");
 {% elsif parameter.IsArray -%}
 foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDictionary -%}


### PR DESCRIPTION
In response to #4310, since it seems like there will be no follow-up.

In the current implementation the parameter name is specified every time in the request:
`/users?id=3&id=4&id=5`

However, as per specification, if we set `explode` to false, we would expect:
`/users?id=3,4,5`

This pull request removes the unnecessary explosion, when `explode` is set to false, for arrays with collectionFormat "csv" and in the case when no collectionFormat is set.