### PR TITLE
Adds check to consider the required flag on multipart forms in the C# Code generator

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
@@ -442,7 +442,7 @@ components:
             var code = codeGenerator.GenerateFile();
 
             //// Assert
-            Assert.Contains("public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model, System.Threading.CancellationToken cancellationToken)", code);
+            Assert.Contains("public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model, System.Threading.CancellationToken cancellationToken)", code);
             Assert.Contains("var content_file_ = new System.Net.Http.StreamContent(file.Data);", code);
             Assert.Contains("public partial class FileParameter", code);
         }
@@ -504,7 +504,7 @@ components:
             var code = codeGenerator.GenerateFile();
 
             //// Assert
-            Assert.Contains("public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model, System.Threading.CancellationToken cancellationToken)", code);
+            Assert.Contains("public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model, System.Threading.CancellationToken cancellationToken)", code);
             Assert.Contains("var content_file_ = new System.Net.Http.StreamContent(file.Data);", code);
             Assert.Contains("public partial class FileParameter", code);
         }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -247,7 +247,7 @@
                 content_.Headers.Remove("Content-Type");
                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 {%                 for parameter in operation.FormParameters %}
-{%                     if parameter.IsNullable -%}
+{%                     if parameter.IsNullable or parameter.IsOptional -%}
                 if ({{ parameter.VariableName }} != null)
 {%                     else -%}
                 if ({{ parameter.VariableName }} == null)

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -366,7 +366,8 @@ namespace NSwag.CodeGeneration.Models
                         OpenApiParameterCollectionFormat.Multi : OpenApiParameterCollectionFormat.Undefined,
                     //Explode = p.Value.Type.HasFlag(JsonObjectType.Array) && p.Value.Item != null,
                     //Schema = p.Value.Type.HasFlag(JsonObjectType.Array) && p.Value.Item != null ? p.Value.Item : p.Value,
-                    Position = parameters.Count + 100 + i
+                    Position = parameters.Count + 100 + i,
+                    IsRequired = p.Value.IsRequired
                 })).ToList();
             }
 


### PR DESCRIPTION
The problem is that for multipart forms the `required` fields are ignored. This causes the client to throw an `ArgumentNullException` even if the parameter is NOT required.

For
```json
            "multipart/form-data": {
              "schema": {
                "required": [
                  "file"
                ],
                "type": "object",
                "properties": {
                  "file": {
                    "type": "string",
                    "description": "",
                    "format": "binary"
                  },
                  "fileDescription": {
                    "type": "string",
                    "description": ""
                  }
                }
              }, ...
```
we would expect
```csharp
                    if (file == null)
                        throw new System.ArgumentNullException("file");
                    else
                    {
                     ...
                    }

                    if (fileDescription != null)
                    {
                     ...
                    }
```
However, we get
```csharp
                    if (file == null)
                        throw new System.ArgumentNullException("file");
                    else
                    {
                     ...
                    }

                    if (fileDescription == null)
                        throw new System.ArgumentNullException("fileDescription");
                    else
                    {
                     ...
                    }
```