### PR TITLE
Show DisplayName for conflicting actions

### DIFF
--- a/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
+++ b/src/NSwag.Generation.AspNetCore/AspNetCoreOpenApiDocumentGenerator.cs
@@ -157,9 +157,9 @@ namespace NSwag.Generation.AspNetCore
                     var options = serviceProvider.GetService(optionsType);
                     var value = optionsType.GetProperty("Value")?.GetValue(options);
                     var jsonOptions = value?.GetType().GetProperty("JsonSerializerOptions")?.GetValue(value);
-                    if (jsonOptions is JsonSerializerOptions)
+                    if (jsonOptions is JsonSerializerOptions serializerOptions)
                     {
-                        return (JsonSerializerOptions)jsonOptions;
+                        return serializerOptions;
                     }
                 }
                 catch
@@ -336,7 +336,12 @@ namespace NSwag.Generation.AspNetCore
 
                     if (pathItem.ContainsKey(operation.Method))
                     {
-                        throw new InvalidOperationException($"The method '{operation.Method}' on path '{path}' is registered multiple times.");
+                        var conflictingApiDescriptions = operations
+                            .Where(t => t.Item1.Path == operation.Path && t.Item1.Method == operation.Method)
+                            .Select(t => t.Item2)
+                            .ToList();
+
+                        throw new InvalidOperationException($"The method '{operation.Method}' on path '{path}' is registered multiple times for actions {string.Join(", ", conflictingApiDescriptions.Select(apiDesc => apiDesc.ActionDescriptor.DisplayName))}.");
                     }
 
                     pathItem[operation.Method] = operation.Operation;

--- a/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.Generation.WebApi/Processors/OperationParameterProcessor.cs
@@ -269,7 +269,7 @@ namespace NSwag.Generation.WebApi.Processors
         {
             if (operationDescription.Operation.ActualParameters.Count(p => p.Kind == OpenApiParameterKind.Body) > 1)
             {
-                throw new InvalidOperationException("The operation '" + operationDescription.Operation.OperationId + "' has more than one body parameter.");
+                throw new InvalidOperationException($"The operation '{operationDescription.Operation.OperationId}' has more than one body parameter.");
             }
         }
 


### PR DESCRIPTION
Just like in Swashbuckle (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs#L290).

Reduce some code differences between AspNetCore and NSwag.Generation.WebApi projects.

## Before

![image](https://github.com/user-attachments/assets/0e5cec52-0e93-436e-8804-e33a780f2ee1)

## After

![image](https://github.com/user-attachments/assets/149ef2a9-a832-4e26-bd01-270892038911)
