### PR TITLE
Remove Microsoft.Extensions.PlatformAbstractions

### DIFF
--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
   </ItemGroup>
@@ -34,7 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="NConsole" Version="3.12.6605.26941" />
   </ItemGroup>
 

--- a/src/NSwag.Commands/RuntimeUtilities.cs
+++ b/src/NSwag.Commands/RuntimeUtilities.cs
@@ -6,10 +6,6 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
-#if !NETFRAMEWORK
-using Microsoft.Extensions.PlatformAbstractions;
-#endif
-
 namespace NSwag.Commands
 {
     /// <summary>Provides runtime utilities.</summary>
@@ -23,10 +19,9 @@ namespace NSwag.Commands
 #if NETFRAMEWORK
                 return IntPtr.Size == 4 ? Runtime.WinX86 : Runtime.WinX64;
 #else
-                var framework = PlatformServices.Default.Application.RuntimeFramework;
-                if (framework.Identifier == ".NETCoreApp")
+                if (!System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal))
                 {
-                    if (framework.Version.Major >= 9)
+                    if (Environment.Version.Major >= 9)
                     {
                         return Runtime.Net90;
                     }

--- a/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
+++ b/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
@@ -14,12 +14,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
+++ b/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
Trying to remediate some problems with dependencies with incremental update. `Microsoft.Extensions.PlatformAbstractions` has been deprecated and there are APIs to use without that. Old `Moq` brings some vulnerable dependencies with it. 

I tested this with debugger and both `net462` (Console) and core versions (8 and 9, ConsoleCore) seemed to hit the correct breakpoints/paths.