### PR TITLE
Fix for #3620 - .NET Client generation - Query string dictionary is missing property name

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid
@@ -9,7 +9,7 @@ urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('
 {% elsif parameter.IsArray -%}
 foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDictionary -%}
-foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
+foreach (var item_ in {{ parameter.VariableName }}) { urlBuilder_.Append(System.Uri.EscapeDataString("{{ parameter.Name }}")).Append('.').Append(System.Uri.EscapeDataString(item_.Key)).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(item_.Value, System.Globalization.CultureInfo.InvariantCulture))).Append('&'); }
 {% elsif parameter.IsDeepObject -%}
 {%     for property in parameter.PropertyNames -%}
 if ({{parameter.Name}}.{{property.Name}} != null)


### PR DESCRIPTION
This is a fix for https://github.com/RicoSuter/NSwag/issues/3620: Query string dictionary is missing property name

**Proposed solution:**
Prepended property name for dictionary keys, in `src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.QueryParameter.liquid`

**Before:**
`?key1=value1&key2=value2`

**After:**
`?propertyDictName.key1=value1&propertyDictName.key2=value2`