### PR TITLE
fix media type on empty request body

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -286,7 +286,7 @@
                 request_.Content = content_;
 {%             endif -%}
 {%         elsif operation.IsGetOrDeleteOrHead == false -%}
-                request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "{{ operation.Produces }}");
+                request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "{{ operation.Consumes }}");
 {%         endif -%}
 {%     endif -%}
                 request_.Method = new System.Net.Http.HttpMethod("{{ operation.HttpMethodUpper | upcase }}");


### PR DESCRIPTION
the request body should match the media type of what the call consumes (what the server expects), not what the call produces.

This caused runtime break in my use case, as the Produces value includes parameters that don't parse as a simple media type

![image](https://github.com/user-attachments/assets/55d9a2e8-c6af-47d9-be56-48a02d35ef4a)
