### PR TITLE
204 response enhancements

### DIFF
--- a/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
+++ b/src/NSwag.Generation/OpenApiDocumentGeneratorSettings.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Net;
 using Namotion.Reflection;
 using Newtonsoft.Json;
 using NJsonSchema;
@@ -49,6 +50,13 @@ namespace NSwag.Generation
 
         /// <summary>Gets or sets the default response reference type null handling when no nullability information is available (if NotNullAttribute and CanBeNullAttribute are missing, default: NotNull).</summary>
         public ReferenceTypeNullHandling DefaultResponseReferenceTypeNullHandling { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating that the api method/action response should be considered nullable if this response type is documented, even if it is a void response.
+        /// <para>Allows for things like a 204 No Content to be treated as nullable without decorating with the <see cref="NJsonSchema.Annotations.CanBeNullAttribute"/></para>
+        /// <para>If the action is decorated with the <see cref="NJsonSchema.Annotations.NotNullAttribute"/></para> this setting will be ignored for that action.
+        /// </summary>
+        public HttpStatusCode[] ResponseStatusCodesToTreatAsNullable { get; set; } = [];
 
         /// <summary>Gets or sets a value indicating whether to generate x-originalName properties when parameter name is different in .NET and HTTP (default: true).</summary>
         public bool GenerateOriginalParameterNames { get; set; } = true;


### PR DESCRIPTION
# Purpose of change

Partially addresses issues from #1259 

204 is a valid response type and it is valid to potentially return a 200 or a 204 from the same route. Currently nswag generates a server error for 204 results. In addition, this covers the situation where one of the success response types may return a null, but not all.

# Change Summary

- New document generator setting `ResponseStatusCodesToTreatAsNullable` to allow for certain response codes to be treated as a nullable response, even if the response type is void. This means that we don't have to decorate everything that can return a 204 with the `CanBeNull` attribute.

- On the client generation side, we treat all 2xx responses with the same response type as the 200 response as success responses. Expanded that to include responses with the same type but nullable. e.g. a 200 with `MyClass` and a 204 with `MyClass?` would both return true when `IsSuccessStatusCode` is checked. A void type on the 204 would still not return true. That could be another enhancement to make later.

- During client generation, if there are multiple success responses (as defined by the result of `IsSuccessStatusCode`) where some are nullable, we set the whole method return type as nullable.


# Usage Example

In Program.cs we tell the document generator that we want all 204 methods that do not have a `NotNull` attribute to be treated as nullable response types. We also give the response type the same class as the 200 result to pass checks in the generator library that only treat results as successful if they have the same return type as the 200. That part is existing behavior.
``` csharp
services.AddOpenApiDocument(document => 
{ 
    document.ResponseStatusCodesToTreatAsNullable = [HttpStatusCode.NoContent];
});
```

We have an example method in a .net web api.
``` csharp
/// <summary>Example Summary</summary>
[HttpGet]
[ProducesResponseType(typeof(MyClass), StatusCodes.Status200OK)]
[ProducesResponseType(typeof(MyClass), StatusCodes.Status204NoContent)]
public async Task<IActionResult> Get()
{
    MyClass? result = await _myservice.GetResult();
    
    if (result == null)
    {
	    return NoContent();
    }
    
    return Ok(result);
}
```

Note that the 200 is not a nullable response and the 204 is nullable due to the setting in Program.cs. They both use the same return type.
Using this example open api spec and `generateNullableReferenceTypes` set to true. 

``` json
{
  "/api/Example": {
    "get": {
      "summary": "Example Summary",
      "operationId": "Example_Get",
      "responses": {
        "200": {
          "description": "",
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/MyClass"
              }
            }
          }
        },
        "204": {
          "description": "",
          "content": {
            "application/json": {
              "schema": {
                "nullable": true,
                "oneOf": [
                  {
                    "$ref": "#/components/schemas/MyClass"
                  }
                ]
              }
            }
          }
        }
      }
    }
  }
}
```

We would previously have generated something like this:

``` csharp
public virtual async System.Threading.Tasks.Task<MyClass> Get(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) 
{
    if (status_ == 200)
    {
        var objectResponse_ = await ReadObjectResponseAsync<InlPerson>(response_, headers_, cancellationToken).ConfigureAwait(false);
        if (objectResponse_.Object == null)
        {
            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
        }
        return objectResponse_.Object;
    }
    else
    if (status_ == 204)
    {
        // Throws error on 204 which makes this client unusable
        var objectResponse_ = await ReadObjectResponseAsync<InlPerson?>(response_, headers_, cancellationToken).ConfigureAwait(false);
        throw new ApiException<InlPerson?>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null); 
    }
}
```

Now we get this:

``` csharp
// Correctly marks whole method return type as nullable because one of the success status codes returns a nullable type.
public virtual async System.Threading.Tasks.Task<MyClass?> Get(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) 
{
    if (status_ == 200)
    {
        var objectResponse_ = await ReadObjectResponseAsync<InlPerson>(response_, headers_, cancellationToken).ConfigureAwait(false);
        // Note that there is still a null check for a 200 result, which is correct because I did not mark my action result as nullable.
        if (objectResponse_.Object == null)
        {
            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
        }
        return objectResponse_.Object;
    }
    else
    if (status_ == 204)
    {
        var objectResponse_ = await ReadObjectResponseAsync<InlPerson?>(response_, headers_, cancellationToken).ConfigureAwait(false);
        // Correctly returns the value, which will be null for 204.
        return objectResponse_.Object;
    }
}
```

