### PR TITLE
Use JsonContent when creating request bodies

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -220,9 +220,11 @@
 {%         elsif operation.HasPlainTextBodyParameter -%}
                 var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
                 content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%         elsif UseSystemTextJson -%}
+                var content_ = System.Net.Http.Json.JsonContent.Create({{ operation.ContentParameter.VariableName }}, System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}"), {% if UseRequestAndResponseSerializationSettings %}Request{% endif %}JsonSerializerSettings);
 {%         else -%}
-                var json_ = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.SerializeToUtf8Bytes{% else %}Newtonsoft.Json.JsonConvert.SerializeObject{% endif %}({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}{% if UseRequestAndResponseSerializationSettings %}Request{% endif %}JsonSerializerSettings);
-                var content_ = new System.Net.Http.{% if UseSystemTextJson %}ByteArrayContent{% else %}StringContent{% endif %}(json_);
+                var json_ = Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}{% if UseRequestAndResponseSerializationSettings %}Request{% endif %}JsonSerializerSettings);
+                var content_ = new System.Net.Http.StringContent(json_);
                 content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
 {%         endif -%}
                 request_.Content = content_;


### PR DESCRIPTION
This PR applies to the generated code for clients when using System.Text.Json serialization library.

This PR uses the [`JsonContent`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.json.jsoncontent?view=net-9.0) class to send objects as the request body. This is the [documented way](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient) to serialize objects when making HTTP requests. It can be more efficient than serializing the entire request body into a byte array, particularly if the request body is large. This is because the `JsonContent` can stream the body while serializing and reuse buffers between requests.

In terms of the backwards compatibility impact of this change, the documentation says `JsonContent` was added in .NET 5. When running on .NET Framework, a reference to the `System.Net.Http.Json` Nuget package would now be required.

Contributes to #4083
