### PR TITLE
Upgraded Microsoft.Extensions.ApiDescription.* to 9.0.3

### DIFF
--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.nuspec
@@ -15,7 +15,7 @@
     <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="6.0.3" />
+      <dependency id="Microsoft.Extensions.ApiDescription.Client" version="9.0.3" />
       <dependency id="NSwag.MSBuild" version="1.0.0" />
     </dependencies>
     <references />

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -12,7 +12,7 @@
     <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.6</MicrosoftAspNetCoreMvcCorePackageVersion>
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.6</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.4</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftExtensionsApiDescriptionServerPackageVersion>6.0.3</MicrosoftExtensionsApiDescriptionServerPackageVersion>
+    <MicrosoftExtensionsApiDescriptionServerPackageVersion>9.0.3</MicrosoftExtensionsApiDescriptionServerPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>8.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet8>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet9>9.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersionNet9>


### PR DESCRIPTION
Upgraded Microsoft.Extensions.ApiDescription.Server & Microsoft.Extensions.ApiDescription.Client to 9.0.3

This would update the runtime dependencies (which are still dependent on AspNetCore 6.0.3) as well as the following bugfixes for Microsoft.Extensions.ApiDescription.Server:
[Fix up packaging for Extensions.ApiDescription.Server](https://github.com/dotnet/aspnetcore/pull/44136)
[Fixes for OpenAPI document generation with M.E.ApiDescription.Server](https://github.com/dotnet/aspnetcore/pull/57096)
[Upgrade to Microsoft.OpenApi 2.x and support OpenAPI v3.1](https://github.com/dotnet/aspnetcore/pull/59480)
[#59749 move TrimEnd after path normalization](https://github.com/dotnet/aspnetcore/pull/59753)
And the following for Microsoft.Extensions.ApiDescription.Client:
[#59749 move TrimEnd after path normalization](https://github.com/dotnet/aspnetcore/pull/59753)
[Fix duplicate add of items to Compile on Microsoft.Extensions.ApiDescription.Client.targets](https://github.com/dotnet/aspnetcore/pull/51846)