### PR TITLE
Fix optional parameter ordering in generated TS/CS clients

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/OptionalParameterTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/OptionalParameterTests.cs
@@ -37,8 +37,8 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Two,
             Three,
             Four
-
         }
+
         public class MyClass
         {
 #pragma warning disable IDE0051
@@ -144,6 +144,67 @@ namespace NSwag.CodeGeneration.CSharp.Tests
 
             // Assert
             Assert.Contains("TestAsync(string a, string b, string c = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))", code);
+        }
+
+        [Fact]
+        public async Task When_optional_parameter_comes_before_required()
+        {
+            // Arrange
+            const string specification = """
+                                         {
+                                           "openapi": "3.0.0",
+                                           "paths": {
+                                             "/": {
+                                               "get": {
+                                                 "operationId": "Get",
+                                                 "parameters": [
+                                                   {
+                                                     "name": "firstname",
+                                                     "in": "query",
+                                                     "schema": {
+                                                       "type": "string",
+                                                       "nullable": true
+                                                     },
+                                                     "x-position": 1
+                                                   },
+                                                   {
+                                                     "name": "lastname",
+                                                     "in": "query",
+                                                     "required": true,
+                                                     "schema": {
+                                                       "type": "string"
+                                                     },
+                                                     "x-position": 2
+                                                   }
+                                                 ],
+                                                 "responses": {
+                                                   "200": {
+                                                     "description": "",
+                                                     "content": {
+                                                       "application/json": {
+                                                         "schema": {
+                                                           "type": "string"
+                                                         }
+                                                       }
+                                                     }
+                                                   }
+                                                 }
+                                               }
+                                             }
+                                           }
+                                         }
+                                         """;
+
+            // Act
+            var document = await OpenApiDocument.FromJsonAsync(specification, "", SchemaType.OpenApi3);
+            var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings
+            {
+                GenerateOptionalParameters = true
+            });
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("GetAsync(string lastname, string firstname = null,", code);
         }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -55,16 +55,22 @@ namespace NSwag.CodeGeneration.CSharp.Models
                 // TODO: Move to CSharpControllerOperationModel
                 if (generator is CSharpControllerGenerator)
                 {
-                    parameters = [.. parameters
-                        .OrderBy(p => p.Position ?? 0)
-                        .ThenBy(p => !p.IsRequired)
-                        .ThenBy(p => p.Default == null)];
+                    parameters =
+                    [
+                        .. parameters
+                            .OrderBy(p => !p.IsRequired)
+                            .ThenBy(p => p.Default == null)
+                            .ThenBy(p => p.Position ?? 0)
+                    ];
                 }
                 else
                 {
-                    parameters = [.. parameters
-                        .OrderBy(p => p.Position ?? 0)
-                        .ThenBy(p => !p.IsRequired)];
+                    parameters =
+                    [
+                        .. parameters
+                            .OrderBy(p => !p.IsRequired)
+                            .ThenBy(p => p.Position ?? 0)
+                    ];
                 }
             }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/OptionalParameterTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/OptionalParameterTests.cs
@@ -1,0 +1,69 @@
+﻿using NJsonSchema;
+using Xunit;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    public class OptionalParameterTests
+    {
+        [Fact]
+        public async Task When_optional_parameter_comes_before_required()
+        {
+            // Arrange
+            const string specification = """
+                                         {
+                                           "openapi": "3.0.0",
+                                           "paths": {
+                                             "/": {
+                                               "get": {
+                                                 "operationId": "Get",
+                                                 "parameters": [
+                                                   {
+                                                     "name": "firstname",
+                                                     "in": "query",
+                                                     "schema": {
+                                                       "type": "string",
+                                                       "nullable": true
+                                                     },
+                                                     "x-position": 1
+                                                   },
+                                                   {
+                                                     "name": "lastname",
+                                                     "in": "query",
+                                                     "required": true,
+                                                     "schema": {
+                                                       "type": "string"
+                                                     },
+                                                     "x-position": 2
+                                                   }
+                                                 ],
+                                                 "responses": {
+                                                   "200": {
+                                                     "description": "",
+                                                     "content": {
+                                                       "application/json": {
+                                                         "schema": {
+                                                           "type": "string"
+                                                         }
+                                                       }
+                                                     }
+                                                   }
+                                                 }
+                                               }
+                                             }
+                                           }
+                                         }
+                                         """;
+
+            // Act
+            var document = await OpenApiDocument.FromJsonAsync(specification, "", SchemaType.OpenApi3);
+            var generator = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                GenerateOptionalParameters = true
+            });
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("get(lastname: string, firstname?: string | null | undefined)", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptOperationModel.cs
@@ -39,7 +39,12 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
             if (settings.GenerateOptionalParameters)
             {
-                parameters = [.. parameters.OrderBy(p => p.Position ?? 0).ThenBy(p => !p.IsRequired)];
+                parameters =
+                [
+                    .. parameters
+                        .OrderBy(p => !p.IsRequired)
+                        .ThenBy(p => p.Position ?? 0)
+                ];
             }
 
             Parameters = parameters


### PR DESCRIPTION
This was a regression caused by #5044 . The PR unintentionally "fixed" the swallowed double-`OrderBy` where only second one would run, but actually the second one was the primary ordering. Trying to now follow the desired path were anything optional makes priority in ordering and only after then the parameter's actual position.

fixes #5131