### PR TITLE
Optimize OpenApiDocument.GenerateOperationIds

### DIFF
--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -216,7 +216,7 @@ namespace NSwag.CodeGeneration.Models
         public bool HasAcceptHeaderParameterParameter => HeaderParameters.Any(static p => p.Name.Equals("accept", StringComparison.OrdinalIgnoreCase));
 
         /// <summary>Gets a value indicating whether the operation has form parameters.</summary>
-        public bool HasFormParameters => Parameters.Any(p => p.Kind == OpenApiParameterKind.FormData);
+        public bool HasFormParameters => Parameters.Any(static p => p.Kind == OpenApiParameterKind.FormData);
 
         /// <summary>Gets a value indicating whether the operation consumes 'application/x-www-form-urlencoded'.</summary>
         public bool ConsumesOnlyFormUrlEncoded =>


### PR DESCRIPTION
Check if no work needs to be done and always re-iterate with minimal workload and shared duplicate detection data structures.