### PR TITLE
Optimize MultipleClientsFromOperationIdOperationNameGenerator duplicate checks

### DIFF
--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromOperationIdOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromOperationIdOperationNameGenerator.cs
@@ -39,11 +39,19 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
             var operationName = GetOperationName(operation);
 
             var hasOperationWithSameName = false;
-            foreach (var o in document.Operations)
+            // keep iteration logic in sync with OpenApiDocument.Operations - this version is faster as being called a lot
+            // Operations property also allocates OpenApiOperationDescription wrapper for each item
+            foreach (var p in document._paths)
             {
-                if (o.Operation != operation)
+                foreach (var pair in p.Value.ActualPathItem)
                 {
-                    if (GetClientName(o.Operation).SequenceEqual(clientName) && GetOperationName(o.Operation).SequenceEqual(operationName))
+                    var documentOperation = pair.Value;
+                    if (documentOperation == operation)
+                    {
+                        continue;
+                    }
+
+                    if (GetClientName(documentOperation).SequenceEqual(clientName) && GetOperationName(documentOperation).SequenceEqual(operationName))
                     {
                         hasOperationWithSameName = true;
                         break;

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromOperationIdOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/MultipleClientsFromOperationIdOperationNameGenerator.cs
@@ -6,6 +6,7 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using NJsonSchema;
 
 namespace NSwag.CodeGeneration.OperationNameGenerators
@@ -51,7 +52,8 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
                         continue;
                     }
 
-                    if (GetClientName(documentOperation).SequenceEqual(clientName) && GetOperationName(documentOperation).SequenceEqual(operationName))
+                    if (GetOperationName(documentOperation).SequenceEqual(operationName)
+                        && GetClientName(documentOperation).SequenceEqual(clientName))
                     {
                         hasOperationWithSameName = true;
                         break;
@@ -110,12 +112,14 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
             return operationIdSpan.Slice(idxSecondLast + 1);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ReadOnlySpan<char> GetOperationName(OpenApiOperation operation)
         {
-            var idx = operation.OperationId.LastIndexOf('_');
-            return idx != -1 && idx < operation.OperationId.Length - 1
-                ? operation.OperationId.AsSpan(idx + 1)
-                : operation.OperationId.AsSpan();
+            var span = operation.OperationId.AsSpan();
+            var idx = span.LastIndexOf('_');
+            return idx != -1 && idx < span.Length - 1
+                ? span.Slice(idx + 1)
+                : span;
         }
     }
 }

--- a/src/NSwag.Core/OpenApiDocument.cs
+++ b/src/NSwag.Core/OpenApiDocument.cs
@@ -21,7 +21,7 @@ namespace NSwag
     /// <summary>Describes a JSON web service.</summary>
     public partial class OpenApiDocument : JsonExtensionObject, IDocumentPathProvider
     {
-        private readonly ObservableDictionary<string, OpenApiPathItem> _paths;
+        internal readonly ObservableDictionary<string, OpenApiPathItem> _paths;
 
         /// <summary>Initializes a new instance of the <see cref="OpenApiDocument"/> class.</summary>
         public OpenApiDocument()


### PR DESCRIPTION
Still not ideal, but now using direct data structures instead enumeration allocator which also creates wrapper types unnecessary for these scenarios.