### PR TITLE
Fixed template to generate non-deprecated code for _observableThrow method

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -99,10 +99,10 @@
                     return this.process{{ operation.ActualOperationNameUpper }}(response_ as any);
 {%-    endif -%}
                 } catch (e) {
-                    return {{ Framework.RxJs.ObservableThrowMethod }}(e) as any as Observable<{{ operation.ResultType }}>;
+                    return {{ Framework.RxJs.ObservableThrowMethod }}(() => e) as any as Observable<{{ operation.ResultType }}>;
                 }
             } else
-                return {{ Framework.RxJs.ObservableThrowMethod }}(response_) as any as Observable<{{ operation.ResultType }}>;
+                return {{ Framework.RxJs.ObservableThrowMethod }}(() => response_) as any as Observable<{{ operation.ResultType }}>;
         }){% if Framework.UseRxJs6 %}){% endif %};
     }
 


### PR DESCRIPTION
Currently generated code for Framework.RxJs.ObservableThrowMethod does not comply with RxJs 7+ versions.
_observableThrow is generated as deprecated for the same reason.
Fixed Angular client template to generate non--deprecated code.