### PR TITLE
Remove requirement for specific NET SDK in GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,6 @@ jobs:
         run: |
           echo "Adding GNU tar to PATH"
           echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0
-            9.0.204
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish
@@ -81,7 +76,7 @@ jobs:
         with:
           dotnet-version: |
             8.0
-            9.0.204
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish
@@ -94,11 +89,6 @@ jobs:
     name: macos-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0
-            9.0.204
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,11 +42,6 @@ jobs:
         run: |
           echo "Adding GNU tar to PATH"
           echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0
-            9.0.204
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
@@ -78,7 +73,7 @@ jobs:
         with:
           dotnet-version: |
             8.0
-            9.0.204
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
@@ -86,11 +81,6 @@ jobs:
     name: macos-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0
-            9.0.204
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -46,7 +46,11 @@ class CustomGitHubActionsAttribute : GitHubActionsAttribute
 
         var newSteps = new List<GitHubActionsStep>(job.Steps);
 
-        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["8.0", "9.0.204"]));
+        var onUbuntu = image.ToString().StartsWith("ubuntu", StringComparison.OrdinalIgnoreCase);
+        if (onUbuntu)
+        {
+            newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["8.0", "9.0"]));
+        }
 
         var onWindows = image.ToString().StartsWith("windows", StringComparison.OrdinalIgnoreCase);
         if (onWindows)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -149,6 +149,7 @@ partial class Build : NukeBuild
             DotNetRestore(x => x
                 .SetProjectFile(SolutionFile)
                 .SetVerbosity(DotNetVerbosity.minimal)
+                .AddProperty("BuildWithNetFrameworkHostedCompiler", "true")
             );
         });
 


### PR DESCRIPTION
This was originally added because Windows images were changed and incompatible, now this earlier change seems again incompatible with newer images..