### PR TITLE
Remove null-checks for non-required properties (csharp code generation)

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -249,10 +249,12 @@
 {%                 for parameter in operation.FormParameters %}
 {%                     if parameter.IsNullable -%}
                 if ({{ parameter.VariableName }} != null)
-{%                     else -%}
+{%                     elsif parameter.IsRequired -%}
                 if ({{ parameter.VariableName }} == null)
                     throw new System.ArgumentNullException("{{ parameter.VariableName }}");
                 else
+{%                     else -%}
+				if ({{ parameter.VariableName }} != null)
 {%                     endif -%}
                 {
 {%                     if parameter.IsFile -%}


### PR DESCRIPTION
Same as described in https://github.com/RicoSuter/NSwag/pull/5023:

Given:
```
            "multipart/form-data": {
              "schema": {
                "required": [
                  "file"
                ],
                "type": "object",
                "properties": {
                  "file": {
                    "type": "string",
                    "description": "",
                    "format": "binary"
                  },
                  "fileDescription": {
                    "type": "string",
                    "description": ""
                  }
                }
              }, ...
```

Instead of:
```
                    if (file == null)
                        throw new System.ArgumentNullException("file");
                    else
                    {
                     ...
                    }

                    if (fileDescription != null)
                    {
                     ...
                    }
```

It generates:
```
                    if (file == null)
                        throw new System.ArgumentNullException("file");
                    else
                    {
                     ...
                    }

                    if (fileDescription == null)
                        throw new System.ArgumentNullException("fileDescription");
                    else
                    {
                     ...
                    }
```

This PR resolves the issue with a different approach (tested and used in our application)