### PR TITLE
Make the access modifier for the client interface match the client

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Interface.liquid
@@ -1,6 +1,6 @@
 {% template Client.Interface.Annotations %}
 [System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
-public partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ ClientBaseInterface }}{% endif %}
+{{ ClientClassAccessModifier }} partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ ClientBaseInterface }}{% endif %}
 {
     {% template Client.Interface.Body %}
 {% for operation in InterfaceOperations -%}


### PR DESCRIPTION
This makes the `Client.Interface.liquid` template match the [`Client.Class.liquid`](https://github.com/RicoSuter/NSwag/blob/3cc1c36c7f9d632174bd6b478311879cb343251a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid#L3) template. This will prevent CS0050 from occurring when the `clientClassAccessModifier` and `typeAccessModifier` settings are set to `internal`.

Currently CS0050 is thrown when these settings are set to `internal` because the interface is `public` while the types in the method signatures are `internal`.