### PR TITLE
Prioritize wildcard over json over first entry for accept content-type

### DIFF
--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -124,6 +124,9 @@ namespace NSwag.CodeGeneration.Models
         public IDictionary<string, object> ExtensionData => _response.ExtensionData;
 
         /// <summary>Gets the produced mime type of this response if available.</summary>
-        public string Produces => _response.Content.Keys.FirstOrDefault();
+        public string Produces =>
+            _response.Content.Keys.FirstOrDefault(k => k == "*/*") ??
+            _response.Content.Keys.FirstOrDefault(k => k == "application/json") ??
+            _response.Content.Keys.FirstOrDefault();
     }
 }


### PR DESCRIPTION
We have an issue with a external API definition that defines the following response:
```
      responses:
        '200':
          description: Status Code 200
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/QueryResult'
            application/json:
              schema:
                $ref: '#/components/schemas/QueryResult'
```

When generating a C# Client for this, the accept header will be set to "application/xml" while the client tries to deserialize the response as json. Since json is prioritized in many other spots this should be done here as well.