### PR TITLE
refactor(codegen): sort operation responses by status code

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -391,7 +391,8 @@
 {% endif %}
 
                     var status_ = (int)response_.StatusCode;
-{%     for response in operation.Responses -%}
+{%     assign orderedResponses = operation.Responses | sort: "StatusCode" -%}
+{%     for response in orderedResponses -%}
                     if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
                     {
                         {% template Client.Class.ProcessResponse %}


### PR DESCRIPTION
Sorts the operation responses by status code in the NSwag CodeGeneration CSharp client template. This change ensures that responses are checked in a consistent order.

This fixes #5200.