### PR TITLE
Fix to expose an optional param for AbortSignal (for axios) / CancelToken (for fetch) when GenerateClientInterfaces = true

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/AxiosTests.cs
@@ -28,6 +28,12 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             public void AddMessage([FromForm] Foo message, [FromForm] string messageId)
             {
             }
+
+            [HttpGet]
+            public Foo GetMessage([FromQuery] string messageId)
+            {
+                return new Foo { Bar = $"Hello World ({messageId})" };
+            }
         }
 
         [Fact]
@@ -172,6 +178,39 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             {
                 Template = TypeScriptTemplate.Axios,
                 UseAbortSignal = true,
+                TypeScriptGeneratorSettings =
+                {
+                    TypeScriptVersion = 2.0m
+                }
+            });
+            var code = codeGen.GenerateFile();
+
+            // Assert
+            Assert.Contains("signal?: AbortSignal", code);
+        }
+
+        [Fact]
+        public async Task When_abort_signal_and_generate_client_interfaces_contains_signal_param_in_both_interface_and_concrete_implementation()
+        {
+            // Arrange
+            var generator = new WebApiOpenApiDocumentGenerator(new WebApiOpenApiDocumentGeneratorSettings
+            {
+                SchemaSettings = new NewtonsoftJsonSchemaGeneratorSettings
+                {
+                    SchemaType = SchemaType.OpenApi3
+                }
+            });
+
+            var document = await generator.GenerateForControllerAsync<UrlEncodedRequestConsumingController>();
+            var json = document.ToJson();
+            Assert.NotNull(json);
+
+            // Act
+            var codeGen = new TypeScriptClientGenerator(document, new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Axios,
+                UseAbortSignal = true,
+                GenerateClientInterfaces = true,
                 TypeScriptGeneratorSettings =
                 {
                     TypeScriptVersion = 2.0m

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AxiosClient.liquid
@@ -3,7 +3,7 @@
 {% if ExportTypes %}export {% endif %}interface I{{ Class }} {
 {%     for operation in Operations -%}
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}): Promise<{{ operation.ResultType }}>;
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if operation.Parameters.size > 0 %}, {%endif%}{% endfor %}{% if UseAbortSignal %}signal?: AbortSignal{% else %} cancelToken?: CancelToken{% endif %}): Promise<{{ operation.ResultType }}>;
 {%     endfor -%}}
 {%- endif %}
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -4,7 +4,7 @@
 {%    for operation in Operations %}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}): Promise<{{ operation.ResultType }}>;
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if operation.Parameters.size > 0 %}, {%endif%}{% endfor %}{% if UseAbortSignal %}signal?: AbortSignal{% else %} cancelToken?: CancelToken{% endif %}): Promise<{{ operation.ResultType }}>;
 {%-    endfor %}}
 {%- endif -%}
 


### PR DESCRIPTION
Fix to expose an optional param for AbortSignal (for axios) / CancelToken (for fetch) on the client's interface similar to the concrete implementation so you can actually use it.
Fixes https://github.com/RicoSuter/NSwag/issues/3634 (#3634)
but also mentioned in this issue: https://github.com/RicoSuter/NSwag/issues/4045 (#4045) which implemented this only on the concrete implementation.