### PR TITLE
Surface ExtensionData in CSharpControllerTemplateModel

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
@@ -94,5 +94,8 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets the API version.</summary>
         public string Version => _document.Info.Version;
+
+        /// <summary>Gets the extension data.</summary>
+        public IDictionary<string, object> ExtensionData => _document.ExtensionData;
     }
 }


### PR DESCRIPTION
Similar to how `ExtensionData` can be accessed on a C# controller's operations objects, I wanted to be able to access the `ExtensionData` in a custom template that extended `Controller.Class.Annotations`. 

Here's a [gist](https://gist.github.com/hirudan/9cce6010702d08a87b043de92d3863ca) with minimal OpenAPI spec and Liquid template that I ran through NSwag Studio and observed the intended result (also in the gist).

My ultimate use case is to be able to write a custom template extension that will emit a `[FeatureGate]` attribute on top of the generated controller if I specify a custom property on the OpenAPI doc, but this will hopefully be generally useful for other purposes too.

First time contributing, so apologies if I didn't follow protocol quite right.