### PR TITLE
Update Microsoft.AspNetCore.* references to target 2.3.0

### DIFF
--- a/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
+++ b/src/NSwag.AspNet.Owin/NSwag.AspNet.Owin.csproj
@@ -21,9 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.2.2" />
-    <PackageReference Include="Owin" Version="1.0" />
+    <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -9,13 +9,11 @@
     <!-- Execute PopulateNuspec fairly late. -->
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);PopulateNuspec</GenerateNuspecDependsOn>
 
-    <MicrosoftAspNetCoreMvcCorePackageVersion>1.0.6</MicrosoftAspNetCoreMvcCorePackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>1.0.6</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
-    <MicrosoftAspNetCoreStaticFilesPackageVersion>1.0.4</MicrosoftAspNetCoreStaticFilesPackageVersion>
+    <MicrosoftAspNetCoreMvcCorePackageVersion>2.3.0</MicrosoftAspNetCoreMvcCorePackageVersion>
+    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>2.3.0</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
+    <MicrosoftAspNetCoreStaticFilesPackageVersion>2.3.0</MicrosoftAspNetCoreStaticFilesPackageVersion>
     <MicrosoftExtensionsApiDescriptionServerPackageVersion>8.0.14</MicrosoftExtensionsApiDescriptionServerPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>1.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
-    <SystemIOFileSystemPackageVersion>4.3.0</SystemIOFileSystemPackageVersion>
-    <SystemXmlXPathXDocumentPackageVersion>4.0.1</SystemXmlXPathXDocumentPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>2.1.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,15 +27,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="$(MicrosoftAspNetCoreMvcFormattersJsonPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.IO.FileSystem" Version="$(SystemIOFileSystemPackageVersion)" />
-    <PackageReference Include="System.Xml.XPath.XDocument" Version="$(SystemXmlXPathXDocumentPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,8 +53,6 @@
         microsoftAspNetCoreStaticFilesPackageVersion=$(MicrosoftAspNetCoreStaticFilesPackageVersion);
         microsoftExtensionsApiDescriptionServerPackageVersion=$(MicrosoftExtensionsApiDescriptionServerPackageVersion);
         microsoftExtensionsFileProvidersEmbeddedPackageVersion=$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion);
-        systemIOFileSystemPackageVersion=$(SystemIOFileSystemPackageVersion);
-        systemXmlXPathXDocumentPackageVersion=$(SystemXmlXPathXDocumentPackageVersion);
       </NuspecProperties>
     </PropertyGroup>
   </Target>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.nuspec
@@ -34,8 +34,6 @@
                 <dependency id="Microsoft.AspNetCore.StaticFiles" version="$microsoftAspNetCoreStaticFilesPackageVersion$" exclude="Build,Analyzers" />
                 <dependency id="Microsoft.Extensions.ApiDescription.Server" version="$microsoftExtensionsApiDescriptionServerPackageVersion$" />
                 <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="$microsoftExtensionsFileProvidersEmbeddedPackageVersion$" exclude="Build,Analyzers" />
-                <dependency id="System.IO.FileSystem" version="$systemIOFileSystemPackageVersion$" exclude="Build,Analyzers" />
-                <dependency id="System.Xml.XPath.XDocument" version="$systemXmlXPathXDocumentPackageVersion$" exclude="Build,Analyzers" />
             </group>
             <group targetFramework="net8.0">
                 <dependency id="NSwag.Annotations" version="$version$" exclude="Build,Analyzers" />

--- a/src/NSwag.Commands/NSwag.Commands.csproj
+++ b/src/NSwag.Commands/NSwag.Commands.csproj
@@ -11,26 +11,8 @@
     <EmbeddedResource Include="Commands\Generation\AspNetCore\AspNetCore.targets" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="[2.1.7, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.1.34, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.1.25, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="[2.1.40, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.1.1, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.1.3, 2.2)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.1.18, 2.2)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.Console.x86/NSwag.Console.x86.csproj
+++ b/src/NSwag.Console.x86/NSwag.Console.x86.csproj
@@ -15,14 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="NConsole" Version="3.12.6605.26941" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\NSwag.AspNetCore.Launcher.x86\NSwag.AspNetCore.Launcher.x86.csproj" />
     <ProjectReference Include="..\NSwag.Commands\NSwag.Commands.csproj" />
   </ItemGroup>

--- a/src/NSwag.Console/NSwag.Console.csproj
+++ b/src/NSwag.Console/NSwag.Console.csproj
@@ -9,13 +9,6 @@
     <RootNamespace>NSwag</RootNamespace>
     <DependsOnNETStandard>true</DependsOnNETStandard>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="NConsole" Version="3.12.6605.26941" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NSwag.AspNetCore.Launcher\NSwag.AspNetCore.Launcher.csproj" />

--- a/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
+++ b/src/NSwag.ConsoleCore/NSwag.ConsoleCore.csproj
@@ -13,21 +13,6 @@
     <ProjectReference Include="..\NSwag.Commands\NSwag.Commands.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NConsole" Version="3.12.6605.26941" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
-  </ItemGroup>
-
   <!-- Workaround for https://github.com/NuGet/Home/issues/3891 -->
   <PropertyGroup>
      <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>

--- a/src/NSwag.Generation.AspNetCore.Tests.Web/NSwag.Generation.AspNetCore.Tests.Web.csproj
+++ b/src/NSwag.Generation.AspNetCore.Tests.Web/NSwag.Generation.AspNetCore.Tests.Web.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
+++ b/src/NSwag.Generation.AspNetCore.Tests/NSwag.Generation.AspNetCore.Tests.csproj
@@ -18,12 +18,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
+++ b/src/NSwag.Generation.AspNetCore/NSwag.Generation.AspNetCore.csproj
@@ -7,9 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/NSwagStudio/NSwagStudio.csproj
+++ b/src/NSwagStudio/NSwagStudio.csproj
@@ -59,14 +59,13 @@
     <PackageReference Include="AvalonEdit" Version="5.0.3" />
     <PackageReference Include="Expression.Interaction" Version="3.0.40218" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="MyToolkit" Version="2.5.16" />
     <PackageReference Include="MyToolkit.Extended" Version="2.5.16" />
     <PackageReference Include="Namotion.Reflection" Version="3.4.2" />
     <PackageReference Include="NConsole" Version="3.12.6605.26941" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />


### PR DESCRIPTION
2.3.0 is now the preferred and still maintained target if running on full framework:

https://devblogs.microsoft.com/dotnet/servicing-release-advisory-aspnetcore-23/

Also trimming some csproj dependencies and redundancy.