### PR TITLE
Fix generating typescript fetch client interfaces when useAbortSignal is false

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/FetchTests.cs
@@ -65,9 +65,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
 
             // Assert
             await VerifyHelper.Verify(code);
-
-            // should use AbortController instead of CancelToken
-            // CodeCompiler.AssertCompile(code);
+            TypeScriptCompiler.AssertCompile(code);
         }
 
         [Fact]
@@ -98,9 +96,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
 
             // Assert
             await VerifyHelper.Verify(code);
-
-            // should use AbortController instead of CancelToken
-            // CodeCompiler.AssertCompile(code);
+            TypeScriptCompiler.AssertCompile(code);
         }
 
         [Fact]

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
@@ -3,7 +3,7 @@
 
 interface IDiscussionClient {
 
-    addMessage(message: Foo | null | undefined,  cancelToken?: CancelToken): Promise<void>;
+    addMessage(message: Foo | null | undefined): Promise<void>;
 }
 
 class DiscussionClient implements IDiscussionClient {

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
@@ -3,7 +3,7 @@
 
 export interface IDiscussionClient {
 
-    addMessage(message: Foo | null | undefined,  cancelToken?: CancelToken): Promise<void>;
+    addMessage(message: Foo | null | undefined): Promise<void>;
 }
 
 export class DiscussionClient implements IDiscussionClient {

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -4,7 +4,7 @@
 {%    for operation in Operations %}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if operation.Parameters.size > 0 %}, {%endif%}{% endfor %}{% if UseAbortSignal %}signal?: AbortSignal{% else %} cancelToken?: CancelToken{% endif %}): Promise<{{ operation.ResultType }}>;
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {%endif%}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal{% endif %}): Promise<{{ operation.ResultType }}>;
 {%-    endfor %}}
 {%- endif -%}
 


### PR DESCRIPTION
- Fix Fetch template to not create CancelToken on the interface
- Restore two Fetch test cases to check that generated typescript code compiles