### PR TITLE
Fix NPM CLI argument handling

### DIFF
--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -36,8 +36,6 @@ args.forEach((arg, idx) => {
 if (runtimeIndices.length > 1) {
     console.error("Error: Multiple /runtime:* arguments detected. Please specify only one. Maybe remove the legacy --core argument?");
     process.exit(1);
-} else if (runtimeIndices.length === 1) {
-    args.splice(runtimeIndices[0], 1);
 }
 
 if (runtimeValue) {


### PR DESCRIPTION
NConsole seems to have a bug which makes it a requirement that there needs to be one unused argument. This restores the old behavior and runtime parameter is passed to actual NET CLI.

fixes #5238
