### PR TITLE
#5250 - K6 template for Typescript has errors when void is return type

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
@@ -13,8 +13,8 @@ export class UrlEncodedRequestConsumingClient {
       this.commonRequestParameters = commonRequestParameters || {};
     }
 
-    addMessage(message: Foo | null | undefined, messageId: string | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    addMessage(message: Foo | null | undefined, messageId: string | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -33,16 +33,16 @@ export class UrlEncodedRequestConsumingClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/x-www-form-urlencoded",
           },
         }
       );
 
+      return response;
     }
-
   /**
   *
   */

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
@@ -6,11 +6,11 @@ import type { Params, Response } from "k6/http";
 
 interface IDiscussionClient {
 
-  addMessage(message: Foo, requestParameters?: Params):  void ;
+  addMessage(message: Foo, requestParameters?: Params): Response;
 
-  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response;
 
-  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response;
 }
 
 class DiscussionClient implements IDiscussionClient {
@@ -22,8 +22,8 @@ class DiscussionClient implements IDiscussionClient {
       this.commonRequestParameters = commonRequestParameters || {};
     }
 
-    addMessage(message: Foo, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    addMessage(message: Foo, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -37,18 +37,19 @@ class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -62,18 +63,19 @@ class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -87,16 +89,16 @@ class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
-
   /**
   *
   */

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_export_types_is_true_then_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_export_types_is_true_then_add_export_before_classes.verified.txt
@@ -6,11 +6,11 @@ import type { Params, Response } from "k6/http";
 
 export interface IDiscussionClient {
 
-  addMessage(message: Foo, requestParameters?: Params):  void ;
+  addMessage(message: Foo, requestParameters?: Params): Response;
 
-  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response;
 
-  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response;
 }
 
 export class DiscussionClient implements IDiscussionClient {
@@ -22,8 +22,8 @@ export class DiscussionClient implements IDiscussionClient {
       this.commonRequestParameters = commonRequestParameters || {};
     }
 
-    addMessage(message: Foo, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    addMessage(message: Foo, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -37,18 +37,19 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -62,18 +63,19 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -87,16 +89,16 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
-
   /**
   *
   */

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_generic_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_generic_request.verified.txt
@@ -13,8 +13,8 @@ class DiscussionClient {
       this.commonRequestParameters = commonRequestParameters || {};
     }
 
-    addMessage(message: Foo, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    addMessage(message: Foo, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -28,18 +28,19 @@ class DiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -53,18 +54,19 @@ class DiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -78,16 +80,16 @@ class DiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
-
   /**
   *
   */

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/K6Tests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
@@ -6,11 +6,11 @@ import type { Params, Response } from "k6/http";
 
 export interface IDiscussionClient {
 
-  addMessage(message: Foo, requestParameters?: Params):  void ;
+  addMessage(message: Foo, requestParameters?: Params): Response;
 
-  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response;
 
-  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void ;
+  genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response;
 }
 
 export class DiscussionClient implements IDiscussionClient {
@@ -22,8 +22,8 @@ export class DiscussionClient implements IDiscussionClient {
       this.commonRequestParameters = commonRequestParameters || {};
     }
 
-    addMessage(message: Foo, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    addMessage(message: Foo, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -37,18 +37,19 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest1(request: GenericRequest1 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -62,18 +63,19 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
 
-    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params):  void  {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    genericRequestTest2(request: GenericRequest2 | null | undefined, requestParameters?: Params): Response  {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -87,16 +89,16 @@ export class DiscussionClient implements IDiscussionClient {
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
             "Content-Type": "application/json",
           },
         }
       );
 
+      return response;
     }
-
   /**
   *
   */

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/K6Client.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/K6Client.liquid
@@ -7,7 +7,7 @@ import type { Params, Response } from "k6/http";
 {%    for operation in Operations %}
 
   {% template Client.Method.Documentation %}
-  {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}, requestParameters?: Params): {% if operation.ResultType != "void" %} { response: Response; data: {{ operation.ResultType }} }{% else %} {{ operation.ResultType }} {% endif %};
+  {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if operation.Parameters.size > 0 %}, {% endif %}requestParameters?: Params): {% if operation.ResultType != "void" %}{ response: Response; data: {{ operation.ResultType }} }{% else %}Response{% endif %};
 {%-    endfor %}}
 {%- endif -%}
 
@@ -38,8 +38,8 @@ import type { Params, Response } from "k6/http";
 {%- endif -%}
 {% for operation in Operations %}
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal{% endif %}, requestParameters?: Params): {% if operation.ResultType != "void" %} { response: Response; data: {{ operation.ResultType }} }{% else %} {{ operation.ResultType }} {% endif %} {
-      const _mergedRequestParameters = this._mergeRequestParameters(
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false %}, {% endif %}{% endfor %}{% if UseAbortSignal %}{% if operation.Parameters.size > 0 %}, {% endif %}signal?: AbortSignal{% endif %}{% if operation.Parameters.size > 0 %}, {% endif %}requestParameters?: Params): {% if operation.ResultType != "void" %}{ response: Response; data: {{ operation.ResultType }} }{% else %}Response {% endif %} {
+      const mergedRequestParameters = this._mergeRequestParameters(
         requestParameters || {},
         this.commonRequestParameters,
       );
@@ -55,9 +55,9 @@ import type { Params, Response } from "k6/http";
         url_.toString(),
         content_,
         {
-          ..._mergedRequestParameters,
+          ...mergedRequestParameters,
           headers: {
-            ..._mergedRequestParameters?.headers,
+            ...mergedRequestParameters?.headers,
 {%-    if operation.HasContent or operation.ConsumesOnlyFormUrlEncoded -%}
             "Content-Type": "{{ operation.Consumes }}",
 {%-    endif -%}
@@ -69,7 +69,7 @@ import type { Params, Response } from "k6/http";
       );
 {%-   else -%}
       const response = http.request("{{ operation.HttpMethodUpper | upcase }}", url_.toString(), undefined, {
-        ..._mergedRequestParameters,
+        ...mergedRequestParameters,
       });
 {%-   endif -%}
 
@@ -84,16 +84,17 @@ import type { Params, Response } from "k6/http";
         response,
         data,
       };
+{%-   else -%}
+      return response;
 {%-   endif -%}
     }
 {% endfor -%}
-
   /**
-  * Combines the provided request parameters with default parameters for the client.
+  * Merges the provided request parameters with default parameters for the client.
   *
   * @param {Params} requestParameters - The parameters provided specifically for the request
   * @param {Params} commonRequestParameters - Common parameters for all requests
-  * @returns {Params} - The combined parameters
+  * @returns {Params} - The merged parameters
   */
   private _mergeRequestParameters(
     requestParameters?: Params,


### PR DESCRIPTION
Fixes #5250 - Fixing errors by handling for void by having k6 http.Response as a return type so k6 checks can check status codes to identify success or failure.