### PR TITLE
Restore Microsoft.Extensions.ApiDescription.Server reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,9 +43,11 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
+++ b/src/NSwag.AspNetCore/NSwag.AspNetCore.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NSwag.Annotations\NSwag.Annotations.csproj" />
     <ProjectReference Include="..\NSwag.Core.Yaml\NSwag.Core.Yaml.csproj" />


### PR DESCRIPTION
The reference to Microsoft.Extensions.ApiDescription.Server was removed from NSwag.AspNetCore in #5217
Was that intentional, or should we add it back? 