### PR TITLE
feat: Node.js compatible generated TypeScript clients

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ArrayParameterTests.When_parameter_is_array_then_TypeScript_is_correct.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ArrayParameterTests.When_parameter_is_array_then_TypeScript_is_correct.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class MyClass {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "http://localhost:8080/";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ArrayParameterTests.when_content_is_formdata_with_property_array_then_content_should_be_added_in_foreach_in_typescript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ArrayParameterTests.when_content_is_formdata_with_property_array_then_content_should_be_added_in_foreach_in_typescript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class FileUploadClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInMultipartFileArray_ThenFormDataIsUsedInTypeScript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInMultipartFileArray_ThenFormDataIsUsedInTypeScript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class FileUploadClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInNestedMultipartForm_ThenFormDataIsUsedInTypeScript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInNestedMultipartForm_ThenFormDataIsUsedInTypeScript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class FileUploadClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInSingleMultipartFile_ThenFormDataIsUsedInTypeScript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.WhenSpecContainsFormDataInSingleMultipartFile_ThenFormDataIsUsedInTypeScript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class FileUploadClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.When_body_is_binary_then_blob_is_used_as_parameter_in_TypeScript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/BinaryTests.When_body_is_binary_then_blob_is_used_as_parameter_in_TypeScript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://www.example.com/";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/CodeGenerationTests.When_generating_TypeScript_code_then_output_contains_expected_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/CodeGenerationTests.When_generating_TypeScript_code_then_output_contains_expected_classes.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class MyClass {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/CodeGenerationTests.When_path_starts_with_numeric_can_generate_client.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/CodeGenerationTests.When_path_starts_with_numeric_can_generate_client.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://myapi.centralus-01.azurewebsites.net/";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_abort_signal.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_abort_signal.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_abort_signal_and_generate_client_interfaces_interface_contains_signal_param.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_abort_signal_and_generate_client_interfaces_interface_contains_signal_param.verified.txt
@@ -9,12 +9,12 @@ export interface IUrlEncodedRequestConsumingClient {
 }
 
 export class UrlEncodedRequestConsumingClient implements IUrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
@@ -7,12 +7,12 @@ interface IDiscussionClient {
 }
 
 class DiscussionClient implements IDiscussionClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
@@ -7,12 +7,12 @@ export interface IDiscussionClient {
 }
 
 export class DiscussionClient implements IDiscussionClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_include_RequestCredentialsType_Include.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_include_RequestCredentialsType_Include.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_include_RequestModeType_Cors.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_include_RequestModeType_Cors.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_abort_signal.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_abort_signal.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Aurelia.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Aurelia.verified.txt
@@ -7,12 +7,12 @@ import { HttpClient, RequestInit } from 'aurelia-fetch-client';
 
 @inject(String, HttpClient)
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37289,12 +37289,12 @@ export class Client {
 
 @inject(String, HttpClient)
 export class AddonPropertiesResource_getAddonPropertiesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37350,12 +37350,12 @@ export class AddonPropertiesResource_getAddonPropertiesClient {
 
 @inject(String, HttpClient)
 export class AddonPropertiesResource_deleteAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37425,12 +37425,12 @@ export class AddonPropertiesResource_deleteAddonPropertyClient {
 
 @inject(String, HttpClient)
 export class AddonPropertiesResource_getAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37504,12 +37504,12 @@ export class AddonPropertiesResource_getAddonPropertyClient {
 
 @inject(String, HttpClient)
 export class AddonPropertiesResource_putAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37587,12 +37587,12 @@ export class AddonPropertiesResource_putAddonPropertyClient {
 
 @inject(String, HttpClient)
 export class DynamicModulesResource_removeModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37647,12 +37647,12 @@ export class DynamicModulesResource_removeModulesClient {
 
 @inject(String, HttpClient)
 export class DynamicModulesResource_getModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37704,12 +37704,12 @@ export class DynamicModulesResource_getModulesClient {
 
 @inject(String, HttpClient)
 export class DynamicModulesResource_registerModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37768,12 +37768,12 @@ export class DynamicModulesResource_registerModulesClient {
 
 @inject(String, HttpClient)
 export class AppIssueFieldValueUpdateResource_updateIssueFieldsClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37833,12 +37833,12 @@ export class AppIssueFieldValueUpdateResource_updateIssueFieldsClient {
 
 @inject(String, HttpClient)
 export class MigrationResource_updateEntityPropertiesValueClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37897,12 +37897,12 @@ export class MigrationResource_updateEntityPropertiesValueClient {
 
 @inject(String, HttpClient)
 export class MigrationResource_workflowRuleSearchClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37961,12 +37961,12 @@ export class MigrationResource_workflowRuleSearchClient {
 
 @inject(String, HttpClient)
 export class ServiceRegistryResource_servicesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Fetch.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Fetch.verified.txt
@@ -3,12 +3,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37284,12 +37284,12 @@ export class Client {
 }
 
 export class AddonPropertiesResource_getAddonPropertiesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37344,12 +37344,12 @@ export class AddonPropertiesResource_getAddonPropertiesClient {
 }
 
 export class AddonPropertiesResource_deleteAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37418,12 +37418,12 @@ export class AddonPropertiesResource_deleteAddonPropertyClient {
 }
 
 export class AddonPropertiesResource_getAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37496,12 +37496,12 @@ export class AddonPropertiesResource_getAddonPropertyClient {
 }
 
 export class AddonPropertiesResource_putAddonPropertyClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37578,12 +37578,12 @@ export class AddonPropertiesResource_putAddonPropertyClient {
 }
 
 export class DynamicModulesResource_removeModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37637,12 +37637,12 @@ export class DynamicModulesResource_removeModulesClient {
 }
 
 export class DynamicModulesResource_getModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37693,12 +37693,12 @@ export class DynamicModulesResource_getModulesClient {
 }
 
 export class DynamicModulesResource_registerModulesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37756,12 +37756,12 @@ export class DynamicModulesResource_registerModulesClient {
 }
 
 export class AppIssueFieldValueUpdateResource_updateIssueFieldsClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37820,12 +37820,12 @@ export class AppIssueFieldValueUpdateResource_updateIssueFieldsClient {
 }
 
 export class MigrationResource_updateEntityPropertiesValueClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37883,12 +37883,12 @@ export class MigrationResource_updateEntityPropertiesValueClient {
 }
 
 export class MigrationResource_workflowRuleSearchClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 
@@ -37946,12 +37946,12 @@ export class MigrationResource_workflowRuleSearchClient {
 }
 
 export class ServiceRegistryResource_servicesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "https://your-domain.atlassian.net";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ObjectParameterTests.when_content_is_formdata_with_property_object_then_content_should_be_json_typescript.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/ObjectParameterTests.when_content_is_formdata_with_property_object_then_content_should_be_json_typescript.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class FileUploadClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/OptionalParameterTests.When_optional_parameter_comes_before_required.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/OptionalParameterTests.When_optional_parameter_comes_before_required.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptDiscriminatorTests.When_parameter_is_abstract_then_generate_union.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptDiscriminatorTests.When_parameter_is_abstract_then_generate_union.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class DiscriminatorClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_and_ts20_then_it_is_a_union_type_with_undefined.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_and_ts20_then_it_is_a_union_type_with_undefined.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class NullableParameterClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_and_ts20_then_it_is_not_included_in_query_string.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_and_ts20_then_it_is_not_included_in_query_string.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class NullableParameterClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_optional_and_ts20_then_it_is_a_union_type_with_undefined.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_optional_and_ts20_then_it_is_a_union_type_with_undefined.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class NullableOptionalParameterClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_optional_and_ts20_then_it_is_not_included_in_query_string.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/TypeScriptOperationParameterTests.When_parameter_is_nullable_optional_and_ts20_then_it_is_not_included_in_query_string.verified.txt
@@ -2,12 +2,12 @@
 // ReSharper disable InconsistentNaming
 
 export class NullableOptionalParameterClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/temp_7aa36f3f-17b9-44df-818f-20a51fb73bb5.ts
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/temp_7aa36f3f-17b9-44df-818f-20a51fb73bb5.ts
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class UrlEncodedRequestConsumingClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/FetchClient.liquid
@@ -12,16 +12,16 @@
 @inject({% if HasConfigurationClass %}{{ ConfigurationClass }}, {% endif %}String, HttpClient)
 {%- endif -%}
 {% if ExportTypes %}export {% endif %}class {{ Class }} {% if HasBaseClass %}extends {{ BaseClass }} {% endif %}{% if GenerateClientInterfaces %}implements I{{ Class }} {% endif %}{
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 {{ '' }}
 {%- if HasExtendedConstructor == false -%}
-    constructor({% if HasConfigurationClass %}configuration: {{ ConfigurationClass }}, {% endif %}baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
+    constructor({% if HasConfigurationClass %}configuration: {{ ConfigurationClass }}, {% endif %}baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
 {%-    if HasBaseClass -%}
         super({% if HasConfigurationClass %}configuration{% endif %});
 {%-    endif -%}
-        this.http = http ? http : window as any;
+        this.http = http ? http : globalThis as any;
 {%-    if UseGetBaseUrlMethod -%}
         this.baseUrl = this.getBaseUrl("{{ BaseUrl }}", baseUrl);
 {%-    else -%}

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET100Minimal_targetFramework=net10.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET100Minimal_targetFramework=net10.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 
@@ -171,12 +171,12 @@ export class Client {
 }
 
 export class ExampleClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET100_targetFramework=net10.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET100_targetFramework=net10.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class ValuesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 
@@ -171,12 +171,12 @@ export class Client {
 }
 
 export class ExampleClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 
@@ -171,12 +171,12 @@ export class Client {
 }
 
 export class ExampleClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET80_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET80_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class ValuesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET90Minimal_targetFramework=net9.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET90Minimal_targetFramework=net9.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class Client {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 
@@ -171,12 +171,12 @@ export class Client {
 }
 
 export class ExampleClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET90_targetFramework=net9.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckTypeScriptAsync_projectName=NSwag.Sample.NET90_targetFramework=net9.0_generatesCode=True.verified.txt
@@ -8,12 +8,12 @@
 // ReSharper disable InconsistentNaming
 
 export class ValuesClient {
-    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private http: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> };
     private baseUrl: string;
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+    constructor(baseUrl?: string, http?: { fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : globalThis as any;
         this.baseUrl = baseUrl ?? "";
     }
 


### PR DESCRIPTION
This PR follows on from https://github.com/RicoSuter/NSwag/pull/5032 which migrated NSwag TypeScript generated clients to use `globalThis`.  

It does two things:
- replaces usage of `window` with `globalThis` in the constructor
- replaces use of `url: RequestInfo` in the definition of `fetch` with `input: string | URL | Request`.   This is because `RequestInfo` is a DOM / browser specific type in TypeScript's `lib.dom.d.ts` file.  

The result of these changes migrate the TypeScript generated clients to be **both** browser compatible (which they already are) **and** Node.js compatible as well.

You can see details of `fetch` in Node.js: https://nodejs.org/api/globals.html#fetch 

