### PR TITLE
Fix legacy document transformation

### DIFF
--- a/src/NSwag.Commands/NSwagDocumentBase.cs
+++ b/src/NSwag.Commands/NSwagDocumentBase.cs
@@ -167,14 +167,7 @@ namespace NSwag.Commands
             where TDocument : NSwagDocumentBase, new()
         {
             var data = File.ReadAllText(filePath);
-            data = TransformLegacyDocument(data, out var requiredLegacyTransformations);
-
-            if (requiredLegacyTransformations)
-            {
-                // Save now to avoid transformations
-                var document = LoadDocument<TDocument>(filePath, data);
-                await document.SaveAsync();
-            }
+            data = TransformLegacyDocument(data, out var _);
 
             if (applyTransformations)
             {


### PR DESCRIPTION
Remove the unused requireParametersWithoutDefault property from TransformLegacyDocument, fixes #5303.

Remove code that overwrites documents when legacy transformations are necessary, fixes #1886.