### PR TITLE
Fix specifying runtime for `NSwag.Npm` resulting in a `NConsole.UnusedArgumentException`

### DIFF
--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -75,6 +75,9 @@ if (runtimeIndices.length > 1) {
     console.error("Error: Multiple /runtime:* arguments detected. Please specify only one. Maybe remove the legacy --core argument?");
     process.exit(1);
 }
+else if (runtimeIndices.length === 1) {
+    args.splice(runtimeIndices[0], 1);
+}
 
 if (runtimeValue) {
     if (runtimeValue.toLowerCase() === "netcore") {


### PR DESCRIPTION
Running the following command results in the following exception:

`nswag openapi2tsclient /runtime:Net100 /input:../openapi.json /template:angular /InjectionTokenType:InjectionToken /HttpClass:HttpClient /RxJsVersion:6.0 /operationGenerationMode:MultipleClientsFromFirstTagAndOperationId /output:src/service.ts`

```csharp
NConsole.UnusedArgumentException: Unrecognised arguments are present: [Used arguments (7) != Provided arguments (8) -> Check [/runtime:Net100]]
   at NConsole.CommandLineProcessor.ProcessSingleAsync(String[] args, Object input) in /_/src/NSwag.Commands/NConsole/CommandLineProcessor.cs:line 181
   at NConsole.CommandLineProcessor.ProcessAsync(String[] args, Object input) in /_/src/NSwag.Commands/NConsole/CommandLineProcessor.cs:line 120
```

This commit fixes the problem by removing the runtime argument before passing the args to the dotnet console app. It matches functionality with what the comment says it should be doing on line 63.