### PR TITLE
fix: nullpointer

### DIFF
--- a/src/NSwag.Generation.AspNetCore/Processors/OperationResponseProcessor.cs
+++ b/src/NSwag.Generation.AspNetCore/Processors/OperationResponseProcessor.cs
@@ -76,7 +76,7 @@ namespace NSwag.Generation.AspNetCore.Processors
 
                     if (!IsVoidResponse(returnType))
                     {
-                        var returnTypeAttributes = context.MethodInfo?.ReturnParameter?.GetCustomAttributes(false).OfType<Attribute>();
+                        var returnTypeAttributes = context.MethodInfo?.ReturnParameter?.GetCustomAttributes(false).OfType<Attribute>() ?? [];
                         var contextualReturnType = returnType.ToContextualType(returnTypeAttributes);
 
                         var nullableXmlAttribute = GetResponseXmlDocsElement(context.MethodInfo, httpStatusCode)?.Attribute("nullable");


### PR DESCRIPTION
I'm trying to add endpoint definitions manually via `IApiDescriptionProvider` but as soon as I add `ApiDescription.SupportedResponseTypes` the swagger generator crashes due to a simple nullpointer.

The compiler and IDE even warns about this issue but it is ignored and this exception is expected to happen when `MethodInfo` ist null

## Workaround

```cs
// add some MethodInfo to EndpointMetadata
ActionDescriptor = new ActionDescriptor
{
    EndpointMetadata = [MethodBase.GetCurrentMethod()!]
}
```