### PR TITLE
Update to NJsonSchema v11.6.0 and Namotion.Reflection v3.5.0 (v14.7.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>14.6.3</VersionPrefix>
+    <VersionPrefix>14.7.0</VersionPrefix>
 
     <Authors>Rico Suter</Authors>
     <Copyright>Copyright © Rico Suter, 2025</Copyright>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,14 +21,14 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MyToolkit" Version="2.5.16" />
     <PackageVersion Include="MyToolkit.Extended" Version="2.5.16" />
-    <PackageVersion Include="Namotion.Reflection" Version="3.4.3" />
+    <PackageVersion Include="Namotion.Reflection" Version="3.5.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NJsonSchema" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration.CSharp" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration.TypeScript" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.Yaml" Version="11.5.2" />
+    <PackageVersion Include="NJsonSchema" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration.CSharp" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration.TypeScript" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema.Yaml" Version="11.6.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.0.0" />
     <PackageVersion Include="Verify.XunitV3" Version="30.5.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationBasePathTests.When_custom_BasePath_is_not_specified_then_the_BasePath_from_document_is_used_as_Route.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationBasePathTests.When_custom_BasePath_is_not_specified_then_the_BasePath_from_document_is_used_as_Route.verified.txt
@@ -17,7 +17,6 @@ namespace MyNamespace
     }
 
     [Microsoft.AspNetCore.Mvc.Route("virtual_directory/v1")]
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationBasePathTests.When_custom_BasePath_is_specified_then_that_is_used_as_Route.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationBasePathTests.When_custom_BasePath_is_specified_then_that_is_used_as_Route.verified.txt
@@ -17,7 +17,6 @@ namespace MyNamespace
     }
 
     [Microsoft.AspNetCore.Mvc.Route("v1")]
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationDefaultParameterTests.When_parameter_has_default_then_set_in_partial_controller.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Controllers/Snapshots/ControllerGenerationDefaultParameterTests.When_parameter_has_default_then_set_in_partial_controller.verified.txt
@@ -17,7 +17,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_body_is_binary_array_then_IFormFile_Collection_is_used_as_parameter_in_CSharp_ASPNETCore.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_body_is_binary_array_then_IFormFile_Collection_is_used_as_parameter_in_CSharp_ASPNETCore.verified.txt
@@ -14,7 +14,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_body_is_binary_then_IFormFile_is_used_as_parameter_in_CSharp_ASPNETCore.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_body_is_binary_then_IFormFile_is_used_as_parameter_in_CSharp_ASPNETCore.verified.txt
@@ -14,7 +14,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_response_body_is_binary_then_IActionResult_is_used_as_return_type_in_CSharp_ASPNETCore.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_response_body_is_binary_then_IActionResult_is_used_as_return_type_in_CSharp_ASPNETCore.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class ControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("logo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_aspnet_actiontype_inuse_with_abstract_then_actiontype_is_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_aspnet_actiontype_inuse_with_abstract_then_actiontype_is_generated.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_aspnet_actiontype_inuse_with_partial_then_actiontype_is_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_aspnet_actiontype_inuse_with_partial_then_actiontype_is_generated.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_complextype_then_abstractcontroller_is_generated_with_frombody_attribute.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_complextype_then_abstractcontroller_is_generated_with_frombody_attribute.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_complextype_then_partialcontroller_is_generated_with_frombody_attribute.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_complextype_then_partialcontroller_is_generated_with_frombody_attribute.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_header_parameter_then_partialcontroller_is_generated_with_fromheader_attribute.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operation_with_header_parameter_then_partialcontroller_is_generated_with_fromheader_attribute.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : System.Web.Http.ApiController
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operations_with_required_parameters_then_abstractcontroller_is_generated_with_bindrequired_attribute.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operations_with_required_parameters_then_abstractcontroller_is_generated_with_bindrequired_attribute.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operations_with_required_parameters_then_partialcontroller_is_generated_with_bindrequired_attribute.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controller_has_operations_with_required_parameters_then_partialcontroller_is_generated_with_bindrequired_attribute.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_abstract_then_abstractcontroller_is_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_abstract_then_abstractcontroller_is_generated.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_notsetted_then_partialcontroller_is_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_notsetted_then_partialcontroller_is_generated.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_partial_then_partialcontroller_is_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllergenerationformat_partial_then_partialcontroller_is_generated.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllerroutenamingstrategy_none_then_route_attribute_name_not_specified.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllerroutenamingstrategy_none_then_route_attribute_name_not_specified.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllerroutenamingstrategy_operationid_then_route_attribute_name_specified.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllerroutenamingstrategy_operationid_then_route_attribute_name_specified.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllertarget_aspnet_and_multiple_controllers_then_only_single_custom_fromheader_generated.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllertarget_aspnet_and_multiple_controllers_then_only_single_custom_fromheader_generated.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class ControllerBase : System.Web.Http.ApiController
     {
         [System.Web.Http.HttpGet, System.Web.Http.Route("Foo")]
@@ -26,7 +25,6 @@ namespace MyNamespace
         public abstract System.Threading.Tasks.Task<ComplexTypeResponse> ComplexRequired([System.Web.Http.FromBody] ComplexType complexType);
 
     }
-
 
     public abstract class SecondaryControllerBase : System.Web.Http.ApiController
     {

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllertarget_aspnetcore_then_use_builtin_fromheader.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_controllertarget_aspnetcore_then_use_builtin_fromheader.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_the_generation_of_dto_classes_are_disabled_then_file_is_generated_without_any_dto_clasess.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/ControllerGenerationFormatTests.When_the_generation_of_dto_classes_are_disabled_then_file_is_generated_without_any_dto_clasess.verified.txt
@@ -32,7 +32,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleisabstract_and_usecancellationtokenistrue_and_requesthasnoparameter_then_cancellationtoken_is_added.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleisabstract_and_usecancellationtokenistrue_and_requesthasnoparameter_then_cancellationtoken_is_added.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpPost, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleisabstract_and_usecancellationtokenistrue_and_requesthasparameter_then_cancellationtoken_is_added.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleisabstract_and_usecancellationtokenistrue_and_requesthasparameter_then_cancellationtoken_is_added.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpPost, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleispartial_and_usecancellationtokenistrue_and_requesthasnoparameter_then_cancellationtoken_is_added.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleispartial_and_usecancellationtokenistrue_and_requesthasnoparameter_then_cancellationtoken_is_added.verified.txt
@@ -16,7 +16,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleispartial_and_usecancellationtokenistrue_and_requesthasparameter_then_cancellationtoken_is_added.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_controllerstyleispartial_and_usecancellationtokenistrue_and_requesthasparameter_then_cancellationtoken_is_added.verified.txt
@@ -16,7 +16,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_usecancellationtokenparameter_notsetted_then_cancellationtoken_isnot_added.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseCancellationTokenTests.When_usecancellationtokenparameter_notsetted_then_cancellationtoken_isnot_added.verified.txt
@@ -4,7 +4,6 @@ namespace MyNamespace
 {
     using System = global::System;
 
-
     public abstract class TestControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         [Microsoft.AspNetCore.Mvc.HttpPost, Microsoft.AspNetCore.Mvc.Route("Foo")]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,9 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RequiredByC11Keyword { get; set; }
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,9 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RequiredByC11Keyword { get; set; }
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
@@ -260,7 +260,8 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,9 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RequiredByC11Keyword { get; set; }
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,9 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RequiredByC11Keyword { get; set; }
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/WrapResponsesTests.When_success_responses_are_wrapped_then_SwaggerResponse_is_returned_web_api.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/WrapResponsesTests.When_success_responses_are_wrapped_then_SwaggerResponse_is_returned_web_api.verified.txt
@@ -14,7 +14,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/WrapResponsesTests.When_success_responses_are_wrapped_then_SwaggerResponse_is_returned_web_api_aspnetcore.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/WrapResponsesTests.When_success_responses_are_wrapped_then_SwaggerResponse_is_returned_web_api_aspnetcore.verified.txt
@@ -14,7 +14,6 @@ namespace MyNamespace
 
     }
 
-
     public partial class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private ITestController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET100Minimal_targetFramework=net10.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET100Minimal_targetFramework=net10.0_generatesCode=True.verified.txt
@@ -43,7 +43,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;
@@ -92,7 +91,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ExampleController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IExampleController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET100_targetFramework=net10.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET100_targetFramework=net10.0_generatesCode=True.verified.txt
@@ -52,7 +52,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ValuesController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IValuesController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -43,7 +43,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;
@@ -92,7 +91,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ExampleController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IExampleController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET80_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET80_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -55,7 +55,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ValuesController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IValuesController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET90Minimal_targetFramework=net9.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET90Minimal_targetFramework=net9.0_generatesCode=True.verified.txt
@@ -43,7 +43,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class Controller : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IController _implementation;
@@ -92,7 +91,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ExampleController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IExampleController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET90_targetFramework=net9.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpControllersAsync_projectName=NSwag.Sample.NET90_targetFramework=net9.0_generatesCode=True.verified.txt
@@ -52,7 +52,6 @@ namespace MyNamespace
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "")]
-
     public partial class ValuesController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
         private IValuesController _implementation;

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.cs
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.cs
@@ -49,20 +49,25 @@ namespace NSwag.ConsoleCore.Tests
                 }
             });
 
+            // Read stdout/stderr asynchronously to avoid deadlock when pipe buffers fill up
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
             try
             {
-                process.WaitForExit(20000);
+                process.WaitForExit(60000);
             }
             finally
             {
                 process.Kill();
             }
 
+            var output = await outputTask;
+            var error = await errorTask;
+
             // Assert
             if (process.ExitCode != 0)
             {
-                var output = await process.StandardOutput.ReadToEndAsync();
-                var error = await process.StandardError.ReadToEndAsync();
                 Assert.Fail(output + error);
             }
 


### PR DESCRIPTION
- Use latest NJsonSchema v11.6.0, https://github.com/RicoSuter/NJsonSchema/releases/tag/v11.6.0
- Use latest Namotion.Reflection v3.5.0, https://github.com/RicoSuter/Namotion.Reflection/commits/master/
- Prepare v14.7.0 release