### PR TITLE
fix: replace FileReader with Blob.text() in Angular blobToText for SSR compatibility

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
@@ -146,12 +146,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_consumes_is_url_encoded_then_construct_url_encoded_request.verified.txt
@@ -147,8 +147,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
@@ -433,8 +433,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_false_then_dont_add_export_before_classes.verified.txt
@@ -432,12 +432,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
@@ -433,8 +433,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_export_types_is_true_then_add_export_before_classes.verified.txt
@@ -432,12 +432,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_generic_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_generic_request.verified.txt
@@ -426,12 +426,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_generic_request.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_generic_request.verified.txt
@@ -427,8 +427,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
@@ -433,8 +433,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/AngularTests.When_return_value_is_void_then_client_returns_observable_of_void.verified.txt
@@ -432,12 +432,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_includeHttpContext.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_includeHttpContext.verified.txt
@@ -207,8 +207,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_includeHttpContext.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_includeHttpContext.verified.txt
@@ -206,12 +206,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_includeHttpContext.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_includeHttpContext.verified.txt
@@ -205,8 +205,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_includeHttpContext.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/FetchTests.When_no_includeHttpContext.verified.txt
@@ -204,12 +204,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Angular.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Angular.verified.txt
@@ -104980,12 +104980,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Angular.verified.txt
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/Snapshots/JIRA_OpenAPI_Angular.verified.txt
@@ -104981,8 +104981,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -43,12 +43,10 @@ function blobToText(blob: any): Observable<string> {
             observer.next("");
             observer.complete();
         } else {
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            blob.text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
         }
     });
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.Utilities.liquid
@@ -44,8 +44,8 @@ function blobToText(blob: any): Observable<string> {
             observer.complete();
         } else {
             blob.text().then(
-                text => { observer.next(text); observer.complete(); },
-                err => observer.error(err)
+                (text: string) => { observer.next(text); observer.complete(); },
+                (err: any) => observer.error(err)
             );
         }
     });


### PR DESCRIPTION
## Problem

The generated Angular `blobToText` function uses `FileReader`, which is a browser-only DOM API. This causes crashes in any non-browser Angular environment:

- **Angular SSR / Universal** — `ReferenceError: FileReader is not defined` on every API call, since NSwag sets `responseType: 'blob'` for all requests and every response (including error bodies) is routed through `blobToText`
- **NativeScript Angular** — `FileReader.onload` event is undefined in NativeScript's runtime (see #3177)
- **Jest / jsdom test environments** — depending on jsdom version and configuration, `FileReader` may not be available or may behave differently
- **Electron main process** — Node.js context, no DOM APIs

Because `blobToText` sits in the hot path of every generated `processXxx` method (both success and error branches), there is no easy way to work around this without patching the generated output or adding layered interceptors that fight each other.

## Fix

Replace `FileReader` with `Blob.text()`, which is:
- Available in **all modern browsers** (Chrome 76+, Firefox 69+, Safari 14.1+, Edge 79+)
- Available in **Node.js 16+** as a stable global

The change is in `File.Utilities.liquid`, Angular block only — the AngularJS `blobToText` is unchanged:

```diff
-            let reader = new FileReader();
-            reader.onload = event => {
-                observer.next((event.target as any).result);
-                observer.complete();
-            };
-            reader.readAsText(blob);
+            (blob as Blob).text().then(
+                text => { observer.next(text); observer.complete(); },
+                err => observer.error(err)
+            );
```

All 8 affected Angular snapshot files have been updated accordingly.

## Verification

I have applied this fix locally in an Angular SSR project (Node 18) and the crash is resolved. However I want to be upfront: **real-world testing has been limited** — I haven't verified all edge cases like large blobs, binary responses, or error body handling across different Angular versions. Additional review and testing from maintainers or other users would be very welcome before merging.

## Related issues

Fixes #3177
Related: #1692

---

*Drafted with the help of [Claude Code](https://claude.ai/code). The root cause analysis, template change, and snapshot updates were done with AI assistance — flagging this for transparency.*