### PR TITLE
Upgrade to NJsonSchema v11.6.1 (NSwag v14.7.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>14.7.0</VersionPrefix>
+    <Versionrefix>14.7.1</Versionrefix>
 
     <Authors>Rico Suter</Authors>
     <Copyright>Copyright © Rico Suter, 2025</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Versionrefix>14.7.1</Versionrefix>
+    <VersionPrefix>14.7.1</VersionPrefix>
 
     <Authors>Rico Suter</Authors>
     <Copyright>Copyright © Rico Suter, 2025</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <VersionPrefix>14.7.1</VersionPrefix>
 
     <Authors>Rico Suter</Authors>
-    <Copyright>Copyright © Rico Suter, 2025</Copyright>
+    <Copyright>Copyright © Rico Suter, 2026</Copyright>
 
     <Description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,12 +23,12 @@
     <PackageVersion Include="MyToolkit.Extended" Version="2.5.16" />
     <PackageVersion Include="Namotion.Reflection" Version="3.5.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NJsonSchema" Version="11.6.0" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration" Version="11.6.0" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration.CSharp" Version="11.6.0" />
-    <PackageVersion Include="NJsonSchema.CodeGeneration.TypeScript" Version="11.6.0" />
-    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.6.0" />
-    <PackageVersion Include="NJsonSchema.Yaml" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema" Version="11.6.1" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration" Version="11.6.1" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration.CSharp" Version="11.6.1" />
+    <PackageVersion Include="NJsonSchema.CodeGeneration.TypeScript" Version="11.6.1" />
+    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.6.1" />
+    <PackageVersion Include="NJsonSchema.Yaml" Version="11.6.1" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.0.0" />
     <PackageVersion Include="Verify.XunitV3" Version="30.5.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
+    <!-- Pin transitive dependencies of Nuke.Common to patched versions (CVE fixes). -->
+    <PackageReference Include="NuGet.Packaging" Version="6.14.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
+++ b/src/NSwag.ApiDescription.Client/NSwag.ApiDescription.Client.targets
@@ -8,6 +8,8 @@
         Condition="'$(TargetFramework)' == 'net8.0'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net80)/dotnet-nswag.dll"</_NSwagCommand>
     <_NSwagCommand
         Condition="'$(TargetFramework)' == 'net9.0'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net90)/dotnet-nswag.dll"</_NSwagCommand>
+    <_NSwagCommand
+        Condition="'$(TargetFramework)' == 'net10.0'">dotnet --roll-forward-on-no-candidate-fx 2 "$(NSwagDir_Net100)/dotnet-nswag.dll"</_NSwagCommand>
   </PropertyGroup>
 
   <!-- OpenApiReference support for C# -->

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordNewtonsoftJsonSchemaGeneratorTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_disabled_properties_with_required_keyword_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/UseRequiredKeywordSystemTextJsonSchemaGeneratorSettingsTests.When_setting_is_enabled_properties_with_required_keyword_and_attribute_should_generate_with_required_keyword.verified.txt
@@ -260,8 +260,7 @@ namespace MyNamespace
         [Newtonsoft.Json.JsonProperty("RequiredByAttribute", Required = Newtonsoft.Json.Required.Always)]
         public required int RequiredByAttribute { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
+        [Newtonsoft.Json.JsonProperty("RequiredByC11Keyword", Required = Newtonsoft.Json.Required.AllowNull)]
         public required string RequiredByC11Keyword { get; set; }
 
         [Newtonsoft.Json.JsonProperty("RequiredByAttributeAndC11Keyword", Required = Newtonsoft.Json.Required.Always)]

--- a/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
+++ b/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/RicoSuter/NSwag/master/assets/NuGetIcon.png</iconUrl>
     <description>NSwag: The OpenAPI/Swagger API toolchain for .NET and TypeScript</description>
     <tags>OpenAPI Swagger AspNetCore Documentation CodeGen TypeScript WebApi AspNet</tags>
-    <copyright>Copyright © Rico Suter, 2025</copyright>
+    <copyright>Copyright © Rico Suter, 2026</copyright>
     <repository type="git" url="https://github.com/RicoSuter/NSwag.git"/>
     <developmentDependency>true</developmentDependency>
     <dependencies />


### PR DESCRIPTION
Upgrades NJsonSchema to [v11.6.1](https://github.com/RicoSuter/NJsonSchema/releases/tag/v11.6.1), which corrects the regression introduced in v11.6.0 around the C# `required` keyword and `[JsonRequired]` handling.

## What this fixes downstream

Closes [#5359](https://github.com/RicoSuter/NSwag/issues/5359): `required T?` / `[JsonRequired] T?` DTO properties incorrectly lost their nullability and gained a spurious `MinLength=1` on strings, causing generated TypeScript and C# clients to drop null-safety for fields the server can legitimately return as null.

For `public required string[]? OptionList { get; init; }`:

| | TypeScript client | C# client |
|---|---|---|
| v14.7.0 (broken) | `optionList: string[]` | `public string[] OptionList` |
| After this PR | `optionList: string[] \| null` | `public string[]? OptionList` |

## Semantics

NJsonSchema v11.6.1 treats the C# `required` keyword and `[JsonRequired]` as **presence markers** only — they add the property to the schema's `required` array without suppressing nullability or adding `MinLength=1`. Only DataAnnotations `[Required]` carries the "non-null value" semantic.

See [NJsonSchema#1919](https://github.com/RicoSuter/NJsonSchema/pull/1919) for the full discussion, truth tables, and Swagger 2.0 / OpenAPI 3.x behavior.

## Note

v14.7.0 should be skipped — users should upgrade directly from v14.6.3 to v14.7.1.

Also closes #5358