### PR TITLE
Add support for model name prefix and suffix in CSharp generator

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ModelNamePrefixSuffixTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ModelNamePrefixSuffixTests.cs
@@ -1,0 +1,166 @@
+using NJsonSchema;
+using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
+
+namespace NSwag.CodeGeneration.CSharp.Tests
+{
+    public class ModelNamePrefixSuffixTests
+    {
+        private static OpenApiDocument CreateDocument()
+        {
+            var document = new OpenApiDocument();
+            var settings = new NewtonsoftJsonSchemaGeneratorSettings();
+            var generator = new JsonSchemaGenerator(settings);
+
+            document.Paths["/person"] = new OpenApiPathItem
+            {
+                [OpenApiOperationMethod.Get] = new OpenApiOperation
+                {
+                    Responses =
+                    {
+                        {
+                            "200", new OpenApiResponse
+                            {
+                                Schema = new JsonSchema
+                                {
+                                    Reference = generator.Generate(typeof(SamplePerson), new OpenApiSchemaResolver(document, settings))
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            return document;
+        }
+
+        [Fact]
+        public void When_ModelNameSuffix_is_set_then_generated_model_class_has_suffix()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNameSuffix = "Dto"
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("class SamplePersonDto", code);
+            Assert.DoesNotContain("class SamplePerson ", code);
+        }
+
+        [Fact]
+        public void When_ModelNamePrefix_is_set_then_generated_model_class_has_prefix()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNamePrefix = "My"
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("class MySamplePerson", code);
+            Assert.DoesNotContain("class SamplePerson ", code);
+        }
+
+        [Fact]
+        public void When_both_ModelNamePrefix_and_ModelNameSuffix_are_set_then_generated_model_class_has_both()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNamePrefix = "My",
+                ModelNameSuffix = "Dto"
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("class MySamplePersonDto", code);
+            Assert.DoesNotContain("class SamplePerson ", code);
+        }
+
+        [Fact]
+        public void When_ModelNamePrefix_and_ModelNameSuffix_are_empty_then_generated_model_class_name_is_unchanged()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNamePrefix = "",
+                ModelNameSuffix = ""
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("class SamplePerson", code);
+        }
+
+        [Fact]
+        public void When_ModelNameSuffix_is_set_then_return_type_in_client_also_uses_suffix()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNameSuffix = "Dto"
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("SamplePersonDto", code);
+            Assert.DoesNotContain("Task<SamplePerson>", code);
+        }
+        [Fact]
+        public void When_ModelNameSuffix_is_set_then_enum_names_are_not_affected()
+        {
+            // Arrange
+            var document = CreateDocument();
+            var settings = new CSharpClientGeneratorSettings
+            {
+                ModelNameSuffix = "Dto"
+            };
+
+            // Act
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert - enum is unchanged
+            Assert.Contains("enum SampleStatus", code);
+            Assert.DoesNotContain("enum SampleStatusDto", code);
+            // class still gets the suffix
+            Assert.Contains("class SamplePersonDto", code);
+        }
+    }
+
+    public class SamplePerson
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public SampleStatus Status { get; set; }
+    }
+
+    public enum SampleStatus
+    {
+        Active,
+        Inactive
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBaseSettings.cs
@@ -31,6 +31,8 @@ namespace NSwag.CodeGeneration.CSharp
                 typeof(CSharpGeneratorBaseSettings).GetTypeInfo().Assembly
             ]);
 
+            CSharpGeneratorSettings.TypeNameGenerator = new CSharpTypeNameGenerator();
+
             ResponseArrayType = "System.Collections.Generic.ICollection";
             ResponseDictionaryType = "System.Collections.Generic.IDictionary";
 
@@ -65,5 +67,30 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the dictionary type of operation parameters.</summary>
         public string ParameterDictionaryType { get; set; }
+
+        private string _modelNamePrefix = "";
+        private string _modelNameSuffix = "";
+
+        /// <summary>Gets or sets the prefix to prepend to all generated model class names (default: "").</summary>
+        public string ModelNamePrefix
+        {
+            get => _modelNamePrefix;
+            set
+            {
+                _modelNamePrefix = value ?? string.Empty;
+                CSharpGeneratorSettings.TypeNameGenerator = new CSharpTypeNameGenerator(_modelNamePrefix, _modelNameSuffix);
+            }
+        }
+
+        /// <summary>Gets or sets the suffix to append to all generated model class names (default: "").</summary>
+        public string ModelNameSuffix
+        {
+            get => _modelNameSuffix;
+            set
+            {
+                _modelNameSuffix = value ?? string.Empty;
+                CSharpGeneratorSettings.TypeNameGenerator = new CSharpTypeNameGenerator(_modelNamePrefix, _modelNameSuffix);
+            }
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/CSharpTypeNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpTypeNameGenerator.cs
@@ -1,0 +1,36 @@
+using NJsonSchema;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>Generates a CSharp type name with optional prefix and suffix.</summary>
+    public class CSharpTypeNameGenerator : DefaultTypeNameGenerator
+    {
+        private readonly string _prefix;
+        private readonly string _suffix;
+
+        /// <summary>Initializes a new instance of the <see cref="CSharpTypeNameGenerator"/> class.</summary>
+        /// <param name="prefix">The prefix to prepend to generated type names.</param>
+        /// <param name="suffix">The suffix to append to generated type names.</param>
+        public CSharpTypeNameGenerator(string prefix = "", string suffix = "")
+        {
+            _prefix = prefix ?? string.Empty;
+            _suffix = suffix ?? string.Empty;
+        }
+
+        /// <summary>Generates the type name for the given schema.</summary>
+        /// <param name="schema">The schema.</param>
+        /// <param name="typeNameHint">The type name hint.</param>
+        /// <returns>The type name.</returns>
+        protected override string Generate(JsonSchema schema, string typeNameHint)
+        {
+            var name = base.Generate(schema, typeNameHint);
+
+            if (!schema.ActualSchema.IsEnumeration && (!string.IsNullOrEmpty(_prefix) || !string.IsNullOrEmpty(_suffix)))
+            {
+                return _prefix + name + _suffix;
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -116,6 +116,20 @@ namespace NSwag.Commands.CodeGeneration
             set => Settings.ResponseDictionaryType = value;
         }
 
+        [Argument(Name = "ModelNamePrefix", IsRequired = false, Description = "The prefix to prepend to all generated model class names (default: '').")]
+        public string ModelNamePrefix
+        {
+            get => Settings.ModelNamePrefix;
+            set => Settings.ModelNamePrefix = value;
+        }
+
+        [Argument(Name = "ModelNameSuffix", IsRequired = false, Description = "The suffix to append to all generated model class names (default: '').")]
+        public string ModelNameSuffix
+        {
+            get => Settings.ModelNameSuffix;
+            set => Settings.ModelNameSuffix = value;
+        }
+
         [Argument(Name = "WrapResponses", IsRequired = false, Description = "Specifies whether to wrap success responses to allow full response access.")]
         public bool WrapResponses
         {


### PR DESCRIPTION
- Introduced ModelNamePrefix and ModelNameSuffix properties in CSharpGeneratorBaseSettings.
- Updated CSharpTypeNameGenerator to handle prefix and suffix for generated type names.
- Added tests to verify the correct application of prefix and suffix in generated model class names.

This change helps in creating a clear distinction in your application when classes might end up having the same name.