### PR TITLE
Respect required properties for multipart/form-data parameters

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/BinaryTests.cs
@@ -546,5 +546,75 @@ paths:
           Assert.DoesNotContain("ActionResult<Microsoft.AspNetCore.Mvc.FileResult>", code);
           Assert.Contains("System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult> GetLogo", code);
         }
+
+        [Fact]
+        public async Task When_multipart_required_fields_via_ref_are_used_then_controller_parameters_are_non_nullable()
+        {
+            var yaml = @"openapi: 3.0.0
+servers:
+  - url: https://www.example.com/
+info:
+  version: '2.0.0'
+  title: 'Test API'   
+paths:
+  /files:
+    post:
+      tags:
+        - Files
+      summary: 'Create File'
+      operationId: addFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AddFileRequest'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    AddFileRequest:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+        comment:
+          type: string
+      required:
+        - file
+        - id
+        - name";
+
+            var document = await OpenApiYamlDocument.FromYamlAsync(yaml);
+
+            // Act
+            CSharpControllerGeneratorSettings settings = new CSharpControllerGeneratorSettings
+            {
+                ControllerTarget = CSharpControllerTarget.AspNetCore,
+                ControllerStyle = CSharpControllerStyle.Abstract,
+                UseActionResultType = true,
+            };
+
+            var codeGenerator = new CSharpControllerGenerator(document, settings);
+            var code = codeGenerator.GenerateFile();
+
+            // Assert
+            await VerifyHelper.Verify(code);
+            CSharpCompiler.AssertCompile(code);
+
+            Assert.Contains("AddFile(FileParameter file, int id, string name, string comment)",
+                code.Replace("\n", " ").Replace("\r", " "));
+            Assert.DoesNotContain("FileParameter? file", code);
+            Assert.DoesNotContain("int? id", code);
+            Assert.DoesNotContain("string? name", code);
+            Assert.DoesNotContain("string? comment", code);
+        }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_inline_schema.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_inline_schema.verified.txt
@@ -51,12 +51,12 @@ namespace MyNamespace
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
 
-        public virtual System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model)
+        public virtual System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model)
         {
             return AddFileAsync(file, model, System.Threading.CancellationToken.None);
         }
 
-        public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model, System.Threading.CancellationToken cancellationToken)
         {
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_required_fields_via_ref_are_used_then_controller_parameters_are_non_nullable.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_required_fields_via_ref_are_used_then_controller_parameters_are_non_nullable.verified.txt
@@ -1,0 +1,69 @@
+﻿
+
+namespace MyNamespace
+{
+    using System = global::System;
+
+    public abstract class ControllerBase : Microsoft.AspNetCore.Mvc.ControllerBase
+    {
+        [Microsoft.AspNetCore.Mvc.HttpPost, Microsoft.AspNetCore.Mvc.Route("files")]
+        public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult> AddFile(FileParameter file, int id, string name, string comment);
+
+    }
+
+    public partial class AddFileRequest
+    {
+
+        [Newtonsoft.Json.JsonProperty("file", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public byte[] File { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
+        public int Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("comment", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Comment { get; set; }
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    public partial class FileParameter
+    {
+        public FileParameter(System.IO.Stream data)
+            : this (data, null, null)
+        {
+        }
+
+        public FileParameter(System.IO.Stream data, string fileName)
+            : this (data, fileName, null)
+        {
+        }
+
+        public FileParameter(System.IO.Stream data, string fileName, string contentType)
+        {
+            Data = data;
+            FileName = fileName;
+            ContentType = contentType;
+        }
+
+        public System.IO.Stream Data { get; private set; }
+
+        public string FileName { get; private set; }
+
+        public string ContentType { get; private set; }
+    }
+
+
+}

--- a/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_with_ref_should_read_schema.verified.txt
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/Snapshots/BinaryTests.When_multipart_with_ref_should_read_schema.verified.txt
@@ -51,12 +51,12 @@ namespace MyNamespace
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
 
-        public virtual System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model)
+        public virtual System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model)
         {
             return AddFileAsync(file, model, System.Threading.CancellationToken.None);
         }
 
-        public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model? model, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<CreateAddFileResponse> AddFileAsync(FileParameter file, Model model, System.Threading.CancellationToken cancellationToken)
         {
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/OperationModelBase.cs
@@ -362,9 +362,12 @@ namespace NSwag.CodeGeneration.Models
                 parameters = [.. parameters.Where(p => !_settings.ExcludedParameterNames.Contains(p.Name))];
             }
 
-            var formDataSchemaProperties = _operation?.ActualRequestBody?._content?.TryGetValue("multipart/form-data", out var formData) == true
-                ? formData.Schema?.ActualSchema?.ActualProperties
+            var formDataSchema = _operation?.ActualRequestBody?._content?.TryGetValue("multipart/form-data", out var formData) == true
+                ? formData.Schema?.ActualSchema
                 : null;
+
+            var formDataSchemaProperties = formDataSchema?.ActualProperties;
+            var formDataRequiredProperties = formDataSchema?.RequiredProperties;
 
             if (formDataSchemaProperties?.Count > 0)
             {
@@ -376,6 +379,7 @@ namespace NSwag.CodeGeneration.Models
                         Kind = OpenApiParameterKind.FormData,
                         Schema = p.Value,
                         Description = p.Value.Description,
+                        IsRequired = formDataRequiredProperties?.Contains(p.Key) == true,
                         CollectionFormat = (p.Value.Type & JsonObjectType.Array) != 0 && p.Value.Item != null
                             ? OpenApiParameterCollectionFormat.Multi
                             : OpenApiParameterCollectionFormat.Undefined,


### PR DESCRIPTION
When expanding a multipart/form-data schema (including via $ref) into form parameters in GetActualParameters(), IsRequired was never set. Since it defaults to false, all form fields - even required ones - were generated as nullable.

Fix by reading the schema's RequiredProperties and setting IsRequired accordingly. This affects both the C# and TypeScript generators.

Related: RicoSuter/NSwag#4379, RicoSuter/NSwag#3906, RicoSuter/NSwag#4185