### PR TITLE
Fix development build dependencies and TypeScript test compiler

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
-    <!-- Pin transitive dependencies of Nuke.Common to patched versions (CVE fixes). -->
-    <PackageReference Include="NuGet.Packaging" Version="6.14.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <!-- Keep the build runner compatible with the NuGet assemblies loaded by the .NET SDK. -->
+    <PackageReference Include="NuGet.Packaging" Version="7.9.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/package-lock.json
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/package-lock.json
@@ -10,7 +10,7 @@
         "@types/node": "^24.1.0",
         "angular": "^1.8.3",
         "axios": "^1.11.0",
-        "typescript": "^4.3.5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@types/jquery": {
@@ -331,16 +331,17 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/package.json
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/package.json
@@ -5,6 +5,6 @@
     "angular": "^1.8.3",
     "axios": "^1.11.0",
     "@types/k6": "^1.1.1",
-    "typescript": "^4.3.5"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
The PR workflow fails during NUKE startup with .NET SDK 10.0.400 because the build runner loads NuGet.Frameworks 6.x while the SDK requests 7.9.0. Update the build-only NuGet.Packaging pin to 7.9.0 and System.Security.Cryptography.Xml to 10.0.10, which addresses the reported security advisories. Update the TypeScript test compiler to 5.9.3 so it can compile the existing Node 24 type declarations.

Only the build project and TypeScript test package/lockfile change. Published project dependencies, target frameworks, product versions, templates, and publishing logic are unchanged. This is a prerequisite tooling repair for #5398; it contains none of that PR's return-type changes.

Validation:
- Reproduced the original NuGet.Frameworks assembly-loading failure in a temporary regular clone using CI's SDK and DOTNET_ROOT; the patched runner proceeds into the Compile target. Full CI remains to run.
- All 59 TypeScript generator tests pass (the four parameter tests failed before the compiler update).
- Build-project audit, including transitive dependencies, reports no vulnerable packages.
- Packed NSwag.CodeGeneration.TypeScript for net462, netstandard2.0, and net8.0. Its NuGet manifest matches a package built from master, excluding source repository branch/commit metadata.
- Independent review and git diff --check pass.
