### PR TITLE
docs: add general pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,19 +14,19 @@ Remove these comments when filling in the description. Drop optional sections th
 
 Review the relevant diffs before answering. Write "None" explicitly if there are no breaking changes. -->
 
-## Verification
-
-<!-- Describe the checks you actually ran and their results, including test counts when available. State what you did not verify and why. Choose evidence relevant to this change, for example:
-
-- A regression test that fails before the fix and passes afterward.
-- Build, unit, integration, or manual test results.
-- Review of snapshot or output diffs against the intended behavior; accepting updated snapshots alone is not verification.
-- Compilation or runtime checks for affected outputs where a text diff cannot establish correctness.
-- Package contents, dependency, or compatibility comparisons when packaging or build changes could affect consumers.
-- Documentation or sample updates for changed behavior.
-
-Summarize meaningful differences or link to them instead of pasting large outputs. A small documentation change can simply describe its manual review. -->
-
 ## Performance
 
 <!-- Optional. Include this section when performance was measured. Summarize the scenario, before/after results, and relevant costs such as time or allocations. Include regressions and measurement limitations as well as improvements. -->
+
+## Verification
+
+<!-- Tick what you did and describe the results, including test counts when available. Strike through an entry with ~~two tildes~~ and give a short reason when it does not apply. Leave applicable checks unticked if they are not done, and explain what remains unverified and why.
+
+Choose checks relevant to the change: regression tests, builds, unit or integration tests, or manual checks. Review snapshot and output diffs against the intended behavior; accepting updated snapshots alone is not verification. Use compilation or runtime checks where a text diff cannot establish correctness. For build or packaging changes, consider package contents, dependencies, and compatibility.
+
+Summarize meaningful results or link to them instead of pasting large outputs. A documentation-only change can describe its manual review and mark unrelated checks as not applicable. -->
+
+- [ ] Breaking changes and migration steps documented, or "None" stated
+- [ ] Relevant builds and tests run, with results recorded
+- [ ] Relevant snapshot or output diffs reviewed
+- [ ] Documentation and samples updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- Start with a short summary of the problem and resulting behavior. Include a before/after example when it helps.
+
+Link issues as appropriate: "Closes #123" for an issue this PR resolves, "Related to #123" for context, or "Follow-up: #123" for work left for later.
+
+Remove these comments when filling in the description. Drop optional sections that do not help explain the change. Keep Breaking changes and Verification. -->
+
+## Why
+
+<!-- Optional. Explain the reason or tradeoff when the opening summary does not already make it clear. -->
+
+## Breaking changes
+
+<!-- Describe anything existing users must account for and how to migrate. Consider public APIs, behavior, configuration defaults, supported platforms, dependencies, and any new obligations for callers, even when their code still compiles.
+
+Review the relevant diffs before answering. Write "None" explicitly if there are no breaking changes. -->
+
+## Verification
+
+<!-- Describe the checks you actually ran and their results, including test counts when available. State what you did not verify and why. Choose evidence relevant to this change, for example:
+
+- A regression test that fails before the fix and passes afterward.
+- Build, unit, integration, or manual test results.
+- Review of snapshot or output diffs against the intended behavior; accepting updated snapshots alone is not verification.
+- Compilation or runtime checks for affected outputs where a text diff cannot establish correctness.
+- Package contents, dependency, or compatibility comparisons when packaging or build changes could affect consumers.
+- Documentation or sample updates for changed behavior.
+
+Summarize meaningful differences or link to them instead of pasting large outputs. A small documentation change can simply describe its manual review. -->
+
+## Performance
+
+<!-- Optional. Include this section when performance was measured. Summarize the scenario, before/after results, and relevant costs such as time or allocations. Include regressions and measurement limitations as well as improvements. -->


### PR DESCRIPTION
Add a lightweight pull request template adapted from Namotion.Interceptor for general NSwag contributions, including library, tooling, build, and documentation changes. It asks contributors to explain the problem, resulting behavior, breaking changes, and verification evidence.

## Why

Use a short verification checklist to make omissions visible. Contributors check completed items, strike through inapplicable items with a reason, and explain checks that remain undone. Keep the opening summary, optional Why and Performance sections, and explicit Breaking changes section. Verification covers relevant builds/tests, snapshot or output diffs, and documentation without requiring a LOC table, helper scripts, or specialized load/chaos testing.

## Breaking changes

None. This adds contribution guidance only; product code, build configuration, and published packages are unchanged.

## Verification

Manually reviewed the template for general applicability, clear handling of incomplete and inapplicable checks, and consistency with the existing contribution guidance. Confirmed it contains no references to Interceptor-only scripts or test suites. `git diff --check` passes.

- [x] Breaking changes and migration steps documented, or "None" stated
- [ ] ~~Relevant builds and tests run, with results recorded~~ Not applicable: Markdown template only; manually reviewed.
- [ ] ~~Relevant snapshot or output diffs reviewed~~ Not applicable: no snapshots or product outputs changed.
- [x] Documentation and samples updated: the PR template is the only documentation change; no samples are affected.
